### PR TITLE
Replace `std::env::home_dir` with `dirs::home_dir` (#9077)

### DIFF
--- a/path/Cargo.toml
+++ b/path/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "path"
-version = "0.1.0"
-authors = ["debris <marek.kotewicz@gmail.com>"]
+version = "0.1.1"
+authors = ["Parity Technologies <admin@parity.io>"]
+license = "GPL3"
 
 [dependencies]
+dirs = "1.0.2"

--- a/path/src/lib.rs
+++ b/path/src/lib.rs
@@ -15,6 +15,8 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Path utilities
+extern crate dirs;
+
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -22,7 +24,7 @@ use std::path::PathBuf;
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push("Library");
 	home.push(name);
 	home
@@ -32,7 +34,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push("AppData");
 	home.push("Roaming");
 	home.push(name);
@@ -43,7 +45,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push(format!(".{}", name.to_lowercase()));
 	home
 }


### PR DESCRIPTION
Pull in upstream changes

`std::env::home_dir` is deprecated but will probably take a while until
it is deprecated on stable. For more info see https://github.com/rust-lang/rust/pull/51656