### PR TITLE
Upstream changes to kvdb-rocksdb

### DIFF
--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -167,8 +167,6 @@ pub struct DatabaseConfig {
 	pub compaction: CompactionProfile,
 	/// Set number of columns
 	pub columns: Option<u32>,
-	/// Should we keep WAL enabled?
-	pub wal: bool,
 }
 
 impl DatabaseConfig {
@@ -196,7 +194,6 @@ impl Default for DatabaseConfig {
 			memory_budget: None,
 			compaction: CompactionProfile::default(),
 			columns: None,
-			wal: true,
 		}
 	}
 }
@@ -327,10 +324,7 @@ impl Database {
 			cf_options.push(col_config(&config, &block_opts)?);
 		}
 
-		let mut write_opts = WriteOptions::new();
-		if !config.wal {
-			write_opts.disable_wal(true);
-		}
+		let write_opts = WriteOptions::new();
 		let mut read_opts = ReadOptions::new();
 		read_opts.set_verify_checksums(false);
 


### PR DESCRIPTION
ref. https://github.com/paritytech/parity/pull/8963

Upstream commit cda535: db: remove wal disabling / fast-and-loose option