### PR TITLE
Add fixed-hash to parity-common

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+	"fixed-hash",
 	"hashdb",
 	"keccak-hash",
 	"kvdb",

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "fixed-hash"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
-homepage = "https://github.com/paritytech/primitives"
+homepage = "https://github.com/paritytech/parity-common"
 description = "Fixed-size hashes"
 
 [dependencies]

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fixed-hash"
+version = "0.2.1"
+authors = ["Parity Technologies <admin@parity.io>"]
+license = "MIT"
+homepage = "https://github.com/paritytech/primitives"
+description = "Fixed-size hashes"
+
+[dependencies]
+heapsize = { version = "0.4", optional = true }
+rand = { version = "0.4", optional = true }
+rustc-hex = { version = "1.0", optional = true }
+quickcheck = { version = "0.6", optional = true }
+
+[target.'cfg(not(target_os = "unknown"))'.dependencies]
+libc = { version = "0.2", optional = true, default-features = false }
+
+[features]
+default = ["libc"]
+std = ["rustc-hex", "rand"]
+heapsizeof = ["heapsize"]
+impl_quickcheck_arbitrary = ["quickcheck"]

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -1,0 +1,491 @@
+// Copyright 2015-2017 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Return `s` without the `0x` at the beginning of it, if any.
+pub fn clean_0x(s: &str) -> &str {
+	if s.starts_with("0x") {
+		&s[2..]
+	} else {
+		s
+	}
+}
+
+#[macro_export]
+macro_rules! construct_hash {
+	($from: ident, $size: expr) => {
+		#[repr(C)]
+		/// Unformatted binary data of fixed length.
+		pub struct $from (pub [u8; $size]);
+
+
+		impl From<[u8; $size]> for $from {
+			fn from(bytes: [u8; $size]) -> Self {
+				$from(bytes)
+			}
+		}
+
+		impl From<$from> for [u8; $size] {
+			fn from(s: $from) -> Self {
+				s.0
+			}
+		}
+
+		impl ::core::ops::Deref for $from {
+			type Target = [u8];
+
+			#[inline]
+			fn deref(&self) -> &[u8] {
+				&self.0
+			}
+		}
+
+		impl AsRef<[u8]> for $from {
+			#[inline]
+			fn as_ref(&self) -> &[u8] {
+				&self.0
+			}
+		}
+
+		impl AsMut<[u8]> for $from {
+			#[inline]
+			fn as_mut(&mut self) -> &mut [u8] {
+				&mut self.0
+			}
+		}
+
+		impl AsRef<$from> for $from {
+			#[inline]
+			fn as_ref(&self) -> &$from {
+				&self
+			}
+		}
+
+		impl ::core::ops::DerefMut for $from {
+			#[inline]
+			fn deref_mut(&mut self) -> &mut [u8] {
+				&mut self.0
+			}
+		}
+
+		impl $from {
+			/// Create a new, zero-initialised, instance.
+			pub fn new() -> $from {
+				$from([0; $size])
+			}
+
+			/// Synonym for `new()`. Prefer to new as it's more readable.
+			pub fn zero() -> $from {
+				$from([0; $size])
+			}
+
+			/// Get the size of this object in bytes.
+			pub fn len() -> usize {
+				$size
+			}
+
+			#[inline]
+			/// Assign self to be of the same value as a slice of bytes of length `len()`.
+			pub fn clone_from_slice(&mut self, src: &[u8]) -> usize {
+				let min = ::core::cmp::min($size, src.len());
+				self.0[..min].copy_from_slice(&src[..min]);
+				min
+			}
+
+			/// Convert a slice of bytes of length `len()` to an instance of this type.
+			pub fn from_slice(src: &[u8]) -> Self {
+				let mut r = Self::new();
+				r.clone_from_slice(src);
+				r
+			}
+
+			/// Copy the data of this object into some mutable slice of length `len()`.
+			pub fn copy_to(&self, dest: &mut[u8]) {
+				let min = ::core::cmp::min($size, dest.len());
+				dest[..min].copy_from_slice(&self.0[..min]);
+			}
+
+			/// Returns `true` if all bits set in `b` are also set in `self`.
+			pub fn contains<'a>(&'a self, b: &'a Self) -> bool {
+				&(b & self) == b
+			}
+
+			/// Returns `true` if no bits are set.
+			pub fn is_zero(&self) -> bool {
+				self.eq(&Self::new())
+			}
+
+			/// Returns the lowest 8 bytes interpreted as a BigEndian integer.
+			pub fn low_u64(&self) -> u64 {
+				let mut ret = 0u64;
+				for i in 0..::core::cmp::min($size, 8) {
+					ret |= (self.0[$size - 1 - i] as u64) << (i * 8);
+				}
+				ret
+			}
+
+			impl_std_for_hash_internals!($from, $size);
+		}
+
+		impl ::core::fmt::Debug for $from {
+			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+				write!(f, "{:#x}", self)
+			}
+		}
+
+		impl ::core::fmt::Display for $from {
+			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+				write!(f, "0x")?;
+				for i in &self.0[0..2] {
+					write!(f, "{:02x}", i)?;
+				}
+				write!(f, "…")?;
+				for i in &self.0[$size - 2..$size] {
+					write!(f, "{:02x}", i)?;
+				}
+				Ok(())
+			}
+		}
+
+		impl ::core::fmt::LowerHex for $from {
+			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+				if f.alternate() {
+					write!(f, "0x");
+				}
+				for i in &self.0[..] {
+					write!(f, "{:02x}", i)?;
+				}
+				Ok(())
+			}
+		}
+
+		impl Copy for $from {}
+		#[cfg_attr(feature="dev", allow(expl_impl_clone_on_copy))]
+		impl Clone for $from {
+			fn clone(&self) -> $from {
+				let mut ret = $from::new();
+				ret.0.copy_from_slice(&self.0);
+				ret
+			}
+		}
+
+		impl Eq for $from {}
+
+		impl PartialOrd for $from {
+			fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+				Some(self.cmp(other))
+			}
+		}
+
+		impl ::core::hash::Hash for $from {
+			fn hash<H>(&self, state: &mut H) where H: ::core::hash::Hasher {
+				state.write(&self.0);
+				state.finish();
+			}
+		}
+
+		impl ::core::ops::Index<usize> for $from {
+			type Output = u8;
+
+			fn index(&self, index: usize) -> &u8 {
+				&self.0[index]
+			}
+		}
+		impl ::core::ops::IndexMut<usize> for $from {
+			fn index_mut(&mut self, index: usize) -> &mut u8 {
+				&mut self.0[index]
+			}
+		}
+		impl ::core::ops::Index<::core::ops::Range<usize>> for $from {
+			type Output = [u8];
+
+			fn index(&self, index: ::core::ops::Range<usize>) -> &[u8] {
+				&self.0[index]
+			}
+		}
+		impl ::core::ops::IndexMut<::core::ops::Range<usize>> for $from {
+			fn index_mut(&mut self, index: ::core::ops::Range<usize>) -> &mut [u8] {
+				&mut self.0[index]
+			}
+		}
+		impl ::core::ops::Index<::core::ops::RangeFull> for $from {
+			type Output = [u8];
+
+			fn index(&self, _index: ::core::ops::RangeFull) -> &[u8] {
+				&self.0
+			}
+		}
+		impl ::core::ops::IndexMut<::core::ops::RangeFull> for $from {
+			fn index_mut(&mut self, _index: ::core::ops::RangeFull) -> &mut [u8] {
+				&mut self.0
+			}
+		}
+
+		/// `BitOr` on references
+		impl<'a> ::core::ops::BitOr for &'a $from {
+			type Output = $from;
+
+			fn bitor(self, rhs: Self) -> Self::Output {
+				let mut ret: $from = $from::default();
+				for i in 0..$size {
+					ret.0[i] = self.0[i] | rhs.0[i];
+				}
+				ret
+			}
+		}
+
+		/// Moving `BitOr`
+		impl ::core::ops::BitOr for $from {
+			type Output = $from;
+
+			fn bitor(self, rhs: Self) -> Self::Output {
+				&self | &rhs
+			}
+		}
+
+		/// `BitAnd` on references
+		impl <'a> ::core::ops::BitAnd for &'a $from {
+			type Output = $from;
+
+			fn bitand(self, rhs: Self) -> Self::Output {
+				let mut ret: $from = $from::default();
+				for i in 0..$size {
+					ret.0[i] = self.0[i] & rhs.0[i];
+				}
+				ret
+			}
+		}
+
+		/// Moving `BitAnd`
+		impl ::core::ops::BitAnd for $from {
+			type Output = $from;
+
+			fn bitand(self, rhs: Self) -> Self::Output {
+				&self & &rhs
+			}
+		}
+
+		/// `BitXor` on references
+		impl <'a> ::core::ops::BitXor for &'a $from {
+			type Output = $from;
+
+			fn bitxor(self, rhs: Self) -> Self::Output {
+				let mut ret: $from = $from::default();
+				for i in 0..$size {
+					ret.0[i] = self.0[i] ^ rhs.0[i];
+				}
+				ret
+			}
+		}
+
+		/// Moving `BitXor`
+		impl ::core::ops::BitXor for $from {
+			type Output = $from;
+
+			fn bitxor(self, rhs: Self) -> Self::Output {
+				&self ^ &rhs
+			}
+		}
+
+		impl Default for $from {
+			fn default() -> Self { $from::new() }
+		}
+
+		impl From<u64> for $from {
+			fn from(mut value: u64) -> $from {
+				let mut ret = $from::new();
+				for i in 0..8 {
+					if i < $size {
+						ret.0[$size - i - 1] = (value & 0xff) as u8;
+						value >>= 8;
+					}
+				}
+				ret
+			}
+		}
+
+		impl<'a> From<&'a [u8]> for $from {
+			fn from(s: &'a [u8]) -> $from {
+				$from::from_slice(s)
+			}
+		}
+
+		impl_std_for_hash!($from, $size);
+		impl_heapsize_for_hash!($from);
+		impl_libc_for_hash!($from, $size);
+		impl_quickcheck_arbitrary_for_hash!($from, $size);
+	}
+}
+
+#[cfg(all(feature="heapsizeof", feature="libc", not(target_os = "unknown")))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_heapsize_for_hash {
+	($name: ident) => {
+		impl $crate::heapsize::HeapSizeOf for $name {
+			fn heap_size_of_children(&self) -> usize {
+				0
+			}
+		}
+	}
+}
+
+#[cfg(any(not(feature="heapsizeof"), not(feature="libc"), target_os = "unknown"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_heapsize_for_hash {
+	($name: ident) => {}
+}
+
+#[cfg(feature="std")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_std_for_hash {
+	($from: ident, $size: tt) => {
+		impl $from {
+			/// Get a hex representation.
+			#[deprecated(note="Use LowerHex or Debug formatting instead.")]
+			pub fn hex(&self) -> String {
+				format!("{:?}", self)
+			}
+		}
+
+		impl $crate::rand::Rand for $from {
+			fn rand<R: $crate::rand::Rng>(r: &mut R) -> Self {
+				let mut hash = $from::new();
+				r.fill_bytes(&mut hash.0);
+				hash
+			}
+		}
+
+		impl ::core::str::FromStr for $from {
+			type Err = $crate::rustc_hex::FromHexError;
+
+			fn from_str(s: &str) -> Result<$from, $crate::rustc_hex::FromHexError> {
+				use $crate::rustc_hex::FromHex;
+				let a = s.from_hex()?;
+				if a.len() != $size {
+					return Err($crate::rustc_hex::FromHexError::InvalidHexLength);
+				}
+
+				let mut ret = [0; $size];
+				ret.copy_from_slice(&a);
+				Ok($from(ret))
+			}
+		}
+
+		impl From<&'static str> for $from {
+			fn from(s: &'static str) -> $from {
+				let s = $crate::clean_0x(s);
+				if s.len() % 2 == 1 {
+					("0".to_owned() + s).parse().unwrap()
+				} else {
+					s.parse().unwrap()
+				}
+			}
+		}
+	}
+}
+
+
+#[cfg(not(feature="std"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_std_for_hash {
+	($from: ident, $size: tt) => {}
+}
+
+
+#[cfg(feature="std")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_std_for_hash_internals {
+	($from: ident, $size: tt) => {
+		/// Create a new, cryptographically random, instance.
+		pub fn random() -> $from {
+			let mut hash = $from::new();
+			hash.randomize();
+			hash
+		}
+
+		/// Assign self have a cryptographically random value.
+		pub fn randomize(&mut self) {
+			let mut rng = $crate::rand::OsRng::new().unwrap();
+			*self = $crate::rand::Rand::rand(&mut rng);
+		}
+	}
+}
+
+#[cfg(not(feature="std"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_std_for_hash_internals {
+	($from: ident, $size: tt) => {}
+}
+
+#[cfg(all(feature="libc", not(target_os = "unknown")))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_libc_for_hash {
+	($from: ident, $size: expr) => {
+		impl PartialEq for $from {
+			fn eq(&self, other: &Self) -> bool {
+				unsafe { $crate::libc::memcmp(self.0.as_ptr() as *const $crate::libc::c_void, other.0.as_ptr() as *const $crate::libc::c_void, $size) == 0 }
+			}
+		}
+
+		impl Ord for $from {
+			fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
+				let r = unsafe { $crate::libc::memcmp(self.0.as_ptr() as *const $crate::libc::c_void, other.0.as_ptr() as *const $crate::libc::c_void, $size) };
+				if r < 0 { return ::core::cmp::Ordering::Less }
+				if r > 0 { return ::core::cmp::Ordering::Greater }
+				return ::core::cmp::Ordering::Equal;
+			}
+		}
+	}
+}
+
+#[cfg(any(not(feature="libc"), target_os = "unknown"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_libc_for_hash {
+	($from: ident, $size: expr) => {
+		impl PartialEq for $from {
+			fn eq(&self, other: &Self) -> bool {
+				&self.0[..] == &other.0[..]
+			}
+		}
+
+		impl Ord for $from {
+			fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
+				self.0[..].cmp(&other.0[..])
+			}
+		}
+	}
+}
+
+#[cfg(feature="impl_quickcheck_arbitrary")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_quickcheck_arbitrary_for_hash {
+	($name: ty, $n_bytes: tt) => {
+		impl $crate::quickcheck::Arbitrary for $name {
+			fn arbitrary<G: $crate::quickcheck::Gen>(g: &mut G) -> Self {
+				let mut res = [0u8; $n_bytes];
+				g.fill_bytes(&mut res[..$n_bytes]);
+				res.as_ref().into()
+			}
+		}
+	}
+}
+
+#[cfg(not(feature="impl_quickcheck_arbitrary"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_quickcheck_arbitrary_for_hash {
+	($name: ty, $n_bytes: tt) => {}
+}

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -154,7 +154,7 @@ macro_rules! construct_hash {
 		impl ::core::fmt::LowerHex for $from {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				if f.alternate() {
-					write!(f, "0x");
+					write!(f, "0x")?;
 				}
 				for i in &self.0[..] {
 					write!(f, "{:02x}", i)?;
@@ -488,4 +488,23 @@ macro_rules! impl_quickcheck_arbitrary_for_hash {
 #[doc(hidden)]
 macro_rules! impl_quickcheck_arbitrary_for_hash {
 	($name: ty, $n_bytes: tt) => {}
+}
+
+#[cfg(test)]
+mod tests {
+	construct_hash!(H10, 10);
+	#[test]
+	fn test_construct_hash() {
+		assert_eq!(H10::default(), H10::new());
+		assert_eq!(H10::new(), H10::zero());
+		assert_eq!(H10::len(), 10);
+	}
+
+	#[cfg(feature="heapsizeof")]
+	#[test]
+	fn test_heapsizeof() {
+		use heapsize::HeapSizeOf;
+		let h = H10::zero();
+		assert_eq!(h.heap_size_of_children(),0);
+	}
 }

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -1,0 +1,40 @@
+// Copyright 2015-2017 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature="libc", not(target_os = "unknown")))]
+#[doc(hidden)]
+pub extern crate libc;
+
+#[cfg(not(feature="libc"))]
+#[doc(hidden)]
+pub mod libc { }
+
+#[cfg(feature="heapsizeof")]
+#[doc(hidden)]
+pub extern crate heapsize;
+
+#[cfg(feature="std")]
+#[doc(hidden)]
+pub extern crate core;
+
+#[cfg(feature="std")]
+#[doc(hidden)]
+pub extern crate rustc_hex;
+
+#[cfg(feature="std")]
+#[doc(hidden)]
+pub extern crate rand;
+
+#[cfg(feature="impl_quickcheck_arbitrary")]
+#[doc(hidden)]
+pub extern crate quickcheck;
+
+mod hash;
+pub use hash::*;


### PR DESCRIPTION
Both `susbtrate` and `ethereum-types` use `fixed-hash` to build their hash types so it's getting moved here.