### PR TITLE
Fix seek in TrieDB iterator

### DIFF
--- a/patricia_trie/src/lib.rs
+++ b/patricia_trie/src/lib.rs
@@ -202,7 +202,7 @@ pub trait TrieMut<H: Hasher, C: NodeCodec<H>> {
 
 /// A trie iterator that also supports random access (`seek()`).
 pub trait TrieIterator<H: Hasher, C: NodeCodec<H>>: Iterator {
-	/// Position the iterator on the first element with key > `key`
+	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), H::Out, <C as NodeCodec<H>>::Error>;
 }
 

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -244,9 +244,9 @@ impl<'a, H: Hasher, C: NodeCodec<H>> TrieDBIterator<'a, H, C> {
 				let node = C::decode(&node_data).expect("encoded data read from db; qed");
 				match node {
 					Node::Leaf(slice, _) => {
-						if slice == key {
+						if slice >= key {
 							self.trail.push(Crumb {
-								status: Status::At,
+								status: Status::Entering,
 								node: node.clone().into(),
 							});
 						} else {
@@ -276,7 +276,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> TrieDBIterator<'a, H, C> {
 					Node::Branch(ref nodes, _) => match key.is_empty() {
 						true => {
 							self.trail.push(Crumb {
-								status: Status::At,
+								status: Status::Entering,
 								node: node.clone().into(),
 							});
 							return Ok(())
@@ -458,22 +458,22 @@ mod tests {
 		assert_eq!(d, iter.map(|x| x.unwrap().1).collect::<Vec<_>>());
 		let mut iter = t.iter().unwrap();
 		iter.seek(b"A").unwrap();
-		assert_eq!(&d[1..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
+		assert_eq!(d, &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
 		let mut iter = t.iter().unwrap();
 		iter.seek(b"AA").unwrap();
-		assert_eq!(&d[2..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
+		assert_eq!(&d[1..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
 		let mut iter = t.iter().unwrap();
 		iter.seek(b"A!").unwrap();
 		assert_eq!(&d[1..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
 		let mut iter = t.iter().unwrap();
 		iter.seek(b"AB").unwrap();
-		assert_eq!(&d[3..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
+		assert_eq!(&d[2..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
 		let mut iter = t.iter().unwrap();
 		iter.seek(b"AB!").unwrap();
 		assert_eq!(&d[3..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
 		let mut iter = t.iter().unwrap();
 		iter.seek(b"B").unwrap();
-		assert_eq!(&d[4..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
+		assert_eq!(&d[3..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);
 		let mut iter = t.iter().unwrap();
 		iter.seek(b"C").unwrap();
 		assert_eq!(&d[4..], &iter.map(|x| x.unwrap().1).collect::<Vec<_>>()[..]);


### PR DESCRIPTION
It seems to me that the behavior of `seek` on a `TrieDB` iterator was broken, looking at the tests.
Seeking to "A" which is in the Trie, calling `next` should return "A" and not the next value.
This was particularly broken when in a trie with `[16, 8]` and `[16, 16]`, seeking to `[16, 0]` would start the iterator at `[16, 16]`.