### PR TITLE
unbound salt size

### DIFF
--- a/parity-crypto/src/lib.rs
+++ b/parity-crypto/src/lib.rs
@@ -56,7 +56,7 @@ impl<T> Keccak256<[u8; 32]> for T where T: AsRef<[u8]> {
 	}
 }
 
-pub fn derive_key_iterations(password: &[u8], salt: &[u8; 32], c: u32) -> (Vec<u8>, Vec<u8>) {
+pub fn derive_key_iterations(password: &[u8], salt: &[u8], c: u32) -> (Vec<u8>, Vec<u8>) {
 	let mut derived_key = [0u8; KEY_LENGTH];
 	pbkdf2::sha256(c, pbkdf2::Salt(salt), pbkdf2::Secret(password), &mut derived_key);
 	let derived_right_bits = &derived_key[0..KEY_LENGTH_AES];

--- a/parity-crypto/src/scrypt.rs
+++ b/parity-crypto/src/scrypt.rs
@@ -18,7 +18,7 @@ use error::ScryptError;
 use rcrypto::scrypt::{scrypt, ScryptParams};
 use super::{KEY_LENGTH_AES, KEY_LENGTH};
 
-pub fn derive_key(pass: &[u8], salt: &[u8; 32], n: u32, p: u32, r: u32) -> Result<(Vec<u8>, Vec<u8>), ScryptError> {
+pub fn derive_key(pass: &[u8], salt: &[u8], n: u32, p: u32, r: u32) -> Result<(Vec<u8>, Vec<u8>), ScryptError> {
 	// sanity checks
 	let log_n = (32 - n.leading_zeros() - 1) as u8;
 	if log_n as u32 >= r * 16 {


### PR DESCRIPTION
There is no reason to enforce this 32 bytes bound. Salt can have arbitrary lenght.