### PR TITLE
[hashdb] make the `Hasher` trait useable with `no_std`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ script:
   - cargo build
   - cargo test --all --exclude uint
   - cd uint/ && cargo test --features=std,impl_quickcheck_arbitrary
+  - cd hashdb/ && cargo test --no-default-features
+  - cd plain_hasher/ && cargo test --no-default-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ matrix:
 script:
   - cargo build
   - cargo test --all --exclude uint
-  - cd uint/ && cargo test --features=std,impl_quickcheck_arbitrary
-  - cd hashdb/ && cargo test --no-default-features
-  - cd plain_hasher/ && cargo test --no-default-features
+  - cd uint/ && cargo test --features=std,impl_quickcheck_arbitrary && cd ..
+  - cd hashdb/ && cargo test --no-default-features && cd ..
+  - cd plain_hasher/ && cargo test --no-default-features && cd ..

--- a/hashdb/Cargo.toml
+++ b/hashdb/Cargo.toml
@@ -6,4 +6,8 @@ description = "trait for hash-keyed databases."
 license = "GPL-3.0"
 
 [dependencies]
-elastic-array = "0.10"
+elastic-array = { version = "0.10", optional = true }
+
+[features]
+default = ["std"]
+std = ["elastic-array"]

--- a/hashdb/Cargo.toml
+++ b/hashdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashdb"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "trait for hash-keyed databases."
 license = "GPL-3.0"

--- a/hashdb/README.md
+++ b/hashdb/README.md
@@ -1,1 +1,4 @@
+# HashDB
 `HashDB` defines a common interface for databases of byte-slices keyed to their hash. It is generic over hash type through the `Hasher` trait.
+
+The `Hasher` trait can be used in a `no_std` context.

--- a/hashdb/src/lib.rs
+++ b/hashdb/src/lib.rs
@@ -15,11 +15,19 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Database of byte-slices keyed to their hash.
-extern crate elastic_array;
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+extern crate elastic_array;
+#[cfg(feature = "std")]
+extern crate core;
+
+#[cfg(feature = "std")]
 use elastic_array::ElasticArray128;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
-use std::{fmt::Debug, hash::Hash};
+use core::{fmt::Debug, hash::Hash};
 
 /// Trait describing an object that can hash a slice of bytes. Used to abstract
 /// other types over the hashing algorithm. Defines a single `hash` method and an
@@ -28,7 +36,7 @@ pub trait Hasher: Sync + Send {
 	/// The output type of the `Hasher`
 	type Out: AsRef<[u8]> + AsMut<[u8]> + Default + Debug + PartialEq + Eq + Hash + Send + Sync + Clone + Copy;
 	/// What to use to build `HashMap`s with this `Hasher`
-	type StdHasher: Sync + Send + Default + std::hash::Hasher;
+	type StdHasher: Sync + Send + Default + core::hash::Hasher;
 	/// The length in bytes of the `Hasher` output
 	const LENGTH: usize;
 
@@ -37,9 +45,11 @@ pub trait Hasher: Sync + Send {
 }
 
 /// `HashDB` value type.
+#[cfg(feature = "std")]
 pub type DBValue = ElasticArray128<u8>;
 
 /// Trait modelling datastore keyed by a hash defined by the `Hasher`.
+#[cfg(feature = "std")]
 pub trait HashDB<H: Hasher>: Send + Sync + AsHashDB<H> {
 	/// Get the keys in the database together with number of underlying references.
 	fn keys(&self) -> HashMap<H::Out, i32>;
@@ -65,6 +75,7 @@ pub trait HashDB<H: Hasher>: Send + Sync + AsHashDB<H> {
 }
 
 /// Upcast trait.
+#[cfg(feature = "std")]
 pub trait AsHashDB<H: Hasher> {
 	/// Perform upcast to HashDB for anything that derives from HashDB.
 	fn as_hashdb(&self) -> &HashDB<H>;
@@ -74,6 +85,7 @@ pub trait AsHashDB<H: Hasher> {
 
 // NOTE: There used to be a `impl<T> AsHashDB for T` but that does not work with generics. See https://stackoverflow.com/questions/48432842/implementing-a-trait-for-reference-and-non-reference-types-causes-conflicting-im
 // This means we need concrete impls of AsHashDB in several places, which somewhat defeats the point of the trait.
+#[cfg(feature = "std")]
 impl<'a, H: Hasher> AsHashDB<H> for &'a mut HashDB<H> {
 	fn as_hashdb(&self) -> &HashDB<H> { &**self }
 	fn as_hashdb_mut(&mut self) -> &mut HashDB<H> { &mut **self }

--- a/plain_hasher/src/lib.rs
+++ b/plain_hasher/src/lib.rs
@@ -57,7 +57,7 @@ impl hash::Hasher for PlainHasher {
 
 #[cfg(test)]
 mod tests {
-	use std::hash::Hasher;
+	use core::hash::Hasher;
 	use super::PlainHasher;
 
 	#[test]


### PR DESCRIPTION
Enable use of the `Hasher` trait in a `no_std` context.