### PR TITLE
[rlp] make it possible to use rlp without pulling in ethereum-types

### DIFF
--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -12,6 +12,9 @@ elastic-array = "0.10"
 ethereum-types = { version = "0.3", optional = true }
 rustc-hex = "2.0"
 
+[dev-dependencies]
+hex-literal = "0.1"
+
 [features]
 default = ["ethereum"]
 ethereum = ["ethereum-types"]

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -9,5 +9,9 @@ authors = ["Parity Technologies <admin@parity.io>"]
 [dependencies]
 byteorder = "1.0"
 elastic-array = "0.10"
-ethereum-types = "0.3"
-rustc-hex = "1.0"
+ethereum-types = { version = "0.3", optional = true }
+rustc-hex = "2.0"
+
+[features]
+default = ["ethereum"]
+ethereum = ["ethereum-types"]

--- a/rlp/src/impls.rs
+++ b/rlp/src/impls.rs
@@ -8,6 +8,7 @@
 
 use std::{cmp, mem, str};
 use byteorder::{ByteOrder, BigEndian};
+#[cfg(feature = "ethereum")]
 use bigint::{U128, U256, H64, H128, H160, H256, H512, H520, Bloom};
 use traits::{Encodable, Decodable};
 use stream::RlpStream;
@@ -207,20 +208,34 @@ macro_rules! impl_decodable_for_hash {
 	}
 }
 
+#[cfg(feature = "ethereum")]
 impl_encodable_for_hash!(H64);
+#[cfg(feature = "ethereum")]
 impl_encodable_for_hash!(H128);
+#[cfg(feature = "ethereum")]
 impl_encodable_for_hash!(H160);
+#[cfg(feature = "ethereum")]
 impl_encodable_for_hash!(H256);
+#[cfg(feature = "ethereum")]
 impl_encodable_for_hash!(H512);
+#[cfg(feature = "ethereum")]
 impl_encodable_for_hash!(H520);
+#[cfg(feature = "ethereum")]
 impl_encodable_for_hash!(Bloom);
 
+#[cfg(feature = "ethereum")]
 impl_decodable_for_hash!(H64, 8);
+#[cfg(feature = "ethereum")]
 impl_decodable_for_hash!(H128, 16);
+#[cfg(feature = "ethereum")]
 impl_decodable_for_hash!(H160, 20);
+#[cfg(feature = "ethereum")]
 impl_decodable_for_hash!(H256, 32);
+#[cfg(feature = "ethereum")]
 impl_decodable_for_hash!(H512, 64);
+#[cfg(feature = "ethereum")]
 impl_decodable_for_hash!(H520, 65);
+#[cfg(feature = "ethereum")]
 impl_decodable_for_hash!(Bloom, 256);
 
 macro_rules! impl_encodable_for_uint {
@@ -254,10 +269,14 @@ macro_rules! impl_decodable_for_uint {
 	}
 }
 
+#[cfg(feature = "ethereum")]
 impl_encodable_for_uint!(U256, 32);
+#[cfg(feature = "ethereum")]
 impl_encodable_for_uint!(U128, 16);
 
+#[cfg(feature = "ethereum")]
 impl_decodable_for_uint!(U256, 32);
+#[cfg(feature = "ethereum")]
 impl_decodable_for_uint!(U128, 16);
 
 impl<'a> Encodable for &'a str {

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -37,6 +37,9 @@ extern crate byteorder;
 extern crate ethereum_types as bigint;
 extern crate elastic_array;
 extern crate rustc_hex;
+#[cfg(test)]
+#[macro_use]
+extern crate hex_literal;
 
 mod traits;
 mod error;

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -33,6 +33,7 @@
 //! * You don't want to decode whole rlp at once.
 
 extern crate byteorder;
+#[cfg(feature = "ethereum")]
 extern crate ethereum_types as bigint;
 extern crate elastic_array;
 extern crate rustc_hex;

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -390,7 +390,7 @@ mod tests {
 	#[test]
 	fn test_rlp_display() {
 		use rustc_hex::FromHex;
-		let data = "f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470".from_hex().unwrap();
+		let data = hex!("f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"); //.from_hex().unwrap();
 		let rlp = Rlp::new(&data);
 		assert_eq!(format!("{}", rlp), "[\"0x05\", \"0x010efbef67941f79b2\", \"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"]");
 	}

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -118,7 +118,7 @@ impl<'a> fmt::Display for Rlp<'a> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
 		match self.prototype() {
 			Ok(Prototype::Null) => write!(f, "null"),
-			Ok(Prototype::Data(_)) => write!(f, "\"0x{}\"", self.data().unwrap().to_hex()),
+			Ok(Prototype::Data(_)) => write!(f, "\"0x{}\"", self.data().unwrap().to_hex::<String>()),
 			Ok(Prototype::List(len)) => {
 				write!(f, "[")?;
 				for i in 0..len-1 {

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -6,10 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "ethereum")]
 extern crate ethereum_types as bigint;
 extern crate rlp;
 
 use std::{fmt, cmp};
+#[cfg(feature = "ethereum")]
 use bigint::{U256, H160};
 use rlp::{Encodable, Decodable, Rlp, RlpStream, DecoderError};
 
@@ -130,6 +132,7 @@ fn encode_u64() {
 	run_encode_tests(tests);
 }
 
+#[cfg(feature = "ethereum")]
 #[test]
 fn encode_u256() {
 	let tests = vec![ETestPair(U256::from(0u64), vec![0x80u8]),
@@ -162,6 +165,7 @@ fn encode_str() {
 	run_encode_tests(tests);
 }
 
+#[cfg(feature = "ethereum")]
 #[test]
 fn encode_address() {
 	let tests = vec![
@@ -272,6 +276,7 @@ fn decode_untrusted_u64() {
 	run_decode_tests(tests);
 }
 
+#[cfg(feature = "ethereum")]
 #[test]
 fn decode_untrusted_u256() {
 	let tests = vec![DTestPair(U256::from(0u64), vec![0x80u8]),
@@ -306,6 +311,7 @@ fn decode_untrusted_str() {
 	run_decode_tests(tests);
 }
 
+#[cfg(feature = "ethereum")]
 #[test]
 fn decode_untrusted_address() {
 	let tests = vec![


### PR DESCRIPTION
Makes it possible to use `rlp` in polkadot without pulling in `ethereum-types` and associated luggage.