### PR TITLE
Use exported types in benchmark

### DIFF
--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]

--- a/uint/benches/bigint.rs
+++ b/uint/benches/bigint.rs
@@ -20,20 +20,13 @@ extern crate test;
 extern crate crunchy;
 #[macro_use]
 extern crate uint;
+
+use uint::{U256, U512};
+// NOTE: constructing the type inside the benchmark crate is much faster so the
+// numbers for `U128` are better than they'd normally be.
 construct_uint!(U128, 2);
-construct_uint!(U256, 4);
-construct_uint!(U512, 8);
 
 use test::{Bencher, black_box};
-
-impl U256 {
-	/// Multiplies two 256-bit integers to produce full 512-bit integer
-	/// No overflow possible
-	#[inline(always)]
-	pub fn full_mul(self, other: U256) -> U512 {
-		U512(uint_full_mul_reg!(U256, 4, self, other))
-	}
-}
 
 #[bench]
 fn u256_add(b: &mut Bencher) {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1377,3 +1377,13 @@ macro_rules! impl_quickcheck_arbitrary_for_uint {
 
 construct_uint!(U256, 4);
 construct_uint!(U512, 8);
+
+#[doc(hidden)]
+impl U256 {
+	/// Multiplies two 256-bit integers to produce full 512-bit integer
+	/// No overflow possible
+	#[inline(always)]
+	pub fn full_mul(self, other: U256) -> U512 {
+		U512(uint_full_mul_reg!(U256, 4, self, other))
+	}
+}


### PR DESCRIPTION
As seen in https://github.com/paritytech/parity-common/pull/25 constructing the types inside the benchmark improves the numbers. It is probably better to have the benchmark use the exported types (`U256` and `U512`) to better emulate the speed consuming crates see.