### PR TITLE
Relax version requirements

### DIFF
--- a/memorydb/Cargo.toml
+++ b/memorydb/Cargo.toml
@@ -8,9 +8,9 @@ license = "GPL-3.0"
 [dependencies]
 elastic-array = "0.10"
 heapsize = "0.4"
-hashdb = { version = "0.2.0", path = "../hashdb" }
-plain_hasher = { path = "../plain_hasher" }
-rlp = { version = "0.2.1", path = "../rlp" }
+hashdb = { path = "../hashdb" }
+plain_hasher = { path = "../plain_hasher", default-features = false }
+rlp = { path = "../rlp", default-features = false }
 
 [dev-dependencies]
 tiny-keccak = "1.4.2"

--- a/memorydb/Cargo.toml
+++ b/memorydb/Cargo.toml
@@ -8,12 +8,12 @@ license = "GPL-3.0"
 [dependencies]
 elastic-array = "0.10"
 heapsize = "0.4"
-hashdb = { path = "../hashdb" }
-plain_hasher = { path = "../plain_hasher", default-features = false }
-rlp = { path = "../rlp", default-features = false }
+hashdb = { version = "0.2", path = "../hashdb" }
+plain_hasher = { version = "0.2", path = "../plain_hasher", default-features = false }
+rlp = { version = "0.2", path = "../rlp", default-features = false }
 
 [dev-dependencies]
 tiny-keccak = "1.4.2"
 ethereum-types = "0.3"
-keccak-hasher = { path = "../test-support/keccak-hasher" }
-keccak-hash = { path = "../keccak-hash" }
+keccak-hasher = { version = "0.1", path = "../test-support/keccak-hasher" }
+keccak-hash = { version = "0.1", path = "../keccak-hash" }

--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -16,10 +16,10 @@ parity-bytes = { version = "0.1", path = "../parity-bytes" }
 env_logger = "0.5"
 ethereum-types = "0.3"
 keccak-hash = { version = "0.1", path = "../keccak-hash" }
-memorydb = { path = "../memorydb", default-features = false }
-rlp = { path = "../rlp", default-features = false }
-trie-standardmap = { path = "../trie-standardmap", default-features = false }
-triehash = { path = "../triehash", default-features = false }
+memorydb = { version = "0.2", path = "../memorydb", default-features = false }
+rlp = { version = "0.2", path = "../rlp", default-features = false }
+trie-standardmap = { version = "0.1", path = "../trie-standardmap", default-features = false }
+triehash = { version = "0.2", path = "../triehash", default-features = false }
 
 # REVIEW: what's a better way to deal with this? The tests here in
 # `patricia_trie` use `keccak-hasher` and `patricia-trie-ethereum` to

--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -16,10 +16,10 @@ parity-bytes = { version = "0.1", path = "../parity-bytes" }
 env_logger = "0.5"
 ethereum-types = "0.3"
 keccak-hash = { version = "0.1", path = "../keccak-hash" }
-memorydb = { version = "0.2", path = "../memorydb" }
-rlp = { version = "0.2.1", path = "../rlp" }
-trie-standardmap = { version = "0.1", path = "../trie-standardmap" }
-triehash = { version = "0.2", path = "../triehash" }
+memorydb = { path = "../memorydb", default-features = false }
+rlp = { path = "../rlp", default-features = false }
+trie-standardmap = { path = "../trie-standardmap", default-features = false }
+triehash = { path = "../triehash", default-features = false }
 
 # REVIEW: what's a better way to deal with this? The tests here in
 # `patricia_trie` use `keccak-hasher` and `patricia-trie-ethereum` to

--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -22,7 +22,6 @@ trie-standardmap = { version = "0.1", path = "../trie-standardmap", default-feat
 triehash = { version = "0.2", path = "../triehash", default-features = false }
 parity-bytes = { version = "0.1.0", path = "../parity-bytes" }
 
-
 # REVIEW: what's a better way to deal with this? The tests here in
 # `patricia_trie` use `keccak-hasher` and `patricia-trie-ethereum` to
 # instantiate concrete impls. Neither crate is needed/wanted in `parity-common`

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -8,8 +8,8 @@ license = "GPL-3.0"
 
 [dependencies]
 elastic-array = "0.10"
-hashdb = { path = "../hashdb", default-features = false }
-rlp = { path = "../rlp", default-features = false }
+hashdb = { version = "0.2", path = "../hashdb", default-features = false }
+rlp = { version = "0.2", path = "../rlp", default-features = false }
 
 [dev-dependencies]
 trie-standardmap = { version = "0.1", path = "../trie-standardmap" }

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triehash"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "in memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,8 +8,8 @@ license = "GPL-3.0"
 
 [dependencies]
 elastic-array = "0.10"
-hashdb = { version = "0.2", path = "../hashdb", default_features = false }
-rlp = { version = "0.2", path = "../rlp", default_features = false }
+hashdb = { path = "../hashdb", default-features = false }
+rlp = { path = "../rlp", default-features = false }
 
 [dev-dependencies]
 trie-standardmap = { version = "0.1", path = "../trie-standardmap" }


### PR DESCRIPTION
Omitting the "internal" version requirements for crates within `parity-common` should let downstream consumers set their own requirements. Also use less features where possible.