### PR TITLE
rlp: remove elastic-array crate and use Vec instead

### DIFF
--- a/hashdb/Cargo.toml
+++ b/hashdb/Cargo.toml
@@ -6,8 +6,7 @@ description = "trait for hash-keyed databases."
 license = "GPL-3.0"
 
 [dependencies]
-elastic-array = { version = "0.10", optional = true }
 
 [features]
 default = ["std"]
-std = ["elastic-array"]
+std = []

--- a/hashdb/Cargo.toml
+++ b/hashdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashdb"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "trait for hash-keyed databases."
 license = "GPL-3.0"

--- a/hashdb/src/lib.rs
+++ b/hashdb/src/lib.rs
@@ -19,12 +19,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-extern crate elastic_array;
-#[cfg(feature = "std")]
 extern crate core;
 
 #[cfg(feature = "std")]
-use elastic_array::ElasticArray128;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 use core::{fmt::Debug, hash::Hash};
@@ -44,19 +41,15 @@ pub trait Hasher: Sync + Send {
 	fn hash(x: &[u8]) -> Self::Out;
 }
 
-/// `HashDB` value type.
-#[cfg(feature = "std")]
-pub type DBValue = ElasticArray128<u8>;
-
 /// Trait modelling datastore keyed by a hash defined by the `Hasher`.
 #[cfg(feature = "std")]
-pub trait HashDB<H: Hasher>: Send + Sync + AsHashDB<H> {
+pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 	/// Get the keys in the database together with number of underlying references.
 	fn keys(&self) -> HashMap<H::Out, i32>;
 
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
-	fn get(&self, key: &H::Out) -> Option<DBValue>;
+	fn get(&self, key: &H::Out) -> Option<&T>;
 
 	/// Check for the existance of a hash-key.
 	fn contains(&self, key: &H::Out) -> bool;
@@ -67,7 +60,7 @@ pub trait HashDB<H: Hasher>: Send + Sync + AsHashDB<H> {
 	fn insert(&mut self, value: &[u8]) -> H::Out;
 
 	/// Like `insert()`, except you provide the key and the data is all moved.
-	fn emplace(&mut self, key: H::Out, value: DBValue);
+	fn emplace(&mut self, key: H::Out, value: T);
 
 	/// Remove a datum previously inserted. Insertions can be "owed" such that the same number of `insert()`s may
 	/// happen without the data being eventually being inserted into the DB. It can be "owed" more than once.
@@ -76,18 +69,18 @@ pub trait HashDB<H: Hasher>: Send + Sync + AsHashDB<H> {
 
 /// Upcast trait.
 #[cfg(feature = "std")]
-pub trait AsHashDB<H: Hasher> {
+pub trait AsHashDB<H: Hasher, T> {
 	/// Perform upcast to HashDB for anything that derives from HashDB.
-	fn as_hashdb(&self) -> &HashDB<H>;
+	fn as_hashdb(&self) -> &HashDB<H, T>;
 	/// Perform mutable upcast to HashDB for anything that derives from HashDB.
-	fn as_hashdb_mut(&mut self) -> &mut HashDB<H>;
+	fn as_hashdb_mut(&mut self) -> &mut HashDB<H, T>;
 }
 
 // NOTE: There used to be a `impl<T> AsHashDB for T` but that does not work with generics. See https://stackoverflow.com/questions/48432842/implementing-a-trait-for-reference-and-non-reference-types-causes-conflicting-im
 // This means we need concrete impls of AsHashDB in several places, which somewhat defeats the point of the trait.
 #[cfg(feature = "std")]
-impl<'a, H: Hasher> AsHashDB<H> for &'a mut HashDB<H> {
-	fn as_hashdb(&self) -> &HashDB<H> { &**self }
-	fn as_hashdb_mut(&mut self) -> &mut HashDB<H> { &mut **self }
+impl<'a, H: Hasher, T> AsHashDB<H, T> for &'a mut HashDB<H, T> {
+	fn as_hashdb(&self) -> &HashDB<H, T> { &**self }
+	fn as_hashdb_mut(&mut self) -> &mut HashDB<H, T> { &mut **self }
 }
 

--- a/memorydb/Cargo.toml
+++ b/memorydb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memorydb"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "in-memory implementation of hashdb"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 
 [dependencies]
 heapsize = "0.4"
-hashdb = { version = "0.2", path = "../hashdb" }
+hashdb = { version = "0.3", path = "../hashdb" }
 plain_hasher = { version = "0.2", path = "../plain_hasher", default-features = false }
 rlp = { version = "0.3", path = "../rlp", default-features = false }
 

--- a/memorydb/Cargo.toml
+++ b/memorydb/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/paritytech/parity-common"
 license = "GPL-3.0"
 
 [dependencies]
-elastic-array = "0.10"
 heapsize = "0.4"
 hashdb = { version = "0.2", path = "../hashdb" }
 plain_hasher = { version = "0.2", path = "../plain_hasher", default-features = false }

--- a/memorydb/Cargo.toml
+++ b/memorydb/Cargo.toml
@@ -11,7 +11,7 @@ elastic-array = "0.10"
 heapsize = "0.4"
 hashdb = { version = "0.2", path = "../hashdb" }
 plain_hasher = { version = "0.2", path = "../plain_hasher", default-features = false }
-rlp = { version = "0.2", path = "../rlp", default-features = false }
+rlp = { version = "0.3", path = "../rlp", default-features = false }
 
 [dev-dependencies]
 tiny-keccak = "1.4.2"

--- a/memorydb/benches/memdb.rs
+++ b/memorydb/benches/memdb.rs
@@ -34,7 +34,7 @@ use test::{Bencher, black_box};
 #[bench]
 fn instantiation(b: &mut Bencher) {
     b.iter(|| {
-        MemoryDB::<KeccakHasher>::new();
+        MemoryDB::<KeccakHasher, Vec<u8>>::new();
     })
 }
 
@@ -60,7 +60,7 @@ fn compare_to_null_in_const(b: &mut Bencher) {
 
 #[bench]
 fn contains_with_non_null_key(b: &mut Bencher) {
-    let mut m = MemoryDB::<KeccakHasher>::new();
+    let mut m = MemoryDB::<KeccakHasher, Vec<u8>>::new();
     let key = KeccakHasher::hash(b"abc");
     m.insert(b"abcefghijklmnopqrstuvxyz");
     b.iter(|| {
@@ -70,7 +70,7 @@ fn contains_with_non_null_key(b: &mut Bencher) {
 
 #[bench]
 fn contains_with_null_key(b: &mut Bencher) {
-    let mut m = MemoryDB::<KeccakHasher>::new();
+    let mut m = MemoryDB::<KeccakHasher, Vec<u8>>::new();
     let null_key = KeccakHasher::hash(&NULL_RLP);
     m.insert(b"abcefghijklmnopqrstuvxyz");
     b.iter(|| {

--- a/memorydb/src/lib.rs
+++ b/memorydb/src/lib.rs
@@ -30,7 +30,8 @@ use std::collections::HashMap;
 use std::hash;
 use std::mem;
 
-// Backing `HashMap` parametrized with a `Hasher` for the keys `Hasher::Out` and the `Hasher::StdHasher` as hash map builder.
+// Backing `HashMap` parametrized with a `Hasher` for the keys `Hasher::Out` and the `Hasher::StdHasher`
+// as hash map builder.
 type FastMap<H, T> = HashMap<<H as KeyHasher>::Out, T, hash::BuildHasherDefault<<H as KeyHasher>::StdHasher>>;
 
 /// Reference-counted memory-based `HashDB` implementation.
@@ -84,28 +85,28 @@ type FastMap<H, T> = HashMap<<H as KeyHasher>::Out, T, hash::BuildHasherDefault<
 pub struct MemoryDB<H: KeyHasher, T> {
 	data: FastMap<H, (T, i32)>,
 	hashed_null_node: H::Out,
-    null_node_data: T,
+	null_node_data: T,
 }
 
 impl<'a, H, T> Default for MemoryDB<H, T> where H: KeyHasher, H::Out: HeapSizeOf, T: From<&'a [u8]> {
 	fn default() -> Self { Self::new() }
 }
 
-impl<'a, H, T> MemoryDB<H, T> 
-    where H: KeyHasher,
-          H::Out: HeapSizeOf,
-          T: From<&'a [u8]>,
+impl<'a, H, T> MemoryDB<H, T>
+	where H: KeyHasher,
+		  H::Out: HeapSizeOf,
+		  T: From<&'a [u8]>,
 {
 	/// Create a new instance of the memory DB.
 	pub fn new() -> Self {
-        MemoryDB::from_null_node(&NULL_RLP, NULL_RLP.as_ref().into())
+		MemoryDB::from_null_node(&NULL_RLP, NULL_RLP.as_ref().into())
 	}
 }
 
-impl<H, T> MemoryDB<H, T> 
-    where H: KeyHasher,
-          H::Out: HeapSizeOf,
-          T: Default,
+impl<H, T> MemoryDB<H, T>
+	where H: KeyHasher,
+		  H::Out: HeapSizeOf,
+		  T: Default,
 {
 	/// Remove an element and delete it from storage if reference count reaches zero.
 	/// If the value was purged, return the old value.
@@ -131,14 +132,14 @@ impl<H, T> MemoryDB<H, T>
 
 impl<H: KeyHasher, T> MemoryDB<H, T> {
 
-    /// Create a new `MemoryDB` from a given null key/data
-    pub fn from_null_node(null_key: &[u8], null_node_data: T) -> Self {
+	/// Create a new `MemoryDB` from a given null key/data
+	pub fn from_null_node(null_key: &[u8], null_node_data: T) -> Self {
 		MemoryDB {
 			data: FastMap::<H,_>::default(),
 			hashed_null_node: H::hash(null_key),
-            null_node_data,
+			null_node_data,
 		}
-    }
+	}
 
 	/// Clear all data from the database.
 	///
@@ -207,9 +208,9 @@ impl<H: KeyHasher, T> MemoryDB<H, T> {
 }
 
 impl<H, T> MemoryDB<H, T>
-    where H: KeyHasher,
-          H::Out: HeapSizeOf,
-          T: HeapSizeOf,
+	where H: KeyHasher,
+		  H::Out: HeapSizeOf,
+		  T: HeapSizeOf,
 {
 	/// Returns the size of allocated heap memory
 	pub fn mem_used(&self) -> usize {
@@ -218,8 +219,8 @@ impl<H, T> MemoryDB<H, T>
 }
 
 impl<H, T> HashDB<H, T> for MemoryDB<H, T>
-    where H: KeyHasher,
-          T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Send + Sync,
+	where H: KeyHasher,
+		  T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Send + Sync,
 {
 	fn keys(&self) -> HashMap<H::Out, i32> {
 		self.data.iter()
@@ -311,8 +312,8 @@ impl<H, T> HashDB<H, T> for MemoryDB<H, T>
 }
 
 impl<H, T> AsHashDB<H, T> for MemoryDB<H, T>
-    where H: KeyHasher,
-          T: Default + PartialEq<T> + for<'a> From<&'a[u8]> + Send + Sync,
+	where H: KeyHasher,
+		  T: Default + PartialEq<T> + for<'a> From<&'a[u8]> + Send + Sync,
 {
 	fn as_hashdb(&self) -> &HashDB<H, T> { self }
 	fn as_hashdb_mut(&mut self) -> &mut HashDB<H, T> { self }

--- a/memorydb/src/lib.rs
+++ b/memorydb/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Reference-counted memory-based `HashDB` implementation.
-extern crate elastic_array;
 extern crate hashdb;
 extern crate heapsize;
 extern crate rlp;
@@ -23,7 +22,7 @@ extern crate rlp;
 #[cfg(test)] extern crate tiny_keccak;
 #[cfg(test)] extern crate ethereum_types;
 
-use hashdb::{HashDB, Hasher as KeyHasher, DBValue, AsHashDB};
+use hashdb::{HashDB, Hasher as KeyHasher, AsHashDB};
 use heapsize::HeapSizeOf;
 use rlp::NULL_RLP;
 use std::collections::hash_map::Entry;
@@ -82,23 +81,64 @@ type FastMap<H, T> = HashMap<<H as KeyHasher>::Out, T, hash::BuildHasherDefault<
 /// }
 /// ```
 #[derive(Clone, PartialEq)]
-pub struct MemoryDB<H: KeyHasher> {
-	data: FastMap<H, (DBValue, i32)>,
+pub struct MemoryDB<H: KeyHasher, T> {
+	data: FastMap<H, (T, i32)>,
 	hashed_null_node: H::Out,
+    null_node_data: T,
 }
 
-impl<H> Default for MemoryDB<H>  where H: KeyHasher, H::Out: HeapSizeOf {
+impl<'a, H, T> Default for MemoryDB<H, T> where H: KeyHasher, H::Out: HeapSizeOf, T: From<&'a [u8]> {
 	fn default() -> Self { Self::new() }
 }
 
-impl<H> MemoryDB<H> where H: KeyHasher, H::Out: HeapSizeOf {
+impl<'a, H, T> MemoryDB<H, T> 
+    where H: KeyHasher,
+          H::Out: HeapSizeOf,
+          T: From<&'a [u8]>,
+{
 	/// Create a new instance of the memory DB.
-	pub fn new() -> MemoryDB<H> {
-		MemoryDB {
-			data: FastMap::<H,_>::default(),
-			hashed_null_node: H::hash(&NULL_RLP)
+	pub fn new() -> Self {
+        MemoryDB::from_null_node(&NULL_RLP, NULL_RLP.as_ref().into())
+	}
+}
+
+impl<H, T> MemoryDB<H, T> 
+    where H: KeyHasher,
+          H::Out: HeapSizeOf,
+          T: Default,
+{
+	/// Remove an element and delete it from storage if reference count reaches zero.
+	/// If the value was purged, return the old value.
+	pub fn remove_and_purge(&mut self, key: &<H as KeyHasher>::Out) -> Option<T> {
+		if key == &self.hashed_null_node {
+			return None;
+		}
+		match self.data.entry(key.clone()) {
+			Entry::Occupied(mut entry) =>
+				if entry.get().1 == 1 {
+					Some(entry.remove().0)
+				} else {
+					entry.get_mut().1 -= 1;
+					None
+				},
+			Entry::Vacant(entry) => {
+				entry.insert((T::default(), -1)); // FIXME: shouldn't it be purged?
+				None
+			}
 		}
 	}
+}
+
+impl<H: KeyHasher, T> MemoryDB<H, T> {
+
+    /// Create a new `MemoryDB` from a given null key/data
+    pub fn from_null_node(null_key: &[u8], null_node_data: T) -> Self {
+		MemoryDB {
+			data: FastMap::<H,_>::default(),
+			hashed_null_node: H::hash(null_key),
+            null_node_data,
+		}
+    }
 
 	/// Clear all data from the database.
 	///
@@ -131,7 +171,7 @@ impl<H> MemoryDB<H> where H: KeyHasher, H::Out: HeapSizeOf {
 	}
 
 	/// Return the internal map of hashes to data, clearing the current state.
-	pub fn drain(&mut self) -> FastMap<H, (DBValue, i32)> {
+	pub fn drain(&mut self) -> FastMap<H, (T, i32)> {
 		mem::replace(&mut self.data, FastMap::<H,_>::default())
 	}
 
@@ -140,37 +180,11 @@ impl<H> MemoryDB<H> where H: KeyHasher, H::Out: HeapSizeOf {
 	///
 	/// Even when Some is returned, the data is only guaranteed to be useful
 	/// when the refs > 0.
-	pub fn raw(&self, key: &<H as KeyHasher>::Out) -> Option<(DBValue, i32)> {
+	pub fn raw(&self, key: &<H as KeyHasher>::Out) -> Option<(&T, i32)> {
 		if key == &self.hashed_null_node {
-			return Some((DBValue::from_slice(&NULL_RLP), 1));
+			return Some((&self.null_node_data, 1));
 		}
-		self.data.get(key).cloned()
-	}
-
-	/// Returns the size of allocated heap memory
-	pub fn mem_used(&self) -> usize {
-		self.data.heap_size_of_children()
-	}
-
-	/// Remove an element and delete it from storage if reference count reaches zero.
-	/// If the value was purged, return the old value.
-	pub fn remove_and_purge(&mut self, key: &<H as KeyHasher>::Out) -> Option<DBValue> {
-		if key == &self.hashed_null_node {
-			return None;
-		}
-		match self.data.entry(key.clone()) {
-			Entry::Occupied(mut entry) =>
-				if entry.get().1 == 1 {
-					Some(entry.remove().0)
-				} else {
-					entry.get_mut().1 -= 1;
-					None
-				},
-			Entry::Vacant(entry) => {
-				entry.insert((DBValue::new(), -1));
-				None
-			}
-		}
+		self.data.get(key).map(|(value, count)| (value, *count))
 	}
 
 	/// Consolidate all the entries of `other` into `self`.
@@ -192,8 +206,21 @@ impl<H> MemoryDB<H> where H: KeyHasher, H::Out: HeapSizeOf {
 	}
 }
 
-impl<H: KeyHasher> HashDB<H> for MemoryDB<H> {
+impl<H, T> MemoryDB<H, T>
+    where H: KeyHasher,
+          H::Out: HeapSizeOf,
+          T: HeapSizeOf,
+{
+	/// Returns the size of allocated heap memory
+	pub fn mem_used(&self) -> usize {
+		self.data.heap_size_of_children()
+	}
+}
 
+impl<H, T> HashDB<H, T> for MemoryDB<H, T>
+    where H: KeyHasher,
+          T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Send + Sync,
+{
 	fn keys(&self) -> HashMap<H::Out, i32> {
 		self.data.iter()
 			.filter_map(|(k, v)| if v.1 != 0 {
@@ -204,13 +231,13 @@ impl<H: KeyHasher> HashDB<H> for MemoryDB<H> {
 			.collect()
 	}
 
-	fn get(&self, key: &H::Out) -> Option<DBValue> {
+	fn get(&self, key: &H::Out) -> Option<&T> {
 		if key == &self.hashed_null_node {
-			return Some(DBValue::from_slice(&NULL_RLP));
+			return Some(&self.null_node_data);
 		}
 
 		match self.data.get(key) {
-			Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
+			Some(&(ref d, rc)) if rc > 0 => Some(d),
 			_ => None
 		}
 	}
@@ -226,28 +253,8 @@ impl<H: KeyHasher> HashDB<H> for MemoryDB<H> {
 		}
 	}
 
-	fn insert(&mut self, value: &[u8]) -> H::Out {
-		if value == &NULL_RLP {
-			return self.hashed_null_node.clone();
-		}
-		let key = H::hash(value);
-		match self.data.entry(key) {
-			Entry::Occupied(mut entry) => {
-				let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
-				if *rc <= 0 {
-					*old_value = DBValue::from_slice(value);
-				}
-				*rc += 1;
-			},
-			Entry::Vacant(entry) => {
-				entry.insert((DBValue::from_slice(value), 1));
-			},
-		}
-		key
-	}
-
-	fn emplace(&mut self, key:H::Out, value: DBValue) {
-		if &*value == &NULL_RLP {
+	fn emplace(&mut self, key:H::Out, value: T) {
+		if value == self.null_node_data {
 			return;
 		}
 
@@ -265,6 +272,26 @@ impl<H: KeyHasher> HashDB<H> for MemoryDB<H> {
 		}
 	}
 
+	fn insert(&mut self, value: &[u8]) -> H::Out {
+		if value == &NULL_RLP {
+			return self.hashed_null_node.clone();
+		}
+		let key = H::hash(value);
+		match self.data.entry(key) {
+			Entry::Occupied(mut entry) => {
+				let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
+				if *rc <= 0 {
+					*old_value = value.into();
+				}
+				*rc += 1;
+			},
+			Entry::Vacant(entry) => {
+				entry.insert((value.into(), 1));
+			},
+		}
+		key
+	}
+
 	fn remove(&mut self, key: &H::Out) {
 		if key == &self.hashed_null_node {
 			return;
@@ -276,15 +303,19 @@ impl<H: KeyHasher> HashDB<H> for MemoryDB<H> {
 				*rc -= 1;
 			},
 			Entry::Vacant(entry) => {
-				entry.insert((DBValue::new(), -1));
+				entry.insert((T::default(), -1));
 			},
 		}
 	}
+
 }
 
-impl<H: KeyHasher> AsHashDB<H> for MemoryDB<H> {
-	fn as_hashdb(&self) -> &HashDB<H> { self }
-	fn as_hashdb_mut(&mut self) -> &mut HashDB<H> { self }
+impl<H, T> AsHashDB<H, T> for MemoryDB<H, T>
+    where H: KeyHasher,
+          T: Default + PartialEq<T> + for<'a> From<&'a[u8]> + Send + Sync,
+{
+	fn as_hashdb(&self) -> &HashDB<H, T> { self }
+	fn as_hashdb_mut(&mut self) -> &mut HashDB<H, T> { self }
 }
 
 #[cfg(test)]

--- a/memorydb/src/lib.rs
+++ b/memorydb/src/lib.rs
@@ -88,14 +88,20 @@ pub struct MemoryDB<H: KeyHasher, T> {
 	null_node_data: T,
 }
 
-impl<'a, H, T> Default for MemoryDB<H, T> where H: KeyHasher, H::Out: HeapSizeOf, T: From<&'a [u8]> {
+impl<'a, H, T> Default for MemoryDB<H, T>
+where
+	H: KeyHasher,
+	H::Out: HeapSizeOf,
+	T: From<&'a [u8]>
+{
 	fn default() -> Self { Self::new() }
 }
 
 impl<'a, H, T> MemoryDB<H, T>
-	where H: KeyHasher,
-		  H::Out: HeapSizeOf,
-		  T: From<&'a [u8]>,
+where
+	H: KeyHasher,
+	H::Out: HeapSizeOf,
+	T: From<&'a [u8]>,
 {
 	/// Create a new instance of the memory DB.
 	pub fn new() -> Self {
@@ -104,9 +110,10 @@ impl<'a, H, T> MemoryDB<H, T>
 }
 
 impl<H, T> MemoryDB<H, T>
-	where H: KeyHasher,
-		  H::Out: HeapSizeOf,
-		  T: Default,
+where
+	H: KeyHasher,
+	H::Out: HeapSizeOf,
+	T: Default,
 {
 	/// Remove an element and delete it from storage if reference count reaches zero.
 	/// If the value was purged, return the old value.
@@ -208,9 +215,10 @@ impl<H: KeyHasher, T> MemoryDB<H, T> {
 }
 
 impl<H, T> MemoryDB<H, T>
-	where H: KeyHasher,
-		  H::Out: HeapSizeOf,
-		  T: HeapSizeOf,
+where
+	H: KeyHasher,
+	H::Out: HeapSizeOf,
+	T: HeapSizeOf,
 {
 	/// Returns the size of allocated heap memory
 	pub fn mem_used(&self) -> usize {
@@ -219,8 +227,9 @@ impl<H, T> MemoryDB<H, T>
 }
 
 impl<H, T> HashDB<H, T> for MemoryDB<H, T>
-	where H: KeyHasher,
-		  T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Send + Sync,
+where
+	H: KeyHasher,
+	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Send + Sync,
 {
 	fn keys(&self) -> HashMap<H::Out, i32> {
 		self.data.iter()
@@ -312,8 +321,9 @@ impl<H, T> HashDB<H, T> for MemoryDB<H, T>
 }
 
 impl<H, T> AsHashDB<H, T> for MemoryDB<H, T>
-	where H: KeyHasher,
-		  T: Default + PartialEq<T> + for<'a> From<&'a[u8]> + Send + Sync,
+where
+	H: KeyHasher,
+	T: Default + PartialEq<T> + for<'a> From<&'a[u8]> + Send + Sync,
 {
 	fn as_hashdb(&self) -> &HashDB<H, T> { self }
 	fn as_hashdb_mut(&mut self) -> &mut HashDB<H, T> { self }

--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -20,7 +20,7 @@ keccak-hash = { version = "0.1", path = "../keccak-hash" }
 memorydb = { version = "0.3", path = "../memorydb", default-features = false }
 rlp = { version = "0.3.0", path = "../rlp", default-features = false }
 trie-standardmap = { version = "0.1", path = "../trie-standardmap", default-features = false }
-triehash = { version = "0.2", path = "../triehash", default-features = false }
+triehash = { version = "0.3", path = "../triehash", default-features = false }
 parity-bytes = { version = "0.1.0", path = "../parity-bytes" }
 
 # REVIEW: what's a better way to deal with this? The tests here in

--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.5"
 ethereum-types = "0.4"
 keccak-hash = { version = "0.1", path = "../keccak-hash" }
 memorydb = { version = "0.2", path = "../memorydb", default-features = false }
-rlp = { version = "0.2", path = "../rlp", default-features = false }
+rlp = { version = "0.3.0", path = "../rlp", default-features = false }
 trie-standardmap = { version = "0.1", path = "../trie-standardmap", default-features = false }
 triehash = { version = "0.2", path = "../triehash", default-features = false }
 parity-bytes = { version = "0.1.0", path = "../parity-bytes" }

--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "patricia-trie"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/parity-common"

--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -10,14 +10,14 @@ license = "GPL-3.0"
 elastic-array = "0.10"
 log = "0.3"
 rand = "0.4"
-hashdb = { version = "0.2", path = "../hashdb" }
+hashdb = { version = "0.3", path = "../hashdb" }
 parity-bytes = { version = "0.1", path = "../parity-bytes" }
 
 [dev-dependencies]
 env_logger = "0.5"
 ethereum-types = "0.4"
 keccak-hash = { version = "0.1", path = "../keccak-hash" }
-memorydb = { version = "0.2", path = "../memorydb", default-features = false }
+memorydb = { version = "0.3", path = "../memorydb", default-features = false }
 rlp = { version = "0.3.0", path = "../rlp", default-features = false }
 trie-standardmap = { version = "0.1", path = "../trie-standardmap", default-features = false }
 triehash = { version = "0.2", path = "../triehash", default-features = false }

--- a/patricia_trie/benches/trie.rs
+++ b/patricia_trie/benches/trie.rs
@@ -32,7 +32,7 @@ use ethereum_types::H256;
 use keccak_hash::keccak;
 use memorydb::MemoryDB;
 use test::{Bencher, black_box};
-use trie::{TrieMut, Trie};
+use trie::{DBValue, TrieMut, Trie};
 use trie_standardmap::{Alphabet, ValueMode, StandardMap};
 use keccak_hasher::KeccakHasher;
 use ethtrie::{TrieDB, TrieDBMut};
@@ -74,7 +74,7 @@ fn trie_insertions_32_mir_1k(b: &mut Bencher) {
 	};
 	let d = st.make();
 	b.iter(&mut ||{
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let mut t = TrieDBMut::new(&mut memdb, &mut root);
 		for i in d.iter() {
@@ -92,7 +92,7 @@ fn trie_iter(b: &mut Bencher) {
 		count: 1000,
 	};
 	let d = st.make();
-	let mut memdb = MemoryDB::<KeccakHasher>::new();
+	let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 	let mut root = H256::new();
 	{
 		let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -121,7 +121,7 @@ fn trie_insertions_32_ran_1k(b: &mut Bencher) {
 	let d = st.make();
 	let mut r = H256::new();
 	b.iter(&mut ||{
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let mut t = TrieDBMut::new(&mut memdb, &mut root);
 		for i in d.iter() {
@@ -142,7 +142,7 @@ fn trie_insertions_six_high(b: &mut Bencher) {
 	}
 
 	b.iter(||{
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let mut t = TrieDBMut::new(&mut memdb, &mut root);
 		for i in d.iter() {
@@ -162,7 +162,7 @@ fn trie_insertions_six_mid(b: &mut Bencher) {
 		d.push((k, v))
 	}
 	b.iter(||{
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let mut t = TrieDBMut::new(&mut memdb, &mut root);
 		for i in d.iter() {
@@ -183,7 +183,7 @@ fn trie_insertions_random_mid(b: &mut Bencher) {
 	}
 
 	b.iter(||{
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let mut t = TrieDBMut::new(&mut memdb, &mut root);
 		for i in d.iter() {
@@ -204,7 +204,7 @@ fn trie_insertions_six_low(b: &mut Bencher) {
 	}
 
 	b.iter(||{
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let mut t = TrieDBMut::new(&mut memdb, &mut root);
 		for i in d.iter() {

--- a/patricia_trie/src/fatdb.rs
+++ b/patricia_trie/src/fatdb.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use hashdb::{HashDB, Hasher};
-use super::{Result, TrieDB, Trie, TrieDBIterator, TrieItem, TrieIterator, Query};
+use super::{Result, DBValue, TrieDB, Trie, TrieDBIterator, TrieItem, TrieIterator, Query};
 use node_codec::NodeCodec;
 
 /// A `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
@@ -38,12 +38,12 @@ where
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db HashDB<H>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn new(db: &'db HashDB<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
 		Ok(FatDB { raw: TrieDB::new(db, root)? })
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &HashDB<H> { self.raw.db() }
+	pub fn db(&self) -> &HashDB<H, DBValue> { self.raw.db() }
 }
 
 impl<'db, H, C> Trie<H, C> for FatDB<'db, H, C>
@@ -115,7 +115,7 @@ where
 			.map(|res| {
 				res.map(|(hash, value)| {
 					let aux_hash = H::hash(&hash);
-					(self.trie.db().get(&aux_hash).expect("Missing fatdb hash").into_vec(), value)
+					(self.trie.db().get(&aux_hash).cloned().expect("Missing fatdb hash").into_vec(), value)
 				})
 			})
 	}
@@ -124,7 +124,7 @@ where
 #[cfg(test)]
 mod test {
 	use memorydb::MemoryDB;
-	use hashdb::DBValue;
+	use DBValue;
 	use keccak_hasher::KeccakHasher;
 	use ethtrie::trie::{Trie, TrieMut};
 	use ethtrie::{FatDB, FatDBMut};
@@ -132,7 +132,7 @@ mod test {
 
 	#[test]
 	fn fatdb_to_trie() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = FatDBMut::new(&mut memdb, &mut root);

--- a/patricia_trie/src/fatdbmut.rs
+++ b/patricia_trie/src/fatdbmut.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use hashdb::{HashDB, DBValue, Hasher};
-use super::{Result, TrieDBMut, TrieMut};
+use hashdb::{HashDB, Hasher};
+use super::{Result, DBValue, TrieDBMut, TrieMut};
 use node_codec::NodeCodec;
 
 /// A mutable `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
@@ -23,46 +23,46 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` or `TrieMut` trait object.
 pub struct FatDBMut<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDBMut<'db, H, C>,
 }
 
 impl<'db, H, C> FatDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db mut HashDB<H>, root: &'db mut H::Out) -> Self {
+	pub fn new(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Self {
 		FatDBMut { raw: TrieDBMut::new(db, root) }
 	}
 
 	/// Create a new trie with the backing database `db` and `root`.
 	///
 	/// Returns an error if root does not exist.
-	pub fn from_existing(db: &'db mut HashDB<H>, root: &'db mut H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn from_existing(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Result<Self, H::Out, C::Error> {
 		Ok(FatDBMut { raw: TrieDBMut::from_existing(db, root)? })
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &HashDB<H> {
+	pub fn db(&self) -> &HashDB<H, DBValue> {
 		self.raw.db()
 	}
 
 	/// Get the backing database.
-	pub fn db_mut(&mut self) -> &mut HashDB<H> {
+	pub fn db_mut(&mut self) -> &mut HashDB<H, DBValue> {
 		self.raw.db_mut()
 	}
 }
 
 impl<'db, H, C> TrieMut<H, C> for FatDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&mut self) -> &H::Out { self.raw.root() }
@@ -108,7 +108,7 @@ where
 
 #[cfg(test)]
 mod test {
-	use hashdb::DBValue;
+	use DBValue;
 	use memorydb::MemoryDB;
 	use ethtrie::trie::{Trie, TrieMut};
 	use ethtrie::{TrieDB, FatDBMut};
@@ -118,14 +118,14 @@ mod test {
 
 	#[test]
 	fn fatdbmut_to_trie() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = FatDBMut::new(&mut memdb, &mut root);
 			t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
 		}
 		let t = TrieDB::new(&memdb, &root).unwrap();
-		assert_eq!(t.get(&keccak::keccak(&[0x01u8, 0x23])).unwrap().unwrap(), DBValue::from_slice(&[0x01u8, 0x23]));
+		assert_eq!(t.get(&keccak::keccak(&[0x01u8, 0x23])), Ok(Some(DBValue::from_slice(&[0x01u8, 0x23]))));
 	}
 
 	#[test]
@@ -143,5 +143,4 @@ mod test {
 		t.remove(&key).unwrap();
 		assert_eq!(t.db().get(&aux_hash), None);
 	}
-
 }

--- a/patricia_trie/src/fatdbmut.rs
+++ b/patricia_trie/src/fatdbmut.rs
@@ -130,7 +130,7 @@ mod test {
 
 	#[test]
 	fn fatdbmut_insert_remove_key_mapping() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let key = [0x01u8, 0x23];
 		let val = [0x01u8, 0x24];
@@ -139,7 +139,7 @@ mod test {
 		let mut t = FatDBMut::new(&mut memdb, &mut root);
 		t.insert(&key, &val).unwrap();
 		assert_eq!(t.get(&key), Ok(Some(DBValue::from_slice(&val))));
-		assert_eq!(t.db().get(&aux_hash), Some(DBValue::from_slice(&key)));
+		assert_eq!(t.db().get(&aux_hash), Some(&DBValue::from_slice(&key)));
 		t.remove(&key).unwrap();
 		assert_eq!(t.db().get(&aux_hash), None);
 	}

--- a/patricia_trie/src/lib.rs
+++ b/patricia_trie/src/lib.rs
@@ -42,7 +42,7 @@ extern crate keccak_hasher;
 extern crate triehash;
 
 use std::{fmt, error};
-use hashdb::{HashDB, DBValue, Hasher};
+use hashdb::{HashDB, Hasher};
 use std::marker::PhantomData;
 
 pub mod node;
@@ -69,6 +69,8 @@ pub use self::recorder::Recorder;
 pub use self::lookup::Lookup;
 pub use self::nibbleslice::NibbleSlice;
 pub use node_codec::NodeCodec;
+
+pub type DBValue = elastic_array::ElasticArray128<u8>;
 
 /// Trie Errors.
 ///
@@ -287,7 +289,7 @@ where
 	}
 
 	/// Create new immutable instance of Trie.
-	pub fn readonly(&self, db: &'db HashDB<H>, root: &'db H::Out) -> Result<TrieKinds<'db, H, C>, H::Out, <C as NodeCodec<H>>::Error> {
+	pub fn readonly(&self, db: &'db HashDB<H, DBValue>, root: &'db H::Out) -> Result<TrieKinds<'db, H, C>, H::Out, <C as NodeCodec<H>>::Error> {
 		match self.spec {
 			TrieSpec::Generic => Ok(TrieKinds::Generic(TrieDB::new(db, root)?)),
 			TrieSpec::Secure => Ok(TrieKinds::Secure(SecTrieDB::new(db, root)?)),
@@ -296,7 +298,7 @@ where
 	}
 
 	/// Create new mutable instance of Trie.
-	pub fn create(&self, db: &'db mut HashDB<H>, root: &'db mut H::Out) -> Box<TrieMut<H, C> + 'db> {
+	pub fn create(&self, db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Box<TrieMut<H, C> + 'db> {
 		match self.spec {
 			TrieSpec::Generic => Box::new(TrieDBMut::<_, C>::new(db, root)),
 			TrieSpec::Secure => Box::new(SecTrieDBMut::<_, C>::new(db, root)),
@@ -305,7 +307,7 @@ where
 	}
 
 	/// Create new mutable instance of trie and check for errors.
-	pub fn from_existing(&self, db: &'db mut HashDB<H>, root: &'db mut H::Out) -> Result<Box<TrieMut<H,C> + 'db>, H::Out, <C as NodeCodec<H>>::Error> {
+	pub fn from_existing(&self, db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Result<Box<TrieMut<H,C> + 'db>, H::Out, <C as NodeCodec<H>>::Error> {
 		match self.spec {
 			TrieSpec::Generic => Ok(Box::new(TrieDBMut::<_, C>::from_existing(db, root)?)),
 			TrieSpec::Secure => Ok(Box::new(SecTrieDBMut::<_, C>::from_existing(db, root)?)),

--- a/patricia_trie/src/lib.rs
+++ b/patricia_trie/src/lib.rs
@@ -91,7 +91,9 @@ impl<T, E> fmt::Display for TrieError<T, E> where T: std::fmt::Debug, E: std::fm
 		match *self {
 			TrieError::InvalidStateRoot(ref root) => write!(f, "Invalid state root: {:?}", root),
 			TrieError::IncompleteDatabase(ref missing) => write!(f, "Database missing expected key: {:?}", missing),
-			TrieError::DecoderError(ref hash, ref decoder_err) =>  write!(f, "Decoding failed for hash {:?}; err: {:?}", hash, decoder_err),
+			TrieError::DecoderError(ref hash, ref decoder_err) => {
+				write!(f, "Decoding failed for hash {:?}; err: {:?}", hash, decoder_err)
+			}
 		}
 	}
 }
@@ -170,7 +172,11 @@ pub trait Trie<H: Hasher, C: NodeCodec<H>> {
 
 	/// Search for the key with the given query parameter. See the docs of the `Query`
 	/// trait for more details.
-	fn get_with<'a, 'key, Q: Query<H>>(&'a self, key: &'key [u8], query: Q) -> Result<Option<Q::Item>, H::Out, C::Error> where 'a: 'key;
+	fn get_with<'a, 'key, Q: Query<H>>(
+		&'a self,
+		key: &'key [u8],
+		query: Q
+	) -> Result<Option<Q::Item>, H::Out, C::Error> where 'a: 'key;
 
 	/// Returns a depth-first iterator over the elements of trie.
 	fn iter<'a>(&'a self) -> Result<Box<TrieIterator<H, C, Item = TrieItem<H::Out, C::Error >> + 'a>, H::Out, C::Error>;
@@ -289,7 +295,11 @@ where
 	}
 
 	/// Create new immutable instance of Trie.
-	pub fn readonly(&self, db: &'db HashDB<H, DBValue>, root: &'db H::Out) -> Result<TrieKinds<'db, H, C>, H::Out, <C as NodeCodec<H>>::Error> {
+	pub fn readonly(
+		&self,
+		db: &'db HashDB<H, DBValue>,
+		root: &'db H::Out
+	) -> Result<TrieKinds<'db, H, C>, H::Out, <C as NodeCodec<H>>::Error> {
 		match self.spec {
 			TrieSpec::Generic => Ok(TrieKinds::Generic(TrieDB::new(db, root)?)),
 			TrieSpec::Secure => Ok(TrieKinds::Secure(SecTrieDB::new(db, root)?)),
@@ -307,7 +317,11 @@ where
 	}
 
 	/// Create new mutable instance of trie and check for errors.
-	pub fn from_existing(&self, db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Result<Box<TrieMut<H,C> + 'db>, H::Out, <C as NodeCodec<H>>::Error> {
+	pub fn from_existing(
+		&self,
+		db: &'db mut HashDB<H, DBValue>,
+		root: &'db mut H::Out
+	) -> Result<Box<TrieMut<H,C> + 'db>, H::Out, <C as NodeCodec<H>>::Error> {
 		match self.spec {
 			TrieSpec::Generic => Ok(Box::new(TrieDBMut::<_, C>::from_existing(db, root)?)),
 			TrieSpec::Secure => Ok(Box::new(SecTrieDBMut::<_, C>::from_existing(db, root)?)),

--- a/patricia_trie/src/lookup.rs
+++ b/patricia_trie/src/lookup.rs
@@ -20,13 +20,13 @@ use hashdb::{HashDB, Hasher};
 use nibbleslice::NibbleSlice;
 use node::Node;
 use node_codec::NodeCodec;
-use super::{Result, TrieError, Query};
+use super::{DBValue, Result, TrieError, Query};
 use std::marker::PhantomData;
 
 /// Trie lookup helper object.
 pub struct Lookup<'a, H: Hasher + 'a, C: NodeCodec<H>, Q: Query<H>> {
 	/// database to query from.
-	pub db: &'a HashDB<H>,
+	pub db: &'a HashDB<H, DBValue>,
 	/// Query object to record nodes and transform data.
 	pub query: Q,
 	/// Hash to start at

--- a/patricia_trie/src/node.rs
+++ b/patricia_trie/src/node.rs
@@ -17,7 +17,7 @@
 use elastic_array::ElasticArray36;
 use nibbleslice::NibbleSlice;
 use nibblevec::NibbleVec;
-use hashdb::DBValue;
+use super::DBValue;
 
 /// Partial node key type.
 pub type NodeKey = ElasticArray36<u8>;

--- a/patricia_trie/src/node_codec.rs
+++ b/patricia_trie/src/node_codec.rs
@@ -21,7 +21,7 @@ use hashdb::Hasher;
 use node::Node;
 use ChildReference;
 
-use elastic_array::{ElasticArray1024, ElasticArray128};
+use elastic_array::{ElasticArray128};
 
 /// Trait for trie node encoding/decoding
 pub trait NodeCodec<H: Hasher>: Sized {
@@ -41,15 +41,15 @@ pub trait NodeCodec<H: Hasher>: Sized {
 	fn is_empty_node(data: &[u8]) -> bool;
 
 	/// Returns an empty node
-	fn empty_node() -> ElasticArray1024<u8>;
+	fn empty_node() -> Vec<u8>;
 
 	/// Returns an encoded leaft node
-	fn leaf_node(partial: &[u8], value: &[u8]) -> ElasticArray1024<u8>;
+	fn leaf_node(partial: &[u8], value: &[u8]) -> Vec<u8>;
 
 	/// Returns an encoded extension node
-	fn ext_node(partial: &[u8], child_ref: ChildReference<H::Out>) -> ElasticArray1024<u8>;
+	fn ext_node(partial: &[u8], child_ref: ChildReference<H::Out>) -> Vec<u8>;
 
 	/// Returns an encoded branch node. Takes an iterator yielding `ChildReference<H::Out>` and an optional value
-	fn branch_node<I>(children: I, value: Option<ElasticArray128<u8>>) -> ElasticArray1024<u8>
+	fn branch_node<I>(children: I, value: Option<ElasticArray128<u8>>) -> Vec<u8>
 	where I: IntoIterator<Item=Option<ChildReference<H::Out>>>;
 }

--- a/patricia_trie/src/recorder.rs
+++ b/patricia_trie/src/recorder.rs
@@ -138,7 +138,7 @@ mod tests {
 		use ethtrie::trie::{Trie, TrieMut, Recorder};
 		use memorydb::MemoryDB;
 		use ethtrie::{TrieDB, TrieDBMut};
-        use DBValue;
+		use DBValue;
 
 		let mut db = MemoryDB::<KeccakHasher, DBValue>::new();
 

--- a/patricia_trie/src/recorder.rs
+++ b/patricia_trie/src/recorder.rs
@@ -138,8 +138,9 @@ mod tests {
 		use ethtrie::trie::{Trie, TrieMut, Recorder};
 		use memorydb::MemoryDB;
 		use ethtrie::{TrieDB, TrieDBMut};
+        use DBValue;
 
-		let mut db = MemoryDB::<KeccakHasher>::new();
+		let mut db = MemoryDB::<KeccakHasher, DBValue>::new();
 
 		let mut root = H256::default();
 

--- a/patricia_trie/src/sectriedb.rs
+++ b/patricia_trie/src/sectriedb.rs
@@ -16,7 +16,7 @@
 
 use hashdb::{HashDB, Hasher};
 use super::triedb::TrieDB;
-use super::{Result, Trie, TrieItem, TrieIterator, Query};
+use super::{Result, DBValue, Trie, TrieItem, TrieIterator, Query};
 use node_codec::NodeCodec;
 
 /// A `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
@@ -40,7 +40,7 @@ where
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
 	/// Returns an error if root does not exist.
-	pub fn new(db: &'db HashDB<H>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn new(db: &'db HashDB<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
 		Ok(SecTrieDB { raw: TrieDB::new(db, root)? })
 	}
 
@@ -80,15 +80,15 @@ where
 #[cfg(test)]
 mod test {
 	use memorydb::MemoryDB;
-	use hashdb::DBValue;
 	use keccak;
 	use keccak_hasher::KeccakHasher;
 	use ethtrie::{TrieDBMut, SecTrieDB, trie::{Trie, TrieMut}};
 	use ethereum_types::H256;
+    use DBValue;
 
 	#[test]
 	fn trie_to_sectrie() {
-		let mut db = MemoryDB::<KeccakHasher>::new();
+		let mut db = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut db, &mut root);

--- a/patricia_trie/src/sectriedb.rs
+++ b/patricia_trie/src/sectriedb.rs
@@ -23,16 +23,16 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` trait object. You can use `raw()` to get the backing `TrieDB` object.
 pub struct SecTrieDB<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDB<'db, H, C>
 }
 
 impl<'db, H, C> SecTrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
@@ -56,8 +56,8 @@ where
 }
 
 impl<'db, H, C> Trie<H, C> for SecTrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&self) -> &H::Out { self.raw.root() }
@@ -84,7 +84,7 @@ mod test {
 	use keccak_hasher::KeccakHasher;
 	use ethtrie::{TrieDBMut, SecTrieDB, trie::{Trie, TrieMut}};
 	use ethereum_types::H256;
-    use DBValue;
+	use DBValue;
 
 	#[test]
 	fn trie_to_sectrie() {

--- a/patricia_trie/src/sectriedbmut.rs
+++ b/patricia_trie/src/sectriedbmut.rs
@@ -22,16 +22,16 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` or `TrieMut` trait object. You can use `raw()` to get the backing `TrieDBMut` object.
 pub struct SecTrieDBMut<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDBMut<'db, H, C>
 }
 
 impl<'db, H, C> SecTrieDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
@@ -56,8 +56,8 @@ where
 }
 
 impl<'db, H, C> TrieMut<H, C> for SecTrieDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&mut self) -> &H::Out {
@@ -94,7 +94,7 @@ mod test {
 	use keccak_hasher::KeccakHasher;
 	use ethtrie::{TrieDB, SecTrieDBMut, trie::{Trie, TrieMut}};
 	use ethereum_types::H256;
-    use DBValue;
+	use DBValue;
 
 	#[test]
 	fn sectrie_to_trie() {

--- a/patricia_trie/src/sectriedbmut.rs
+++ b/patricia_trie/src/sectriedbmut.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use hashdb::{HashDB, DBValue, Hasher};
-use super::{Result, TrieMut, TrieDBMut};
+use hashdb::{HashDB, Hasher};
+use super::{Result, DBValue, TrieMut, TrieDBMut};
 use node_codec::NodeCodec;
 
 /// A mutable `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
@@ -37,22 +37,22 @@ where
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db mut HashDB<H>, root: &'db mut H::Out) -> Self {
+	pub fn new(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Self {
 		SecTrieDBMut { raw: TrieDBMut::new(db, root) }
 	}
 
 	/// Create a new trie with the backing database `db` and `root`.
 	///
 	/// Returns an error if root does not exist.
-	pub fn from_existing(db: &'db mut HashDB<H>, root: &'db mut H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn from_existing(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Result<Self, H::Out, C::Error> {
 		Ok(SecTrieDBMut { raw: TrieDBMut::from_existing(db, root)? })
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &HashDB<H> { self.raw.db() }
+	pub fn db(&self) -> &HashDB<H, DBValue> { self.raw.db() }
 
 	/// Get the backing database.
-	pub fn db_mut(&mut self) -> &mut HashDB<H> { self.raw.db_mut() }
+	pub fn db_mut(&mut self) -> &mut HashDB<H, DBValue> { self.raw.db_mut() }
 }
 
 impl<'db, H, C> TrieMut<H, C> for SecTrieDBMut<'db, H, C>
@@ -90,15 +90,15 @@ where
 #[cfg(test)]
 mod test {
 	use memorydb::MemoryDB;
-	use hashdb::DBValue;
 	use keccak;
 	use keccak_hasher::KeccakHasher;
 	use ethtrie::{TrieDB, SecTrieDBMut, trie::{Trie, TrieMut}};
 	use ethereum_types::H256;
+    use DBValue;
 
 	#[test]
 	fn sectrie_to_trie() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = SecTrieDBMut::new(&mut memdb, &mut root);

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -451,7 +451,7 @@ mod tests {
 	fn iterator_seek() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
 
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -102,9 +102,9 @@ where
 		match C::try_decode_hash(node) {
 			Some(key) => {
 				self.db
-                    .get(&key)
-                    .map(|v| Cow::Borrowed(v))
-                    .ok_or_else(|| Box::new(TrieError::IncompleteDatabase(key)))
+					.get(&key)
+					.map(|v| Cow::Borrowed(v))
+					.ok_or_else(|| Box::new(TrieError::IncompleteDatabase(key)))
 			}
 			None => Ok(Cow::Owned(DBValue::from_slice(node)))
 		}
@@ -243,7 +243,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> TrieDBIterator<'a, H, C> {
 	}
 
 	fn seek<'key>(&mut self, node_data: &DBValue, mut key: NibbleSlice<'key>) -> Result<(), H::Out, C::Error> {
-        let mut node_data = Cow::Borrowed(node_data);
+		let mut node_data = Cow::Borrowed(node_data);
 		loop {
 			let (data, mid) = {
 				let node = C::decode(&node_data).expect("encoded data read from db; qed");
@@ -301,7 +301,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> TrieDBIterator<'a, H, C> {
 				}
 			};
 
-            node_data = data;
+			node_data = data;
 			key = key.mid(mid);
 		}
 	}
@@ -423,7 +423,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 
 #[cfg(test)]
 mod tests {
-    use DBValue;
+	use DBValue;
 	use keccak_hasher::KeccakHasher;
 	use memorydb::MemoryDB;
 	use ethtrie::{TrieDB, TrieDBMut, RlpCodec, trie::{Trie, TrieMut, Lookup}};
@@ -522,92 +522,92 @@ mod tests {
 		assert_eq!(format!("{:?}", t), "TrieDB { hash_count: 0, root: Node::Extension { slice: 4, item: Node::Branch { nodes: [Node::Empty, Node::Branch { nodes: [Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Branch { nodes: [Node::Empty, Node::Leaf { slice: , value: [65, 65] }, Node::Leaf { slice: , value: [65, 66] }, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty], value: None }, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty], value: Some([65]) }, Node::Leaf { slice: , value: [66] }, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty], value: None } } }");
 		assert_eq!(format!("{:#?}", t),
 "TrieDB {
-    hash_count: 0,
-    root: Node::Extension {
-        slice: 4,
-        item: Node::Branch {
-            nodes: [
-                Node::Empty,
-                Node::Branch {
-                    nodes: [
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Branch {
-                            nodes: [
-                                Node::Empty,
-                                Node::Leaf {
-                                    slice: ,
-                                    value: [
-                                        65,
-                                        65
-                                    ]
-                                },
-                                Node::Leaf {
-                                    slice: ,
-                                    value: [
-                                        65,
-                                        66
-                                    ]
-                                },
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty,
-                                Node::Empty
-                            ],
-                            value: None
-                        },
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty,
-                        Node::Empty
-                    ],
-                    value: Some(
-                        [
-                            65
-                        ]
-                    )
-                },
-                Node::Leaf {
-                    slice: ,
-                    value: [
-                        66
-                    ]
-                },
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty,
-                Node::Empty
-            ],
-            value: None
-        }
-    }
+	hash_count: 0,
+	root: Node::Extension {
+		slice: 4,
+		item: Node::Branch {
+			nodes: [
+				Node::Empty,
+				Node::Branch {
+					nodes: [
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Branch {
+							nodes: [
+								Node::Empty,
+								Node::Leaf {
+									slice: ,
+									value: [
+										65,
+										65
+									]
+								},
+								Node::Leaf {
+									slice: ,
+									value: [
+										65,
+										66
+									]
+								},
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty,
+								Node::Empty
+							],
+							value: None
+						},
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty,
+						Node::Empty
+					],
+					value: Some(
+						[
+							65
+						]
+					)
+				},
+				Node::Leaf {
+					slice: ,
+					value: [
+						66
+					]
+				},
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty,
+				Node::Empty
+			],
+			value: None
+		}
+	}
 }");
 	}
 

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -522,92 +522,92 @@ mod tests {
 		assert_eq!(format!("{:?}", t), "TrieDB { hash_count: 0, root: Node::Extension { slice: 4, item: Node::Branch { nodes: [Node::Empty, Node::Branch { nodes: [Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Branch { nodes: [Node::Empty, Node::Leaf { slice: , value: [65, 65] }, Node::Leaf { slice: , value: [65, 66] }, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty], value: None }, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty], value: Some([65]) }, Node::Leaf { slice: , value: [66] }, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty, Node::Empty], value: None } } }");
 		assert_eq!(format!("{:#?}", t),
 "TrieDB {
-	hash_count: 0,
-	root: Node::Extension {
-		slice: 4,
-		item: Node::Branch {
-			nodes: [
-				Node::Empty,
-				Node::Branch {
-					nodes: [
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Branch {
-							nodes: [
-								Node::Empty,
-								Node::Leaf {
-									slice: ,
-									value: [
-										65,
-										65
-									]
-								},
-								Node::Leaf {
-									slice: ,
-									value: [
-										65,
-										66
-									]
-								},
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty,
-								Node::Empty
-							],
-							value: None
-						},
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty,
-						Node::Empty
-					],
-					value: Some(
-						[
-							65
-						]
-					)
-				},
-				Node::Leaf {
-					slice: ,
-					value: [
-						66
-					]
-				},
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty,
-				Node::Empty
-			],
-			value: None
-		}
-	}
+    hash_count: 0,
+    root: Node::Extension {
+        slice: 4,
+        item: Node::Branch {
+            nodes: [
+                Node::Empty,
+                Node::Branch {
+                    nodes: [
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Branch {
+                            nodes: [
+                                Node::Empty,
+                                Node::Leaf {
+                                    slice: ,
+                                    value: [
+                                        65,
+                                        65
+                                    ]
+                                },
+                                Node::Leaf {
+                                    slice: ,
+                                    value: [
+                                        65,
+                                        66
+                                    ]
+                                },
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty,
+                                Node::Empty
+                            ],
+                            value: None
+                        },
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty,
+                        Node::Empty
+                    ],
+                    value: Some(
+                        [
+                            65
+                        ]
+                    )
+                },
+                Node::Leaf {
+                    slice: ,
+                    value: [
+                        66
+                    ]
+                },
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty,
+                Node::Empty
+            ],
+            value: None
+        }
+    }
 }");
 	}
 

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -20,9 +20,10 @@ use nibbleslice::NibbleSlice;
 use super::node::{Node, OwnedNode};
 use node_codec::NodeCodec;
 use super::lookup::Lookup;
-use super::{Result, Trie, TrieItem, TrieError, TrieIterator, Query};
+use super::{Result, DBValue, Trie, TrieItem, TrieError, TrieIterator, Query};
 use bytes::Bytes;
 use std::marker::PhantomData;
+use std::borrow::Cow;
 
 /// A `Trie` implementation using a generic `HashDB` backing database, a `Hasher`
 /// implementation to generate keys and a `NodeCodec` implementation to encode/decode
@@ -49,7 +50,7 @@ use std::marker::PhantomData;
 ///
 ///
 /// fn main() {
-///   let mut memdb = MemoryDB::<KeccakHasher>::new();
+///   let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 ///   let mut root = H256::new();
 ///   TrieDBMut::new(&mut memdb, &mut root).insert(b"foo", b"bar").unwrap();
 ///   let t = TrieDB::new(&memdb, &root).unwrap();
@@ -62,7 +63,7 @@ where
 	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
-	db: &'db HashDB<H>,
+	db: &'db HashDB<H, DBValue>,
 	root: &'db H::Out,
 	/// The number of hashes performed so far in operations on this trie.
 	hash_count: usize,
@@ -76,7 +77,7 @@ where
 {
 	/// Create a new trie with the backing database `db` and `root`
 	/// Returns an error if `root` does not exist
-	pub fn new(db: &'db HashDB<H>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn new(db: &'db HashDB<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
 		if !db.contains(root) {
 			Err(Box::new(TrieError::InvalidStateRoot(*root)))
 		} else {
@@ -85,10 +86,10 @@ where
 	}
 
 	/// Get the backing database.
-	pub fn db(&'db self) -> &'db HashDB<H> { self.db }
+	pub fn db(&'db self) -> &'db HashDB<H, DBValue> { self.db }
 
 	/// Get the data of the root node.
-	fn root_data(&self) -> Result<DBValue, H::Out, C::Error> {
+	fn root_data(&self) -> Result<&DBValue, H::Out, C::Error> {
 		self.db
 			.get(self.root)
 			.ok_or_else(|| Box::new(TrieError::InvalidStateRoot(*self.root)))
@@ -97,12 +98,15 @@ where
 	/// Given some node-describing data `node`, return the actual node RLP.
 	/// This could be a simple identity operation in the case that the node is sufficiently small, but
 	/// may require a database lookup.
-	fn get_raw_or_lookup(&'db self, node: &'db [u8]) -> Result<DBValue, H::Out, C::Error> {
+	fn get_raw_or_lookup(&'db self, node: &[u8]) -> Result<Cow<'db, DBValue>, H::Out, C::Error> {
 		match C::try_decode_hash(node) {
 			Some(key) => {
-				self.db.get(&key).ok_or_else(|| Box::new(TrieError::IncompleteDatabase(key)))
+				self.db
+                    .get(&key)
+                    .map(|v| Cow::Borrowed(v))
+                    .ok_or_else(|| Box::new(TrieError::IncompleteDatabase(key)))
 			}
-			None => Ok(DBValue::from_slice(node))
+			None => Ok(Cow::Owned(DBValue::from_slice(node)))
 		}
 	}
 }
@@ -238,7 +242,8 @@ impl<'a, H: Hasher, C: NodeCodec<H>> TrieDBIterator<'a, H, C> {
 		Ok(r)
 	}
 
-	fn seek<'key>(&mut self, mut node_data: DBValue, mut key: NibbleSlice<'key>) -> Result<(), H::Out, C::Error> {
+	fn seek<'key>(&mut self, node_data: &DBValue, mut key: NibbleSlice<'key>) -> Result<(), H::Out, C::Error> {
+        let mut node_data = Cow::Borrowed(node_data);
 		loop {
 			let (data, mid) = {
 				let node = C::decode(&node_data).expect("encoded data read from db; qed");
@@ -296,7 +301,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> TrieDBIterator<'a, H, C> {
 				}
 			};
 
-			node_data = data;
+            node_data = data;
 			key = key.mid(mid);
 		}
 	}
@@ -348,10 +353,10 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 	type Item = TrieItem<'a, H::Out, C::Error>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		enum IterStep<O, E> {
+		enum IterStep<'b, O, E> {
 			Continue,
 			PopTrail,
-			Descend(Result<DBValue, O, E>),
+			Descend(Result<Cow<'b, DBValue>, O, E>),
 		}
 		loop {
 			let iter_step = {
@@ -418,7 +423,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 
 #[cfg(test)]
 mod tests {
-	use hashdb::DBValue;
+    use DBValue;
 	use keccak_hasher::KeccakHasher;
 	use memorydb::MemoryDB;
 	use ethtrie::{TrieDB, TrieDBMut, RlpCodec, trie::{Trie, TrieMut, Lookup}};
@@ -428,7 +433,7 @@ mod tests {
 	fn iterator() {
 		let d = vec![DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B")];
 
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -485,7 +490,7 @@ mod tests {
 
 	#[test]
 	fn get_len() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -503,7 +508,7 @@ mod tests {
 	fn debug_output_supports_pretty_print() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
 
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		let root = {
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -613,7 +618,7 @@ mod tests {
 		use std::marker::PhantomData;
 		use ethtrie::trie::NibbleSlice;
 
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);

--- a/patricia_trie/src/triedbmut.rs
+++ b/patricia_trie/src/triedbmut.rs
@@ -26,7 +26,6 @@ use bytes::ToPretty;
 use hashdb::{HashDB, Hasher, DBValue};
 use nibbleslice::NibbleSlice;
 
-use elastic_array::ElasticArray1024;
 use std::collections::{HashSet, VecDeque};
 use std::marker::PhantomData;
 use std::mem;
@@ -128,7 +127,7 @@ impl<O> Node<O> where O: AsRef<[u8]> + AsMut<[u8]> + Default + Debug + PartialEq
 	}
 
 	// TODO: parallelize
-	fn into_encoded<F, C, H>(self, mut child_cb: F) -> ElasticArray1024<u8>
+	fn into_encoded<F, C, H>(self, mut child_cb: F) -> Vec<u8>
 	where
 		C: NodeCodec<H>,
 		F: FnMut(NodeHandle<H::Out>) -> ChildReference<H::Out>,

--- a/patricia_trie/src/triedbmut.rs
+++ b/patricia_trie/src/triedbmut.rs
@@ -77,11 +77,19 @@ enum Node<H> {
 	Branch(Box<[Option<NodeHandle<H>>; 16]>, Option<DBValue>)
 }
 
-impl<O> Node<O> where O: AsRef<[u8]> + AsMut<[u8]> + Default + Debug + PartialEq + Eq + Hash + Send + Sync + Clone + Copy {
+impl<O> Node<O>
+where
+	O: AsRef<[u8]> + AsMut<[u8]> + Default + Debug + PartialEq + Eq + Hash + Send + Sync + Clone + Copy
+{
 	// load an inline node into memory or get the hash to do the lookup later.
-	fn inline_or_hash<C, H>(node: &[u8], db: &HashDB<H, DBValue>, storage: &mut NodeStorage<H::Out>) -> NodeHandle<H::Out>
-	where C: NodeCodec<H>,
-		  H: Hasher<Out = O>,
+	fn inline_or_hash<C, H>(
+		node: &[u8],
+		db: &HashDB<H, DBValue>,
+		storage: &mut NodeStorage<H::Out>
+	) -> NodeHandle<H::Out>
+	where
+		C: NodeCodec<H>,
+		H: Hasher<Out = O>,
 	{
 		C::try_decode_hash(&node)
 			.map(NodeHandle::Hash)
@@ -976,8 +984,15 @@ mod tests {
 	use ethereum_types::H256;
 	use DBValue;
 
-	fn populate_trie<'db, H, C>(db: &'db mut HashDB<KeccakHasher, DBValue>, root: &'db mut H256, v: &[(Vec<u8>, Vec<u8>)]) -> TrieDBMut<'db>
-		where H: Hasher, H::Out: Decodable + Encodable, C: NodeCodec<H>
+	fn populate_trie<'db, H, C>(
+		db: &'db mut HashDB<KeccakHasher, DBValue>,
+		root: &'db mut H256,
+		v: &[(Vec<u8>, Vec<u8>)]
+	) -> TrieDBMut<'db>
+	where
+		H: Hasher,
+		H::Out: Decodable + Encodable,
+		C: NodeCodec<H>,
 	{
 		let mut t = TrieDBMut::new(db, root);
 		for i in 0..v.len() {

--- a/patricia_trie/src/triedbmut.rs
+++ b/patricia_trie/src/triedbmut.rs
@@ -520,7 +520,7 @@ where
 					let branch_action = self.insert_inspector(branch, partial, value, old_val)?.unwrap_node();
 					InsertAction::Replace(branch_action)
 				} else if cp == existing_key.len() {
-				    trace!(target: "trie", "complete-prefix (cp={:?}): AUGMENT-AT-END", cp);
+					trace!(target: "trie", "complete-prefix (cp={:?}): AUGMENT-AT-END", cp);
 
 					// fully-shared prefix for an extension.
 					// make a stub branch and an extension.
@@ -974,7 +974,7 @@ mod tests {
 	use ethtrie::{TrieDBMut, RlpCodec, trie::{TrieMut, NodeCodec}};
 	use env_logger;
 	use ethereum_types::H256;
-    use DBValue;
+	use DBValue;
 
 	fn populate_trie<'db, H, C>(db: &'db mut HashDB<KeccakHasher, DBValue>, root: &'db mut H256, v: &[(Vec<u8>, Vec<u8>)]) -> TrieDBMut<'db>
 		where H: Hasher, H::Out: Decodable + Encodable, C: NodeCodec<H>

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -3,7 +3,7 @@ name = "rlp"
 description = "Recursive-length prefix encoding, decoding, and compression"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 byteorder = "1.0"
-elastic-array = "0.10"
 ethereum-types = { version = "0.4", optional = true }
 rustc-hex = {version = "2.0", default-features = false }
 

--- a/rlp/src/impls.rs
+++ b/rlp/src/impls.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use std::{mem, str};
+use std::iter::{once, empty};
 use byteorder::{ByteOrder, BigEndian};
 use traits::{Encodable, Decodable};
 use stream::RlpStream;
@@ -31,11 +32,7 @@ pub fn decode_usize(bytes: &[u8]) -> Result<usize, DecoderError> {
 
 impl Encodable for bool {
 	fn rlp_append(&self, s: &mut RlpStream) {
-		if *self {
-			s.encoder().encode_value(&[1]);
-		} else {
-			s.encoder().encode_value(&[0]);
-		}
+		s.encoder().encode_iter(once(if *self { 1u8 } else { 0 }));
 	}
 }
 
@@ -99,9 +96,9 @@ impl<T> Decodable for Option<T> where T: Decodable {
 impl Encodable for u8 {
 	fn rlp_append(&self, s: &mut RlpStream) {
 		if *self != 0 {
-			s.encoder().encode_value(&[*self]);
+			s.encoder().encode_iter(once(*self));
 		} else {
-			s.encoder().encode_value(&[]);
+			s.encoder().encode_iter(empty());
 		}
 	}
 }

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -35,7 +35,6 @@
 extern crate byteorder;
 #[cfg(feature = "ethereum")]
 extern crate ethereum_types;
-extern crate elastic_array;
 extern crate rustc_hex;
 #[cfg(test)]
 #[macro_use]
@@ -47,7 +46,6 @@ mod rlpin;
 mod stream;
 mod impls;
 
-use elastic_array::ElasticArray1024;
 use std::borrow::Borrow;
 
 pub use error::DecoderError;
@@ -92,13 +90,13 @@ pub fn decode_list<T>(bytes: &[u8]) -> Vec<T> where T: Decodable {
 /// 	assert_eq!(out, vec![0x83, b'c', b'a', b't']);
 /// }
 /// ```
-pub fn encode<E>(object: &E) -> ElasticArray1024<u8> where E: Encodable {
+pub fn encode<E>(object: &E) -> Vec<u8> where E: Encodable {
 	let mut stream = RlpStream::new();
 	stream.append(object);
 	stream.drain()
 }
 
-pub fn encode_list<E, K>(object: &[K]) -> ElasticArray1024<u8> where E: Encodable, K: Borrow<E> {
+pub fn encode_list<E, K>(object: &[K]) -> Vec<u8> where E: Encodable, K: Borrow<E> {
 	let mut stream = RlpStream::new();
 	stream.append_list(object);
 	stream.drain()

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -86,7 +86,7 @@ pub fn decode_list<T>(bytes: &[u8]) -> Vec<T> where T: Decodable {
 ///
 /// fn main () {
 /// 	let animal = "cat";
-/// 	let out = rlp::encode(&animal).into_vec();
+/// 	let out = rlp::encode(&animal);
 /// 	assert_eq!(out, vec![0x83, b'c', b'a', b't']);
 /// }
 /// ```

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -64,10 +64,10 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	/// 	let mut stream = RlpStream::new_list(2);
-	/// 	stream.append_empty_data().append_empty_data();
-	/// 	let out = stream.out();
-	/// 	assert_eq!(out, vec![0xc2, 0x80, 0x80]);
+	///		let mut stream = RlpStream::new_list(2);
+	///		stream.append_empty_data().append_empty_data();
+	///		let out = stream.out();
+	///		assert_eq!(out, vec![0xc2, 0x80, 0x80]);
 	/// }
 	/// ```
 	pub fn append_empty_data(&mut self) -> &mut Self {
@@ -83,7 +83,7 @@ impl RlpStream {
 
 	/// Drain the object and return the underlying ElasticArray. Panics if it is not finished.
 	pub fn drain(self) -> Vec<u8> {
-        self.out()
+		self.out()
 	}
 
 	/// Appends raw (pre-serialised) RLP data. Use with caution. Chainable.
@@ -105,10 +105,10 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	/// 	let mut stream = RlpStream::new_list(2);
-	/// 	stream.append(&"cat").append(&"dog");
-	/// 	let out = stream.out();
-	/// 	assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
+	///		let mut stream = RlpStream::new_list(2);
+	///		stream.append(&"cat").append(&"dog");
+	///		let out = stream.out();
+	///		assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
 	/// }
 	/// ```
 	pub fn append<'a, E>(&'a mut self, value: &E) -> &'a mut Self where E: Encodable {
@@ -143,11 +143,11 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	/// 	let mut stream = RlpStream::new_list(2);
-	/// 	stream.begin_list(2).append(&"cat").append(&"dog");
-	/// 	stream.append(&"");
-	/// 	let out = stream.out();
-	/// 	assert_eq!(out, vec![0xca, 0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g', 0x80]);
+	///		let mut stream = RlpStream::new_list(2);
+	///		stream.begin_list(2).append(&"cat").append(&"dog");
+	///		stream.append(&"");
+	///		let out = stream.out();
+	///		assert_eq!(out, vec![0xca, 0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g', 0x80]);
 	/// }
 	/// ```
 	pub fn begin_list(&mut self, len: usize) -> &mut RlpStream {
@@ -219,14 +219,14 @@ impl RlpStream {
 	/// ```rust
 	/// extern crate rlp;
 	/// use rlp::*;
-	/// 
+	///
 	/// fn main () {
-	/// 	let mut stream = RlpStream::new_list(3);
-	/// 	stream.append(&"cat");
-	/// 	stream.clear();
-	/// 	stream.append(&"dog");
-	/// 	let out = stream.out();
-	/// 	assert_eq!(out, vec![0x83, b'd', b'o', b'g']);
+	///		let mut stream = RlpStream::new_list(3);
+	///		stream.append(&"cat");
+	///		stream.clear();
+	///		stream.append(&"dog");
+	///		let out = stream.out();
+	///		assert_eq!(out, vec![0x83, b'd', b'o', b'g']);
 	/// }
 	pub fn clear(&mut self) {
 		// clear bytes
@@ -243,13 +243,13 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	/// 	let mut stream = RlpStream::new_list(2);
-	/// 	stream.append(&"cat");
-	/// 	assert_eq!(stream.is_finished(), false);
-	/// 	stream.append(&"dog");
-	/// 	assert_eq!(stream.is_finished(), true);
-	/// 	let out = stream.out();
-	/// 	assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
+	///		let mut stream = RlpStream::new_list(2);
+	///		stream.append(&"cat");
+	///		assert_eq!(stream.is_finished(), false);
+	///		stream.append(&"dog");
+	///		assert_eq!(stream.is_finished(), true);
+	///		let out = stream.out();
+	///		assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
 	/// }
 	pub fn is_finished(&self) -> bool {
 		self.unfinished_lists.len() == 0
@@ -333,10 +333,10 @@ impl<'a> BasicEncoder<'a> {
 		let size_bytes = 4 - leading_empty_bytes as u8;
 		let mut buffer = [0u8; 4];
 		BigEndian::write_u32(&mut buffer, size);
-        assert!(position <= self.buffer.len());
+		assert!(position <= self.buffer.len());
 
 		self.buffer.extend_from_slice(&buffer[leading_empty_bytes..]);
-        self.buffer[position..].rotate_right(size_bytes as usize);
+		self.buffer[position..].rotate_right(size_bytes as usize);
 		size_bytes as u8
 	}
 

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -64,10 +64,10 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	///		let mut stream = RlpStream::new_list(2);
-	///		stream.append_empty_data().append_empty_data();
-	///		let out = stream.out();
-	///		assert_eq!(out, vec![0xc2, 0x80, 0x80]);
+	/// 	let mut stream = RlpStream::new_list(2);
+	/// 	stream.append_empty_data().append_empty_data();
+	/// 	let out = stream.out();
+	/// 	assert_eq!(out, vec![0xc2, 0x80, 0x80]);
 	/// }
 	/// ```
 	pub fn append_empty_data(&mut self) -> &mut Self {
@@ -105,10 +105,10 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	///		let mut stream = RlpStream::new_list(2);
-	///		stream.append(&"cat").append(&"dog");
-	///		let out = stream.out();
-	///		assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
+	/// 	let mut stream = RlpStream::new_list(2);
+	/// 	stream.append(&"cat").append(&"dog");
+	/// 	let out = stream.out();
+	/// 	assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
 	/// }
 	/// ```
 	pub fn append<'a, E>(&'a mut self, value: &E) -> &'a mut Self where E: Encodable {
@@ -143,11 +143,11 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	///		let mut stream = RlpStream::new_list(2);
-	///		stream.begin_list(2).append(&"cat").append(&"dog");
-	///		stream.append(&"");
-	///		let out = stream.out();
-	///		assert_eq!(out, vec![0xca, 0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g', 0x80]);
+	/// 	let mut stream = RlpStream::new_list(2);
+	/// 	stream.begin_list(2).append(&"cat").append(&"dog");
+	/// 	stream.append(&"");
+	/// 	let out = stream.out();
+	/// 	assert_eq!(out, vec![0xca, 0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g', 0x80]);
 	/// }
 	/// ```
 	pub fn begin_list(&mut self, len: usize) -> &mut RlpStream {
@@ -221,12 +221,12 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	///		let mut stream = RlpStream::new_list(3);
-	///		stream.append(&"cat");
-	///		stream.clear();
-	///		stream.append(&"dog");
-	///		let out = stream.out();
-	///		assert_eq!(out, vec![0x83, b'd', b'o', b'g']);
+	/// 	let mut stream = RlpStream::new_list(3);
+	/// 	stream.append(&"cat");
+	/// 	stream.clear();
+	/// 	stream.append(&"dog");
+	/// 	let out = stream.out();
+	/// 	assert_eq!(out, vec![0x83, b'd', b'o', b'g']);
 	/// }
 	pub fn clear(&mut self) {
 		// clear bytes
@@ -243,13 +243,13 @@ impl RlpStream {
 	/// use rlp::*;
 	///
 	/// fn main () {
-	///		let mut stream = RlpStream::new_list(2);
-	///		stream.append(&"cat");
-	///		assert_eq!(stream.is_finished(), false);
-	///		stream.append(&"dog");
-	///		assert_eq!(stream.is_finished(), true);
-	///		let out = stream.out();
-	///		assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
+	/// 	let mut stream = RlpStream::new_list(2);
+	/// 	stream.append(&"cat");
+	/// 	assert_eq!(stream.is_finished(), false);
+	/// 	stream.append(&"dog");
+	/// 	assert_eq!(stream.is_finished(), true);
+	/// 	let out = stream.out();
+	/// 	assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
 	/// }
 	pub fn is_finished(&self) -> bool {
 		self.unfinished_lists.len() == 0
@@ -266,7 +266,6 @@ impl RlpStream {
 	/// panic! if stream is not finished.
 	pub fn out(self) -> Vec<u8> {
 		match self.is_finished() {
-			//true => self.encoder.out().into_vec(),
 			true => self.buffer,
 			false => panic!()
 		}

--- a/rlp/src/traits.rs
+++ b/rlp/src/traits.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 //! Common RLP traits
-use elastic_array::ElasticArray1024;
 use {DecoderError, Rlp, RlpStream};
 
 /// RLP decodable trait
@@ -22,7 +21,7 @@ pub trait Encodable {
 	fn rlp_append(&self, s: &mut RlpStream);
 
 	/// Get rlp-encoded bytes for this instance
-	fn rlp_bytes(&self) -> ElasticArray1024<u8> {
+	fn rlp_bytes(&self) -> Vec<u8> {
 		let mut s = RlpStream::new();
 		self.rlp_append(&mut s);
 		s.drain()

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -9,5 +9,5 @@ license = "GPL-3.0"
 [dependencies]
 ethereum-types = "0.4"
 tiny-keccak = "1.4.2"
-hashdb = { version = "0.2.0", path = "../../hashdb" }
+hashdb = { version = "0.3.0", path = "../../hashdb" }
 plain_hasher = {  path = "../../plain_hasher" }

--- a/test-support/patricia-trie-ethereum/Cargo.toml
+++ b/test-support/patricia-trie-ethereum/Cargo.toml
@@ -6,7 +6,7 @@ description = "Merkle-Patricia Trie (Ethereum Style)"
 license = "GPL-3.0"
 
 [dependencies]
-patricia-trie = { version = "0.2", path = "../../patricia_trie" }
+patricia-trie = { version = "0.3", path = "../../patricia_trie" }
 keccak-hasher = { version = "0.1", path = "../keccak-hasher" }
 hashdb = { version = "0.2", path = "../../hashdb" }
 rlp = { version = "0.3.0", path = "../../rlp" }

--- a/test-support/patricia-trie-ethereum/Cargo.toml
+++ b/test-support/patricia-trie-ethereum/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 [dependencies]
 patricia-trie = { version = "0.3", path = "../../patricia_trie" }
 keccak-hasher = { version = "0.1", path = "../keccak-hasher" }
-hashdb = { version = "0.2", path = "../../hashdb" }
+hashdb = { version = "0.3", path = "../../hashdb" }
 rlp = { version = "0.3.0", path = "../../rlp" }
 parity-bytes = { version = "0.1", path = "../../parity-bytes" }
 

--- a/test-support/patricia-trie-ethereum/Cargo.toml
+++ b/test-support/patricia-trie-ethereum/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 patricia-trie = { version = "0.2", path = "../../patricia_trie" }
 keccak-hasher = { version = "0.1", path = "../keccak-hasher" }
 hashdb = { version = "0.2", path = "../../hashdb" }
-rlp = { version = "0.2.3", path = "../../rlp" }
+rlp = { version = "0.3.0", path = "../../rlp" }
 parity-bytes = { version = "0.1", path = "../../parity-bytes" }
 
 ethereum-types = "0.4"

--- a/test-support/patricia-trie-ethereum/src/rlp_node_codec.rs
+++ b/test-support/patricia-trie-ethereum/src/rlp_node_codec.rs
@@ -75,14 +75,14 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
     fn empty_node() -> ElasticArray1024<u8> {
         let mut stream = RlpStream::new();
         stream.append_empty_data();
-        stream.drain()
+        ElasticArray1024::from_vec(stream.drain())
     }
 
     fn leaf_node(partial: &[u8], value: &[u8]) -> ElasticArray1024<u8> {
         let mut stream = RlpStream::new_list(2);
         stream.append(&partial);
         stream.append(&value);
-		stream.drain()
+        ElasticArray1024::from_vec(stream.drain())
     }
 
 	fn ext_node(partial: &[u8], child_ref: ChildReference<<KeccakHasher as Hasher>::Out>) -> ElasticArray1024<u8> {
@@ -95,7 +95,7 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
                 stream.append_raw(bytes, 1)
             },
         };
-        stream.drain()
+        ElasticArray1024::from_vec(stream.drain())
 	}
 
 	fn branch_node<I>(children: I, value: Option<ElasticArray128<u8>>) -> ElasticArray1024<u8>
@@ -119,6 +119,6 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
         } else {
             stream.append_empty_data();
         }
-        stream.drain()
+        ElasticArray1024::from_vec(stream.drain())
     }
 }

--- a/test-support/patricia-trie-ethereum/src/rlp_node_codec.rs
+++ b/test-support/patricia-trie-ethereum/src/rlp_node_codec.rs
@@ -16,7 +16,7 @@
 
 //! `NodeCodec` implementation for Rlp
 
-use elastic_array::{ElasticArray1024, ElasticArray128};
+use elastic_array::ElasticArray128;
 use ethereum_types::H256;
 use hashdb::Hasher;
 use keccak_hasher::KeccakHasher;
@@ -72,20 +72,20 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
 	fn is_empty_node(data: &[u8]) -> bool {
 		Rlp::new(data).is_empty()
 	}
-    fn empty_node() -> ElasticArray1024<u8> {
+    fn empty_node() -> Vec<u8> {
         let mut stream = RlpStream::new();
         stream.append_empty_data();
-        ElasticArray1024::from_vec(stream.drain())
+        stream.drain()
     }
 
-    fn leaf_node(partial: &[u8], value: &[u8]) -> ElasticArray1024<u8> {
+    fn leaf_node(partial: &[u8], value: &[u8]) -> Vec<u8> {
         let mut stream = RlpStream::new_list(2);
         stream.append(&partial);
         stream.append(&value);
-        ElasticArray1024::from_vec(stream.drain())
+        stream.drain()
     }
 
-	fn ext_node(partial: &[u8], child_ref: ChildReference<<KeccakHasher as Hasher>::Out>) -> ElasticArray1024<u8> {
+	fn ext_node(partial: &[u8], child_ref: ChildReference<<KeccakHasher as Hasher>::Out>) -> Vec<u8> {
         let mut stream = RlpStream::new_list(2);
         stream.append(&partial);
         match child_ref {
@@ -95,10 +95,10 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
                 stream.append_raw(bytes, 1)
             },
         };
-        ElasticArray1024::from_vec(stream.drain())
+        stream.drain()
 	}
 
-	fn branch_node<I>(children: I, value: Option<ElasticArray128<u8>>) -> ElasticArray1024<u8>
+	fn branch_node<I>(children: I, value: Option<ElasticArray128<u8>>) -> Vec<u8>
 	where I: IntoIterator<Item=Option<ChildReference<<KeccakHasher as Hasher>::Out>>>
     {
         let mut stream = RlpStream::new_list(17);
@@ -119,6 +119,6 @@ impl NodeCodec<KeccakHasher> for RlpNodeCodec<KeccakHasher> {
         } else {
             stream.append_empty_data();
         }
-        ElasticArray1024::from_vec(stream.drain())
+        stream.drain()
     }
 }

--- a/trie-standardmap/Cargo.toml
+++ b/trie-standardmap/Cargo.toml
@@ -10,4 +10,4 @@ license = "GPL-3.0"
 ethereum-types = "0.4"
 keccak-hash = { version = "0.1", path = "../keccak-hash" }
 parity-bytes = { version = "0.1", path = "../parity-bytes" }
-rlp = { version = "0.2.4", path = "../rlp" }
+rlp = { version = "0.3.0", path = "../rlp" }

--- a/trie-standardmap/src/lib.rs
+++ b/trie-standardmap/src/lib.rs
@@ -115,7 +115,7 @@ impl StandardMap {
 			let v = match self.value_mode {
 				ValueMode::Mirror => k.clone(),
 				ValueMode::Random => Self::random_value(seed),
-				ValueMode::Index => encode(&index).into_vec(),
+				ValueMode::Index => encode(&index),
 			};
 			d.push((k, v))
 		}

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "triehash"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
 license = "GPL-3.0"
 
 [dependencies]
-elastic-array = "0.10"
 hashdb = { version = "0.3", path = "../hashdb", default-features = false }
 rlp = { version = "0.3", path = "../rlp", default-features = false }
 

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 [dependencies]
 elastic-array = "0.10"
 hashdb = { version = "0.2", path = "../hashdb", default-features = false }
-rlp = { version = "0.2.4", path = "../rlp", default-features = false }
+rlp = { version = "0.3", path = "../rlp", default-features = false }
 
 [dev-dependencies]
 trie-standardmap = { version = "0.1", path = "../trie-standardmap" }

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 
 [dependencies]
 elastic-array = "0.10"
-hashdb = { version = "0.2", path = "../hashdb", default-features = false }
+hashdb = { version = "0.3", path = "../hashdb", default-features = false }
 rlp = { version = "0.3", path = "../rlp", default-features = false }
 
 [dev-dependencies]

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -49,10 +49,11 @@ fn shared_prefix_len<T: Eq>(first: &[T], second: &[T]) -> usize {
 /// }
 /// ```
 pub fn ordered_trie_root<H, I, A>(input: I) -> H::Out
-	where I: IntoIterator<Item = A>,
-		  A: AsRef<[u8]>,
-		  H: Hasher,
-		  <H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
+where
+	I: IntoIterator<Item = A>,
+	A: AsRef<[u8]>,
+	H: Hasher,
+	<H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
 {
 	let gen_input: Vec<_> = input
 		// first put elements into btree to sort them by nibbles (key'd by index)
@@ -89,11 +90,12 @@ pub fn ordered_trie_root<H, I, A>(input: I) -> H::Out
 /// }
 /// ```
 pub fn trie_root<H, I, A, B>(input: I) -> H::Out
-	where I: IntoIterator<Item = (A, B)>,
-		  A: AsRef<[u8]> + Ord,
-		  B: AsRef<[u8]>,
-		  H: Hasher,
-		  <H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
+where
+	I: IntoIterator<Item = (A, B)>,
+	A: AsRef<[u8]> + Ord,
+	B: AsRef<[u8]>,
+	H: Hasher,
+	<H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
 {
 	let gen_input: Vec<_> = input
 		// first put elements into btree to sort them and to remove duplicates
@@ -127,11 +129,12 @@ pub fn trie_root<H, I, A, B>(input: I) -> H::Out
 /// }
 /// ```
 pub fn sec_trie_root<H, I, A, B>(input: I) -> H::Out
-	where I: IntoIterator<Item = (A, B)>,
-		  A: AsRef<[u8]>,
-		  B: AsRef<[u8]>,
-		  H: Hasher,
-		  <H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
+where
+	I: IntoIterator<Item = (A, B)>,
+	A: AsRef<[u8]>,
+	B: AsRef<[u8]>,
+	H: Hasher,
+	<H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
 {
 	let gen_input: Vec<_> = input
 		// first put elements into btree to sort them and to remove duplicates
@@ -147,11 +150,11 @@ pub fn sec_trie_root<H, I, A, B>(input: I) -> H::Out
 }
 
 fn gen_trie_root<H, A, B>(input: &[(A, B)]) -> H::Out
-	where
-		A: AsRef<[u8]>,
-		B: AsRef<[u8]>,
-		H: Hasher,
-	  	<H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
+where
+	A: AsRef<[u8]>,
+	B: AsRef<[u8]>,
+	H: Hasher,
+	<H as hashdb::Hasher>::Out: cmp::Ord + rlp::Encodable,
 {
 	let mut stream = RlpStream::new();
 	hash256rlp::<H, _, _>(input, 0, &mut stream);
@@ -214,11 +217,11 @@ fn as_nibbles(bytes: &[u8]) -> ElasticArray8<u8> {
 }
 
 fn hash256rlp<H, A, B>(input: &[(A, B)], pre_len: usize, stream: &mut RlpStream)
-	where
-		A: AsRef<[u8]>,
-		B: AsRef<[u8]>,
-		H: Hasher,
-		<H as hashdb::Hasher>::Out: rlp::Encodable,
+where
+	A: AsRef<[u8]>,
+	B: AsRef<[u8]>,
+	H: Hasher,
+	<H as hashdb::Hasher>::Out: rlp::Encodable,
 {
 	let inlen = input.len();
 
@@ -297,11 +300,11 @@ fn hash256rlp<H, A, B>(input: &[(A, B)], pre_len: usize, stream: &mut RlpStream)
 }
 
 fn hash256aux<H, A, B>(input: &[(A, B)], pre_len: usize, stream: &mut RlpStream)
-	where
-		A: AsRef<[u8]>,
-		B: AsRef<[u8]>,
-		H: Hasher,
-		<H as hashdb::Hasher>::Out: rlp::Encodable,
+where
+	A: AsRef<[u8]>,
+	B: AsRef<[u8]>,
+	H: Hasher,
+	<H as hashdb::Hasher>::Out: rlp::Encodable,
 {
 	let mut s = RlpStream::new();
 	hash256rlp::<H, _, _>(input, pre_len, &mut s);


### PR DESCRIPTION
The main purpose is to reduce the unsafe surface (elastic-array uses a ton of them).
The unexpected consequence is to have a nice perf boost.

On my machine:
```
$ cargo benchcmp master vec 
 name                             master ns/iter  vec ns/iter  diff ns/iter   diff %  speedup 
 bench_decode_nested_empty_lists  400             368                   -32   -8.00%   x 1.09 
 bench_decode_u256_value          73              69                     -4   -5.48%   x 1.06 
 bench_decode_u64_value           58              56                     -2   -3.45%   x 1.04 
 bench_stream_1000_empty_lists    14,671          7,921              -6,750  -46.01%   x 1.85 
 bench_stream_nested_empty_lists  303             145                  -158  -52.15%   x 2.09 
 bench_stream_u256_value          440             354                   -86  -19.55%   x 1.24 
 bench_stream_u64_value           140             70                    -70  -50.00%   x 2.00 
```

My guess is, given that elastic-array is quite an old crate, that it is a combination of
- Vec implementation being better than it used to be
- compiler being smarter and probably working very well with Vec in particular

It can also be that the bench is somehow wrong or does not represent the reality. I am not an expert enough on your use case to tell.

Regarding formating issues, I have tried to use parity-ethereum rustfmt.toml but lot of config options are not recognized anymore by rustfmt-preview (stable 1.28). Do you have a recommendation here?

Oh, and this is a breaking change. I can adapt the other repos if needed later on.