### PR TITLE
Add conversion from [u8; *]

### DIFF
--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -813,6 +813,19 @@ macro_rules! construct_uint {
 				arr
 			}
 		}
+
+		impl From<[u8; $n_words * 8]> for $name {
+			fn from(bytes: [u8; $n_words * 8]) -> Self {
+				bytes[..].as_ref().into()
+			}
+		}
+
+		impl<'a> From<&'a [u8; $n_words * 8]> for $name {
+			fn from(bytes: &[u8; $n_words * 8]) -> Self {
+				bytes[..].into()
+			}
+		}
+
 		impl Default for $name {
 			fn default() -> Self {
 				$name::zero()

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -1001,7 +1001,7 @@ fn from_big_endian() {
 }
 
 #[test]
-fn from_fixed_array() {
+fn into_fixed_array() {
 	let expected: [u8; 32] = [
 		0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0,
@@ -1010,6 +1010,41 @@ fn from_fixed_array() {
 	];
 	let ary : [u8; 32] = U256::from(1).into();
 	assert_eq!(ary, expected);
+}
+
+#[test]
+fn test_u256_from_fixed_array() {
+	let ary = [
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 123
+	];
+	let num : U256 = ary.into();
+	assert_eq!( num, U256::from(123) );
+
+	let a_ref : &U256 = &ary.into();
+	assert_eq!( a_ref, &U256::from(123) );
+}
+
+#[test]
+fn test_u512_from_fixed_array() {
+	let ary = [
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 123
+	];
+	let num : U512 = ary.into();
+	assert_eq!( num, U512::from(123) );
+
+	let a_ref : &U512 = &ary.into();
+	assert_eq!( a_ref, &U512::from(123) );
+
 }
 
 #[test]


### PR DESCRIPTION
Conversions I skipped when porting over stuff from bigint but that turned out to be useful.