### PR TITLE
fix patricia-trie bench compilation

### DIFF
--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -20,6 +20,7 @@ memorydb = { version = "0.2", path = "../memorydb" }
 rlp = { version = "0.2.1", path = "../rlp" }
 trie-standardmap = { version = "0.1", path = "../trie-standardmap" }
 triehash = { version = "0.2", path = "../triehash" }
+parity-bytes = { version = "0.1.0", path = "../parity-bytes" }
 
 # REVIEW: what's a better way to deal with this? The tests here in
 # `patricia_trie` use `keccak-hasher` and `patricia-trie-ethereum` to

--- a/patricia_trie/benches/trie.rs
+++ b/patricia_trie/benches/trie.rs
@@ -17,7 +17,7 @@
 #![feature(test)]
 
 extern crate test;
-extern crate ethcore_bytes;
+extern crate parity_bytes;
 extern crate ethereum_types;
 extern crate memorydb;
 extern crate patricia_trie as trie;
@@ -27,7 +27,7 @@ extern crate keccak_hash;
 extern crate trie_standardmap;
 extern crate hashdb;
 
-use ethcore_bytes::Bytes;
+use parity_bytes::Bytes;
 use ethereum_types::H256;
 use keccak_hash::keccak;
 use memorydb::MemoryDB;


### PR DESCRIPTION
patricia-trie benches needed the crate ethcore-bytes. I figured out that it is now parity-bytes.
Needed for #29 

Ideally this should have been caught by a test.