### PR TITLE
Refactor OwnedNode::Branch

### DIFF
--- a/patricia_trie/src/node.rs
+++ b/patricia_trie/src/node.rs
@@ -35,6 +35,33 @@ pub enum Node<'a> {
 	Branch([&'a [u8]; 16], Option<&'a [u8]>),
 }
 
+/// A Sparse (non mutable) owned vector struct to hold branch keys
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct BranchKeys {
+	data: Vec<u8>,
+	ubounds: [usize; 17],
+}
+
+impl<'a> From<[&'a [u8]; 16]> for BranchKeys {
+	fn from(a: [&'a [u8]; 16]) -> Self {
+		let mut data = Vec::with_capacity(a.iter().map(|inner| inner.len()).sum());
+		let mut ubounds = [0; 17];
+		for (inner, ub) in a.iter().zip(ubounds.iter_mut().skip(1)) {
+			data.extend_from_slice(inner);
+			*ub = data.len();
+		}
+		BranchKeys { data, ubounds }
+	}
+}
+
+impl ::std::ops::Index<usize> for BranchKeys {
+	type Output = [u8];
+	fn index(&self, index: usize) -> &[u8] {
+		assert!(index < 16);
+		&self.data[self.ubounds[index]..self.ubounds[index + 1]]
+	}
+}
+
 /// An owning node type. Useful for trie iterators.
 #[derive(Debug, PartialEq, Eq)]
 pub enum OwnedNode {
@@ -45,7 +72,7 @@ pub enum OwnedNode {
 	/// Extension node: partial key and child node.
 	Extension(NibbleVec, DBValue),
 	/// Branch node: 16 children and an optional value.
-	Branch([NodeKey; 16], Option<DBValue>),
+	Branch(BranchKeys, Option<DBValue>),
 }
 
 impl<'a> From<Node<'a>> for OwnedNode {
@@ -54,16 +81,7 @@ impl<'a> From<Node<'a>> for OwnedNode {
 			Node::Empty => OwnedNode::Empty,
 			Node::Leaf(k, v) => OwnedNode::Leaf(k.into(), DBValue::from_slice(v)),
 			Node::Extension(k, child) => OwnedNode::Extension(k.into(), DBValue::from_slice(child)),
-			Node::Branch(c, val) => {
-				let children = [
-					NodeKey::from_slice(c[0]), NodeKey::from_slice(c[1]), NodeKey::from_slice(c[2]), NodeKey::from_slice(c[3]),
-					NodeKey::from_slice(c[4]), NodeKey::from_slice(c[5]), NodeKey::from_slice(c[6]), NodeKey::from_slice(c[7]),
-					NodeKey::from_slice(c[8]), NodeKey::from_slice(c[9]), NodeKey::from_slice(c[10]), NodeKey::from_slice(c[11]),
-					NodeKey::from_slice(c[12]), NodeKey::from_slice(c[13]), NodeKey::from_slice(c[14]), NodeKey::from_slice(c[15]),
-				];
-
-				OwnedNode::Branch(children, val.map(DBValue::from_slice))
-			}
+			Node::Branch(c, val) => OwnedNode::Branch(c.into(), val.map(DBValue::from_slice)),
 		}
 	}
 }

--- a/patricia_trie/src/node.rs
+++ b/patricia_trie/src/node.rs
@@ -58,6 +58,7 @@ impl Branch {
 		Branch { data, ubounds, has_value: value.is_some() }
 	}
 
+	/// Get the node value, if any
 	pub fn get_value(&self) -> Option<&[u8]> {
 		if self.has_value {
 			Some(&self.data[self.ubounds[16]..self.ubounds[17]])
@@ -66,6 +67,7 @@ impl Branch {
 		}
 	}
 
+	/// Test if the node has a value
 	pub fn has_value(&self) -> bool {
 		self.has_value
 	}

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -371,7 +371,8 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 						IterStep::PopTrail
 					},
 					(Status::At, &OwnedNode::Branch(ref branch)) if branch.has_value() => {
-						return Some(Ok((self.key(), DBValue::from_slice(branch.get_value().unwrap()))));
+						let value = branch.get_value().expect("already checked `has_value`");
+						return Some(Ok((self.key(), DBValue::from_slice(value))));
 					},
 					(Status::At, &OwnedNode::Leaf(_, ref v)) => {
 						return Some(Ok((self.key(), v.clone())));
@@ -380,7 +381,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 						IterStep::Descend::<H::Out, C::Error>(self.db.get_raw_or_lookup(&*d))
 					},
 					(Status::At, &OwnedNode::Branch(_)) => IterStep::Continue,
-					(Status::AtChild(i), &OwnedNode::Branch(ref branch)) if branch[i].len() > 0 => {
+					(Status::AtChild(i), &OwnedNode::Branch(ref branch)) if !branch[i].is_empty() => {
 						match i {
 							0 => self.key_nibbles.push(0),
 							i => *self.key_nibbles.last_mut()

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -58,8 +58,8 @@ use std::marker::PhantomData;
 /// }
 /// ```
 pub struct TrieDB<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	db: &'db HashDB<H>,
@@ -70,8 +70,8 @@ where
 }
 
 impl<'db, H, C> TrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and `root`
@@ -132,8 +132,8 @@ where
 
 // This is for pretty debug output only
 struct TrieAwareDebugNode<'db, 'a, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H> + 'db
 {
 	trie: &'db TrieDB<'db, H, C>,
@@ -141,8 +141,8 @@ where
 }
 
 impl<'db, 'a, H, C> fmt::Debug for TrieAwareDebugNode<'db, 'a, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -180,8 +180,8 @@ where
 }
 
 impl<'db, H, C> fmt::Debug for TrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -383,7 +383,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 							i => *self.key_nibbles.last_mut()
 								.expect("pushed as 0; moves sequentially; removed afterwards; qed") = i as u8,
 						}
-						IterStep::Descend::<H::Out, C::Error>(self.db.get_raw_or_lookup(&*children[i]))
+						IterStep::Descend::<H::Out, C::Error>(self.db.get_raw_or_lookup(&children[i]))
 					},
 					(Status::AtChild(i), &OwnedNode::Branch(_, _)) => {
 						if i == 0 {
@@ -441,7 +441,7 @@ mod tests {
 	#[test]
 	fn iterator_seek() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
-	
+
 		let mut memdb = MemoryDB::<KeccakHasher>::new();
 		let mut root = H256::new();
 		{
@@ -450,7 +450,7 @@ mod tests {
 				t.insert(x, x).unwrap();
 			}
 		}
-	
+
 		let t = TrieDB::new(&memdb, &root).unwrap();
 		let mut iter = t.iter().unwrap();
 		assert_eq!(iter.next().unwrap().unwrap(), (b"A".to_vec(), DBValue::from_slice(b"A")));


### PR DESCRIPTION
This is a (small) continuation of #29.

Refactors the `OwnedNode::Branch` variant with a dedicated `Branch` struct.
Uses a single `Vec` to hold all the data. We save several `NodeKey`s and a `DBValue` which are all `ElasticArray`s.

This struct is immutable, which is ok I think reading at the comment for `OwnedNode` (mainly used for iterations). I do not grasp all the consequences out of parity-common.

As for the benches, as expected, iterating the trie is faster. I guess the memory should also be lower:
```
$ cargo benchcmp master branch
 name                        master ns/iter  branch ns/iter  diff ns/iter   diff %  speedup 
 trie_insertions_32_mir_1k   3,557,064       3,606,762             49,698    1.40%   x 0.99 
 trie_insertions_32_ran_1k   3,512,891       3,617,559            104,668    2.98%   x 0.97 
 trie_insertions_random_mid  2,618,781       2,605,743            -13,038   -0.50%   x 1.01 
 trie_insertions_six_high    2,688,483       2,675,930            -12,553   -0.47%   x 1.00 
 trie_insertions_six_low     5,206,615       5,177,413            -29,202   -0.56%   x 1.01 
 trie_insertions_six_mid     3,386,309       3,383,847             -2,462   -0.07%   x 1.00 
 trie_iter                   2,610,651       2,222,271           -388,380  -14.88%   x 1.17
```