### PR TITLE
Fix scoring to favour lower insertion_ids.

### DIFF
--- a/transaction-pool/src/scoring.rs
+++ b/transaction-pool/src/scoring.rs
@@ -138,7 +138,7 @@ impl<T, S: Clone> Clone for ScoreWithRef<T, S> {
 impl<S: cmp::Ord, T> Ord for ScoreWithRef<T, S> {
 	fn cmp(&self, other: &Self) -> cmp::Ordering {
 		other.score.cmp(&self.score)
-			.then(other.transaction.insertion_id.cmp(&self.transaction.insertion_id))
+			.then(self.transaction.insertion_id.cmp(&other.transaction.insertion_id))
 	}
 }
 
@@ -155,3 +155,33 @@ impl<S: cmp::Ord, T>  PartialEq for ScoreWithRef<T, S> {
 }
 
 impl<S: cmp::Ord, T> Eq for ScoreWithRef<T, S> {}
+
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn score(score: u64, insertion_id: u64) -> ScoreWithRef<(), u64> {
+		ScoreWithRef {
+			score,
+			transaction: Transaction {
+				insertion_id,
+				transaction: Default::default(),
+			},
+		}
+	}
+
+	#[test]
+	fn scoring_comparison() {
+		// the higher the score the better
+		assert_eq!(score(10, 0).cmp(&score(0, 0)), cmp::Ordering::Less);
+		assert_eq!(score(0, 0).cmp(&score(10, 0)), cmp::Ordering::Greater);
+
+		// equal is equal
+		assert_eq!(score(0, 0).cmp(&score(0, 0)), cmp::Ordering::Equal);
+
+		// lower insertion id is better
+		assert_eq!(score(0, 0).cmp(&score(0, 10)), cmp::Ordering::Less);
+		assert_eq!(score(0, 10).cmp(&score(0, 0)), cmp::Ordering::Greater);
+	}
+}

--- a/transaction-pool/src/tests/mod.rs
+++ b/transaction-pool/src/tests/mod.rs
@@ -210,6 +210,14 @@ fn should_construct_pending() {
 
 	let tx0 = txq.import(b.tx().nonce(0).gas_price(5).new()).unwrap();
 	let tx1 = txq.import(b.tx().nonce(1).gas_price(5).new()).unwrap();
+
+	let tx9 = txq.import(b.tx().sender(2).nonce(0).new()).unwrap();
+
+	let tx5 = txq.import(b.tx().sender(1).nonce(0).new()).unwrap();
+	let tx6 = txq.import(b.tx().sender(1).nonce(1).new()).unwrap();
+	let tx7 = txq.import(b.tx().sender(1).nonce(2).new()).unwrap();
+	let tx8 = txq.import(b.tx().sender(1).nonce(3).gas_price(4).new()).unwrap();
+
 	let tx2 = txq.import(b.tx().nonce(2).new()).unwrap();
 	// this transaction doesn't get to the block despite high gas price
 	// because of block gas limit and simplistic ordering algorithm.
@@ -217,14 +225,9 @@ fn should_construct_pending() {
 	//gap
 	txq.import(b.tx().nonce(5).new()).unwrap();
 
-	let tx5 = txq.import(b.tx().sender(1).nonce(0).new()).unwrap();
-	let tx6 = txq.import(b.tx().sender(1).nonce(1).new()).unwrap();
-	let tx7 = txq.import(b.tx().sender(1).nonce(2).new()).unwrap();
-	let tx8 = txq.import(b.tx().sender(1).nonce(3).gas_price(4).new()).unwrap();
 	// gap
 	txq.import(b.tx().sender(1).nonce(5).new()).unwrap();
 
-	let tx9 = txq.import(b.tx().sender(2).nonce(0).new()).unwrap();
 	assert_eq!(txq.light_status().transaction_count, 11);
 	assert_eq!(txq.status(NonceReady::default()), Status {
 		stalled: 0,
@@ -325,6 +328,13 @@ fn should_update_scoring_correctly() {
 	let b = TransactionBuilder::default();
 	let mut txq = TestPool::default();
 
+	let tx9 = txq.import(b.tx().sender(2).nonce(0).new()).unwrap();
+
+	let tx5 = txq.import(b.tx().sender(1).nonce(0).new()).unwrap();
+	let tx6 = txq.import(b.tx().sender(1).nonce(1).new()).unwrap();
+	let tx7 = txq.import(b.tx().sender(1).nonce(2).new()).unwrap();
+	let tx8 = txq.import(b.tx().sender(1).nonce(3).gas_price(4).new()).unwrap();
+
 	let tx0 = txq.import(b.tx().nonce(0).gas_price(5).new()).unwrap();
 	let tx1 = txq.import(b.tx().nonce(1).gas_price(5).new()).unwrap();
 	let tx2 = txq.import(b.tx().nonce(2).new()).unwrap();
@@ -334,14 +344,9 @@ fn should_update_scoring_correctly() {
 	//gap
 	txq.import(b.tx().nonce(5).new()).unwrap();
 
-	let tx5 = txq.import(b.tx().sender(1).nonce(0).new()).unwrap();
-	let tx6 = txq.import(b.tx().sender(1).nonce(1).new()).unwrap();
-	let tx7 = txq.import(b.tx().sender(1).nonce(2).new()).unwrap();
-	let tx8 = txq.import(b.tx().sender(1).nonce(3).gas_price(4).new()).unwrap();
 	// gap
 	txq.import(b.tx().sender(1).nonce(5).new()).unwrap();
 
-	let tx9 = txq.import(b.tx().sender(2).nonce(0).new()).unwrap();
 	assert_eq!(txq.light_status().transaction_count, 11);
 	assert_eq!(txq.status(NonceReady::default()), Status {
 		stalled: 0,


### PR DESCRIPTION
Related to: https://github.com/paritytech/parity-ethereum/issues/9398

The issue was that current `ScoringWithRef` implementation was falling back to compare `insertion_id` in case the score is equal, but recently imported transactions were favored - this was incorrect, fifo behaviour is more fair and expected.

CC @Tbaut @dvdplm 