### PR TITLE
Attempt to sort out the circular dependencies for patricia-trie

### DIFF
--- a/patricia_trie/Cargo.toml
+++ b/patricia_trie/Cargo.toml
@@ -16,27 +16,11 @@ parity-bytes = { version = "0.1", path = "../parity-bytes" }
 [dev-dependencies]
 env_logger = "0.5"
 ethereum-types = "0.4"
+tiny-keccak = "1.4"
 keccak-hash = { version = "0.1", path = "../keccak-hash" }
 memorydb = { version = "0.2", path = "../memorydb", default-features = false }
 rlp = { version = "0.2", path = "../rlp", default-features = false }
 trie-standardmap = { version = "0.1", path = "../trie-standardmap", default-features = false }
 triehash = { version = "0.2", path = "../triehash", default-features = false }
-parity-bytes = { version = "0.1.0", path = "../parity-bytes" }
-
-# REVIEW: what's a better way to deal with this? The tests here in
-# `patricia_trie` use `keccak-hasher` and `patricia-trie-ethereum` to
-# instantiate concrete impls. Neither crate is needed/wanted in `parity-common`
-# (but we do want our tests to run…). We can publish them to crates.io (and I
-# did this for `keccak-hasher`, but: see below) but `patricia-trie-ethereum`
-# depends on `patricia_trie` and which will eventually be published as part of
-# `parity-common` but not before that. So it's a cycle. The temporary workaround
-# is to copy `patricia-trie-ethereum` into `parity-common` as a "test helper".
-# Note that this is a *copy*, without any git history or link to the mother
-# repo. They are to be considered test-only helpers and do not necessarily need
-# to be in sync with the `parity-ethereum` versions.
-patricia-trie-ethereum = { version = "0.1", path = "../test-support/patricia-trie-ethereum" }
-# We need this in-tree or we end up with duplicate versions when `keccak-hasher`
-# from crates.io fetches `hashdb` from crates, which causes compiler error
-# `error[E0277]: the trait bound `keccak_hasher::KeccakHasher: hashdb::Hasher`
-# is not satisfied`. Not sure if there's any way around that.
-keccak-hasher = { version = "0.1", path = "../test-support/keccak-hasher" }
+parity-bytes = { version = "0.1", path = "../parity-bytes" }
+plain_hasher = { version = "0.2", path = "../plain_hasher", default-features = false }

--- a/patricia_trie/src/fatdb.rs
+++ b/patricia_trie/src/fatdb.rs
@@ -23,16 +23,16 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` or `TrieMut` trait object.
 pub struct FatDB<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDB<'db, H, C>,
 }
 
 impl<'db, H, C> FatDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
@@ -47,8 +47,8 @@ where
 }
 
 impl<'db, H, C> Trie<H, C> for FatDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&self) -> &H::Out { self.raw.root() }
@@ -70,8 +70,8 @@ where
 
 /// Itarator over inserted pairs of key values.
 pub struct FatDBIterator<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H> + 'db
 {
 	trie_iterator: TrieDBIterator<'db, H, C>,
@@ -79,8 +79,8 @@ where
 }
 
 impl<'db, H, C> FatDBIterator<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Creates new iterator.
@@ -93,8 +93,8 @@ where
 }
 
 impl<'db, H, C> TrieIterator<H, C> for FatDBIterator<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn seek(&mut self, key: &[u8]) -> Result<(), H::Out, C::Error> {
@@ -104,8 +104,8 @@ where
 }
 
 impl<'db, H, C> Iterator for FatDBIterator<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	type Item = TrieItem<'db, H::Out, C::Error>;
@@ -125,14 +125,12 @@ where
 mod test {
 	use memorydb::MemoryDB;
 	use hashdb::DBValue;
-	use keccak_hasher::KeccakHasher;
-	use ethtrie::trie::{Trie, TrieMut};
-	use ethtrie::{FatDB, FatDBMut};
 	use ethereum_types::H256;
+	use super::super::{test_support::*, Trie, TrieMut};
 
 	#[test]
 	fn fatdb_to_trie() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = FatDBMut::new(&mut memdb, &mut root);

--- a/patricia_trie/src/fatdbmut.rs
+++ b/patricia_trie/src/fatdbmut.rs
@@ -23,16 +23,16 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` or `TrieMut` trait object.
 pub struct FatDBMut<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDBMut<'db, H, C>,
 }
 
 impl<'db, H, C> FatDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
@@ -61,8 +61,8 @@ where
 }
 
 impl<'db, H, C> TrieMut<H, C> for FatDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&mut self) -> &H::Out { self.raw.root() }
@@ -109,15 +109,13 @@ where
 mod test {
 	use hashdb::DBValue;
 	use memorydb::MemoryDB;
-	use ethtrie::trie::{Trie, TrieMut};
-	use ethtrie::{TrieDB, FatDBMut};
-	use keccak_hasher::KeccakHasher;
 	use keccak;
 	use ethereum_types::H256;
+	use super::super::{test_support::*, Trie, TrieMut};
 
 	#[test]
 	fn fatdbmut_to_trie() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = FatDBMut::new(&mut memdb, &mut root);

--- a/patricia_trie/src/lib.rs
+++ b/patricia_trie/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Trie interface and implementation.
 extern crate elastic_array;
-extern crate parity_bytes as bytes; // TODO: name changed; update upstream when `parity-common` is available
+extern crate parity_bytes as bytes;
 extern crate hashdb;
 extern crate rand;
 #[macro_use]
@@ -28,8 +28,8 @@ extern crate env_logger;
 extern crate ethereum_types;
 #[cfg(test)]
 extern crate trie_standardmap as standardmap;
-#[cfg(test)]
-extern crate patricia_trie_ethereum as ethtrie;
+// #[cfg(test)]
+// extern crate patricia_trie_ethereum as ethtrie;
 #[cfg(test)]
 extern crate memorydb;
 #[cfg(test)]
@@ -37,7 +37,11 @@ extern crate rlp;
 #[cfg(test)]
 extern crate keccak_hash as keccak;
 #[cfg(test)]
-extern crate keccak_hasher;
+extern crate tiny_keccak;
+#[cfg(test)]
+extern crate plain_hasher;
+// #[cfg(test)]
+// extern crate keccak_hasher;
 #[cfg(test)]
 extern crate triehash;
 
@@ -58,6 +62,9 @@ mod lookup;
 mod nibblevec;
 mod nibbleslice;
 mod node_codec;
+
+#[cfg(test)]
+mod test_support;
 
 pub use self::triedb::{TrieDB, TrieDBIterator};
 pub use self::triedbmut::{TrieDBMut, ChildReference};

--- a/patricia_trie/src/lib.rs
+++ b/patricia_trie/src/lib.rs
@@ -28,8 +28,6 @@ extern crate env_logger;
 extern crate ethereum_types;
 #[cfg(test)]
 extern crate trie_standardmap as standardmap;
-// #[cfg(test)]
-// extern crate patricia_trie_ethereum as ethtrie;
 #[cfg(test)]
 extern crate memorydb;
 #[cfg(test)]
@@ -40,8 +38,6 @@ extern crate keccak_hash as keccak;
 extern crate tiny_keccak;
 #[cfg(test)]
 extern crate plain_hasher;
-// #[cfg(test)]
-// extern crate keccak_hasher;
 #[cfg(test)]
 extern crate triehash;
 

--- a/patricia_trie/src/recorder.rs
+++ b/patricia_trie/src/recorder.rs
@@ -80,8 +80,9 @@ impl<HO: Copy> Recorder<HO> {
 mod tests {
 	use super::*;
 	use keccak::keccak;
-	use keccak_hasher::KeccakHasher;
+	use memorydb::MemoryDB;
 	use ethereum_types::H256;
+	use super::super::{test_support::*, Trie, TrieMut, Recorder};
 
 	#[test]
 	fn basic_recorder() {
@@ -135,11 +136,7 @@ mod tests {
 
 	#[test]
 	fn trie_record() {
-		use ethtrie::trie::{Trie, TrieMut, Recorder};
-		use memorydb::MemoryDB;
-		use ethtrie::{TrieDB, TrieDBMut};
-
-		let mut db = MemoryDB::<KeccakHasher>::new();
+		let mut db = MemoryDB::<TestHasher>::new();
 
 		let mut root = H256::default();
 

--- a/patricia_trie/src/sectriedb.rs
+++ b/patricia_trie/src/sectriedb.rs
@@ -23,16 +23,16 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` trait object. You can use `raw()` to get the backing `TrieDB` object.
 pub struct SecTrieDB<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDB<'db, H, C>
 }
 
 impl<'db, H, C> SecTrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
@@ -56,8 +56,8 @@ where
 }
 
 impl<'db, H, C> Trie<H, C> for SecTrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&self) -> &H::Out { self.raw.root() }
@@ -82,13 +82,12 @@ mod test {
 	use memorydb::MemoryDB;
 	use hashdb::DBValue;
 	use keccak;
-	use keccak_hasher::KeccakHasher;
-	use ethtrie::{TrieDBMut, SecTrieDB, trie::{Trie, TrieMut}};
 	use ethereum_types::H256;
+	use super::super::{test_support::*, Trie, TrieMut};
 
 	#[test]
 	fn trie_to_sectrie() {
-		let mut db = MemoryDB::<KeccakHasher>::new();
+		let mut db = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut db, &mut root);

--- a/patricia_trie/src/sectriedbmut.rs
+++ b/patricia_trie/src/sectriedbmut.rs
@@ -22,16 +22,16 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` or `TrieMut` trait object. You can use `raw()` to get the backing `TrieDBMut` object.
 pub struct SecTrieDBMut<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDBMut<'db, H, C>
 }
 
 impl<'db, H, C> SecTrieDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
@@ -56,8 +56,8 @@ where
 }
 
 impl<'db, H, C> TrieMut<H, C> for SecTrieDBMut<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&mut self) -> &H::Out {
@@ -92,13 +92,12 @@ mod test {
 	use memorydb::MemoryDB;
 	use hashdb::DBValue;
 	use keccak;
-	use keccak_hasher::KeccakHasher;
-	use ethtrie::{TrieDB, SecTrieDBMut, trie::{Trie, TrieMut}};
 	use ethereum_types::H256;
+	use super::super::{test_support::*, Trie, TrieMut};
 
 	#[test]
 	fn sectrie_to_trie() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = SecTrieDBMut::new(&mut memdb, &mut root);

--- a/patricia_trie/src/test_support.rs
+++ b/patricia_trie/src/test_support.rs
@@ -1,0 +1,122 @@
+use hashdb::Hasher;
+use ethereum_types::H256;
+use plain_hasher::PlainHasher;
+use rlp::{DecoderError, RlpStream, Rlp, Prototype};
+use super::{NibbleSlice, node::Node, ChildReference, NodeCodec};
+use std::marker::PhantomData;
+use elastic_array::{ElasticArray1024, ElasticArray128};
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct TestHasher;
+impl Hasher for TestHasher {
+	type Out = H256;
+	type StdHasher = PlainHasher;
+	const LENGTH: usize = 32;
+	fn hash(x: &[u8]) -> Self::Out {
+		let mut out = [0;32];
+		::tiny_keccak::Keccak::keccak256(x, &mut out);
+		out.into()
+	}
+}
+
+#[derive(Default, Clone)]
+pub struct RlpNodeCodec<H: Hasher> {mark: PhantomData<H>}
+
+impl NodeCodec<TestHasher> for RlpNodeCodec<TestHasher> {
+	type Error = DecoderError;
+	const HASHED_NULL_NODE : H256 = H256( [0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6, 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e, 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0, 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21] );
+	fn decode(data: &[u8]) -> ::std::result::Result<Node, Self::Error> {
+		let r = Rlp::new(data);
+		match r.prototype()? {
+			// either leaf or extension - decode first item with NibbleSlice::???
+			// and use is_leaf return to figure out which.
+			// if leaf, second item is a value (is_data())
+			// if extension, second item is a node (either SHA3 to be looked up and
+			// fed back into this function or inline RLP which can be fed back into this function).
+			Prototype::List(2) => match NibbleSlice::from_encoded(r.at(0)?.data()?) {
+				(slice, true) => Ok(Node::Leaf(slice, r.at(1)?.data()?)),
+				(slice, false) => Ok(Node::Extension(slice, r.at(1)?.as_raw())),
+			},
+			// branch - first 16 are nodes, 17th is a value (or empty).
+			Prototype::List(17) => {
+				let mut nodes = [&[] as &[u8]; 16];
+				for i in 0..16 {
+					nodes[i] = r.at(i)?.as_raw();
+				}
+				Ok(Node::Branch(nodes, if r.at(16)?.is_empty() { None } else { Some(r.at(16)?.data()?) }))
+			},
+			// an empty branch index.
+			Prototype::Data(0) => Ok(Node::Empty),
+			// something went wrong.
+			_ => Err(DecoderError::Custom("Rlp is not valid."))
+		}
+	}
+	fn try_decode_hash(data: &[u8]) -> Option<<TestHasher as Hasher>::Out> {
+		let r = Rlp::new(data);
+		if r.is_data() && r.size() == TestHasher::LENGTH {
+			Some(r.as_val().expect("Hash is the correct size; qed"))
+		} else {
+			None
+		}
+	}
+	fn is_empty_node(data: &[u8]) -> bool {
+		Rlp::new(data).is_empty()
+	}
+	fn empty_node() -> ElasticArray1024<u8> {
+		let mut stream = RlpStream::new();
+		stream.append_empty_data();
+		stream.drain()
+	}
+
+	fn leaf_node(partial: &[u8], value: &[u8]) -> ElasticArray1024<u8> {
+		let mut stream = RlpStream::new_list(2);
+		stream.append(&partial);
+		stream.append(&value);
+		stream.drain()
+	}
+
+	fn ext_node(partial: &[u8], child_ref: ChildReference<<TestHasher as Hasher>::Out>) -> ElasticArray1024<u8> {
+		let mut stream = RlpStream::new_list(2);
+		stream.append(&partial);
+		match child_ref {
+			ChildReference::Hash(h) => stream.append(&h),
+			ChildReference::Inline(inline_data, len) => {
+				let bytes = &AsRef::<[u8]>::as_ref(&inline_data)[..len];
+				stream.append_raw(bytes, 1)
+			},
+		};
+		stream.drain()
+	}
+
+	fn branch_node<I>(children: I, value: Option<ElasticArray128<u8>>) -> ElasticArray1024<u8>
+	where I: IntoIterator<Item=Option<ChildReference<<TestHasher as Hasher>::Out>>>
+	{
+		let mut stream = RlpStream::new_list(17);
+		for child_ref in children {
+			match child_ref {
+				Some(c) => match c {
+					ChildReference::Hash(h) => stream.append(&h),
+					ChildReference::Inline(inline_data, len) => {
+						let bytes = &AsRef::<[u8]>::as_ref(&inline_data)[..len];
+						stream.append_raw(bytes, 1)
+					},
+				},
+				None => stream.append_empty_data()
+			};
+		}
+		if let Some(value) = value {
+			stream.append(&&*value);
+		} else {
+			stream.append_empty_data();
+		}
+		stream.drain()
+	}
+}
+
+pub type RlpCodec = RlpNodeCodec<TestHasher>;
+pub type TrieDB<'db> = super::TrieDB<'db, TestHasher, RlpCodec>;
+pub type SecTrieDB<'db> = super::SecTrieDB<'db, TestHasher, RlpCodec>;
+pub type FatDB<'db> = super::FatDB<'db, TestHasher, RlpCodec>;
+pub type TrieDBMut<'db> = super::TrieDBMut<'db, TestHasher, RlpCodec>;
+pub type SecTrieDBMut<'db> = super::SecTrieDBMut<'db, TestHasher, RlpCodec>;
+pub type FatDBMut<'db> = super::FatDBMut<'db, TestHasher, RlpCodec>;

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -30,36 +30,9 @@ use std::marker::PhantomData;
 ///
 /// Use it as a `Trie` trait object. You can use `db()` to get the backing database object.
 /// Use `get` and `contains` to query values associated with keys in the trie.
-///
-/// # Example
-/// ```
-/// extern crate patricia_trie as trie;
-/// extern crate patricia_trie_ethereum as ethtrie;
-/// extern crate hashdb;
-/// extern crate keccak_hasher;
-/// extern crate memorydb;
-/// extern crate ethereum_types;
-///
-/// use trie::*;
-/// use hashdb::*;
-/// use keccak_hasher::KeccakHasher;
-/// use memorydb::*;
-/// use ethereum_types::H256;
-/// use ethtrie::{TrieDB, TrieDBMut};
-///
-///
-/// fn main() {
-///   let mut memdb = MemoryDB::<KeccakHasher>::new();
-///   let mut root = H256::new();
-///   TrieDBMut::new(&mut memdb, &mut root).insert(b"foo", b"bar").unwrap();
-///   let t = TrieDB::new(&memdb, &root).unwrap();
-///   assert!(t.contains(b"foo").unwrap());
-///   assert_eq!(t.get(b"foo").unwrap().unwrap(), DBValue::from_slice(b"bar"));
-/// }
-/// ```
 pub struct TrieDB<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	db: &'db HashDB<H>,
@@ -70,8 +43,8 @@ where
 }
 
 impl<'db, H, C> TrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and `root`
@@ -132,8 +105,8 @@ where
 
 // This is for pretty debug output only
 struct TrieAwareDebugNode<'db, 'a, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H> + 'db
 {
 	trie: &'db TrieDB<'db, H, C>,
@@ -141,8 +114,8 @@ where
 }
 
 impl<'db, 'a, H, C> fmt::Debug for TrieAwareDebugNode<'db, 'a, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -180,8 +153,8 @@ where
 }
 
 impl<'db, H, C> fmt::Debug for TrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -415,16 +388,15 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 #[cfg(test)]
 mod tests {
 	use hashdb::DBValue;
-	use keccak_hasher::KeccakHasher;
 	use memorydb::MemoryDB;
-	use ethtrie::{TrieDB, TrieDBMut, RlpCodec, trie::{Trie, TrieMut, Lookup}};
 	use ethereum_types::H256;
+	use super::super::{test_support::*, Trie, TrieMut, Lookup};
 
 	#[test]
 	fn iterator() {
 		let d = vec![DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B")];
 
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -441,8 +413,8 @@ mod tests {
 	#[test]
 	fn iterator_seek() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
-	
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -450,7 +422,7 @@ mod tests {
 				t.insert(x, x).unwrap();
 			}
 		}
-	
+
 		let t = TrieDB::new(&memdb, &root).unwrap();
 		let mut iter = t.iter().unwrap();
 		assert_eq!(iter.next().unwrap().unwrap(), (b"A".to_vec(), DBValue::from_slice(b"A")));
@@ -481,7 +453,7 @@ mod tests {
 
 	#[test]
 	fn get_len() {
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -499,7 +471,7 @@ mod tests {
 	fn debug_output_supports_pretty_print() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
 
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		let root = {
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);
@@ -607,9 +579,9 @@ mod tests {
 		use rlp;
 		use ethereum_types::H512;
 		use std::marker::PhantomData;
-		use ethtrie::trie::NibbleSlice;
+		use super::super::NibbleSlice;
 
-		let mut memdb = MemoryDB::<KeccakHasher>::new();
+		let mut memdb = MemoryDB::<TestHasher>::new();
 		let mut root = H256::new();
 		{
 			let mut t = TrieDBMut::new(&mut memdb, &mut root);


### PR DESCRIPTION
(based on https://github.com/paritytech/parity-common/pull/41)

The tests in `patricia-trie` needs a concerte impl of Hasher and NodeCodec. They've used the crates copied to `test-support` for this reason but that causes issues when publishing and is just yucky anyway. This attempts to rectify that by adding a `test_support` module with a `TestHasher` impl. 
Far from perfect and other crates (`memorydb` and `triehash`) also has tests that need a concrete impl so the `test-support/keccak-hasher` is still around. Ideas on how to improve this are welcome.