### PR TITLE
kvdb, replace elastic-array with Vecs

### DIFF
--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-memorydb"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "A key-value in-memory database that implements the  `KeyValueDB` trait"
@@ -8,4 +8,4 @@ license = "GPL-3.0"
 
 [dependencies]
 parking_lot = "0.6"
-kvdb = { version = "0.1", path = "../kvdb" }
+kvdb = { version = "0.2.0", path = "../kvdb" }

--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -101,7 +101,7 @@ impl KeyValueDB<DBKey, DBValue> for InMemory {
 	}
 
 	fn iter_from_prefix<'a>(&'a self, col: Option<u32>, prefix: &'a [u8])
-		-> Box<Iterator<Item=(DBKey, DBValue)> + 'a>
+		-> Box<Iterator<Item = (DBKey, DBValue)> + 'a>
 	{
 		match self.columns.read().get(&col) {
 			Some(map) => Box::new(

--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -91,7 +91,7 @@ impl KeyValueDB<DBKey, DBValue> for InMemory {
 		Ok(())
 	}
 
-	fn iter<'a>(&'a self, col: Option<u32>) -> Box<Iterator<Item=(DBKey, DBValue)> + 'a> {
+	fn iter<'a>(&'a self, col: Option<u32>) -> Box<Iterator<Item = (DBKey, DBValue)> + 'a> {
 		match self.columns.read().get(&col) {
 			Some(map) => Box::new( // TODO: worth optimizing at all?
 				map.clone().into_iter()

--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -49,7 +49,7 @@ pub fn create(num_cols: u32) -> InMemory {
 }
 
 impl KeyValueDB<DBKey, DBValue> for InMemory {
-	fn get(&self, col: Option<u32>, key: &[u8]) -> io::Result<Option<DBValue>> {
+	fn get(&self, col: Option<u32>, key: &DBKey) -> io::Result<Option<DBValue>> {
 		let columns = self.columns.read();
 		match columns.get(&col) {
 			None => Err(io::Error::new(io::ErrorKind::Other, format!("No such column family: {:?}", col))),
@@ -105,7 +105,8 @@ impl KeyValueDB<DBKey, DBValue> for InMemory {
 	{
 		match self.columns.read().get(&col) {
 			Some(map) => Box::new(
-				map.clone().into_iter()
+				map.clone()
+					.into_iter()
 					.skip_while(move |&(ref k, _)| !k.starts_with(prefix))
 			),
 			None => Box::new(None.into_iter()),

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by rocksDB"
 license = "GPL-3.0"
 
 [dependencies]
-elastic-array = "0.10"
+ethereum-types = "0.3"
 fs-swap = "0.2.4"
 interleaved-ordered = "0.1.0"
-kvdb = { version = "0.1", path = "../kvdb" }
+kvdb = { version = "0.2", path = "../kvdb" }
 log = "0.4"
 num_cpus = "1.0"
 parking_lot = "0.6"

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -7,7 +7,6 @@ description = "kvdb implementation backed by rocksDB"
 license = "GPL-3.0"
 
 [dependencies]
-ethereum-types = "0.3"
 fs-swap = "0.2.4"
 interleaved-ordered = "0.1.0"
 kvdb = { version = "0.2", path = "../kvdb" }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -529,7 +529,7 @@ impl Database {
 	}
 
 	/// Get database iterator for flushed data.
-	pub fn iter<'a>(&'a self, col: Option<u32>) -> Option<impl Iterator<Item=(DBKey, DBValue)> + 'a> {
+	pub fn iter<'a>(&'a self, col: Option<u32>) -> Option<impl Iterator<Item = (DBKey, DBValue)> + 'a> {
 		match *self.db.read() {
 			Some(DBAndColumns { ref db, ref cfs }) => {
 				let overlay = &self.overlay.read()[Self::to_overlay_column(col)];

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use parity_rocksdb::{
-	DB, Writable, WriteBatch, WriteOptions, IteratorMode, DBIterator,
+	DB, Writable, WriteBatch, WriteOptions, IteratorMode,
 	Options, BlockBasedOptions, Direction, Cache, Column, ReadOptions
 };
 use interleaved_ordered::interleave_ordered;

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -556,8 +556,7 @@ impl Database {
 		&'a self,
 		col: Option<u32>,
 		prefix: &[u8]
-	) -> Option<impl Iterator<Item=(DBKey, DBValue)> + 'a>
-	{
+	) -> Option<impl Iterator<Item=(DBKey, DBValue)> + 'a> {
 		match *self.db.read() {
 			Some(DBAndColumns { ref db, ref cfs }) => {
 				let iter = col.map_or_else(
@@ -568,7 +567,7 @@ impl Database {
 							&self.read_opts,
 						).expect("iterator params are valid; qed"));
 
-				Some(interleave_ordered(Vec::new(), iter.map(|(k, v)| (k.into(), v.into()))))
+				Some(iter.map(|(k, v)| (k.into(), v.into())))
 			}
 			None => None,
 		}
@@ -655,7 +654,7 @@ impl Database {
 // duplicate declaration of methods here to avoid trait import in certain existing cases
 // at time of addition.
 impl KeyValueDB<DBKey, DBValue> for Database {
-	fn get(&self, col: Option<u32>, key: &[u8]) -> io::Result<Option<DBValue>> {
+	fn get(&self, col: Option<u32>, key: &DBKey) -> io::Result<Option<DBValue>> {
 		Database::get(self, col, key)
 	}
 

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -556,7 +556,7 @@ impl Database {
 		&'a self,
 		col: Option<u32>,
 		prefix: &[u8]
-	) -> Option<impl Iterator<Item=(DBKey, DBValue)> + 'a> {
+	) -> Option<impl Iterator<Item = (DBKey, DBValue)> + 'a> {
 		match *self.db.read() {
 			Some(DBAndColumns { ref db, ref cfs }) => {
 				let iter = col.map_or_else(

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "kvdb"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Generic key-value trait"
 license = "GPL-3.0"
 
 [dependencies]
-elastic-array = "0.10"
-parity-bytes = { version = "0.1", path = "../parity-bytes" }

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -77,8 +77,9 @@ impl<K, V> DBTransaction<K, V> {
 
 	/// Insert a key-value pair in the transaction. Any existing value will be overwritten upon write.
 	pub fn put<IK, IV>(&mut self, col: Option<u32>, key: IK, value: IV)
-	where IK: Into<K>,
-		  IV: Into<V>,
+	where
+		IK: Into<K>,
+		IV: Into<V>,
 	{
 		self.ops.push(DBOp::Insert {
 			col: col,

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -121,7 +121,7 @@ pub trait KeyValueDB<K: AsRef<[u8]>, V>: Sync + Send {
 	fn transaction(&self) -> DBTransaction<K, V> { DBTransaction::new() }
 
 	/// Get a value by key.
-	fn get(&self, col: Option<u32>, key: &[u8]) -> io::Result<Option<V>>;
+	fn get(&self, col: Option<u32>, key: &K) -> io::Result<Option<V>>;
 
 	/// Get a value by partial key. Only works for flushed data.
 	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<V>;


### PR DESCRIPTION
Following #29 and #40, replaces ElasticArray with Vecs for kvdb, kvdb-memorydb and kvdb-rocksdb.

There are no benchmarks to check the impacts.