### PR TITLE
Fix is_int() panic with untrusted input

### DIFF
--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -223,7 +223,10 @@ impl<'a> Rlp<'a> {
 		match self.bytes[0] {
 			0...0x80 => true,
 			0x81...0xb7 => self.bytes[1] != 0,
-			b @ 0xb8...0xbf => self.bytes[1 + b as usize - 0xb7] != 0,
+			b @ 0xb8...0xbf => {
+				let payload_idx = 1 + b as usize - 0xb7;
+				payload_idx < self.bytes.len() && self.bytes[payload_idx] != 0
+			},
 			_ => false
 		}
 	}

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -429,3 +429,12 @@ fn test_rlp_stream_unbounded_list() {
 	stream.complete_unbounded_list();
 	assert!(stream.is_finished());
 }
+
+#[test]
+fn test_rlp_is_int() {
+	for b in 0xb8..0xc0 {
+		let data: Vec<u8> = vec![b];
+		let rlp = Rlp::new(&data);
+		assert_eq!(rlp.is_int(), false);
+	}
+}


### PR DESCRIPTION
In `rlp-0.2.2` untrusted RLP can panic() any code that uses `is_int()` (see added test for simple repro). This patch fixes the issue.