### PR TITLE
Update logging in DB recovery

### DIFF
--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -613,8 +613,8 @@ impl Database {
 						let _ = fs::remove_dir_all(new_db);
 					},
 					Err(err) => {
-						warn!("DB restoration failed: could not swap DB directories");
-						return Err(err.into());
+						warn!("Failed to swap DB directories: {:?}", err);
+						return Err(io::Error::new(io::ErrorKind::Other, "DB restoration failed: could not swap DB directories"));
 					}
 				}
 			}

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -606,14 +606,14 @@ impl Database {
 				let _ = fs::remove_dir_all(new_db);
 			},
 			Err(err) => {
-				warn!("DB atomic swap failed: {}", err);
+				debug!("DB atomic swap failed: {}", err);
 				match swap_nonatomic(new_db, &self.path) {
 					Ok(_) => {
 						// ignore errors
 						let _ = fs::remove_dir_all(new_db);
 					},
 					Err(err) => {
-						warn!("DB nonatomic atomic swap failed: {}", err);
+						warn!("DB restoration failed: could not swap DB directories");
 						return Err(err.into());
 					}
 				}


### PR DESCRIPTION
Don't warn when `atomic_swap` fails, since it fallbacks to non-atomic swap which could succeed. 