### PR TITLE
[patricia_trie] Faster common_prefix

### DIFF
--- a/patricia_trie/src/nibbleslice.rs
+++ b/patricia_trie/src/nibbleslice.rs
@@ -99,7 +99,7 @@ impl<'a> NibbleSlice<'a> {
 	/// Create a new nibble slice from the given HPE encoded data (e.g. output of `encoded()`).
 	pub fn from_encoded(data: &'a [u8]) -> (NibbleSlice, bool) {
 		(
-			Self::new_offset( data, if data[0] & 16 == 16 {1} else {2} ),
+			Self::new_offset(data, if data[0] & 16 == 16 { 1 } else { 2 } ),
 			data[0] & 32 == 32
 		)
 	}
@@ -159,7 +159,9 @@ impl<'a> NibbleSlice<'a> {
 			for i in 0..s/2 {
 				let mybyte = self.data[i + my_offset];
 				let theirbyte = them.data[i + their_offset];
-				if mybyte == theirbyte { eq_counter += 2 } else {
+				if mybyte == theirbyte {
+					eq_counter += 2
+				} else {
 					if mybyte & 0b_1111_0000 == theirbyte & 0b_1111_0000 {
 						eq_counter += 1;
 					}

--- a/patricia_trie/src/nibbleslice.rs
+++ b/patricia_trie/src/nibbleslice.rs
@@ -98,7 +98,10 @@ impl<'a> NibbleSlice<'a> {
 
 	/// Create a new nibble slice from the given HPE encoded data (e.g. output of `encoded()`).
 	pub fn from_encoded(data: &'a [u8]) -> (NibbleSlice, bool) {
-		(Self::new_offset(data, if data[0] & 16 == 16 {1} else {2}), data[0] & 32 == 32)
+		(
+			Self::new_offset( data, if data[0] & 16 == 16 {1} else {2} ),
+			data[0] & 32 == 32
+		)
 	}
 
 	/// Is this an empty slice?
@@ -106,24 +109,26 @@ impl<'a> NibbleSlice<'a> {
 
 	/// Get the length (in nibbles, naturally) of this slice.
 	#[inline]
-	pub fn len(&self) -> usize { (self.data.len() + self.data_encode_suffix.len()) * 2 - self.offset - self.offset_encode_suffix }
+	pub fn len(&self) -> usize {
+		(self.data.len() + self.data_encode_suffix.len()) * 2 - self.offset - self.offset_encode_suffix
+	}
 
 	/// Get the nibble at position `i`.
 	#[inline(always)]
 	pub fn at(&self, i: usize) -> u8 {
-		let l = self.data.len() * 2 - self.offset;
-		if i < l {
+		let length = self.data.len() * 2 - self.offset;
+		if i < length {
 			if (self.offset + i) & 1 == 1 {
-				self.data[(self.offset + i) / 2] & 15u8
+				self.data[(self.offset + i) / 2] & 0b_0000_1111 // lower 4 bits
 			}
 			else {
 				self.data[(self.offset + i) / 2] >> 4
 			}
 		}
 		else {
-			let i = i - l;
+			let i = i - length;
 			if (self.offset_encode_suffix + i) & 1 == 1 {
-				self.data_encode_suffix[(self.offset_encode_suffix + i) / 2] & 15u8
+				self.data_encode_suffix[(self.offset_encode_suffix + i) / 2] & 0b_0000_1111
 			}
 			else {
 				self.data_encode_suffix[(self.offset_encode_suffix + i) / 2] >> 4
@@ -147,12 +152,29 @@ impl<'a> NibbleSlice<'a> {
  	/// How many of the same nibbles at the beginning do we match with `them`?
 	pub fn common_prefix(&self, them: &Self) -> usize {
 		let s = min(self.len(), them.len());
-		let mut i = 0usize;
-		while i < s {
-			if self.at(i) != them.at(i) { break; }
-			i += 1;
+		if s % 2 == 0 && s > 2 && self.offset % 2 == 0 && them.offset % 2 == 0 {
+			let my_offset = self.offset / 2;
+			let their_offset = them.offset / 2;
+			let mut eq_counter = 0;
+			for i in 0..s/2 {
+				let mybyte = self.data[i + my_offset];
+				let theirbyte = them.data[i + their_offset];
+				if mybyte == theirbyte { eq_counter += 2 } else {
+					if mybyte & 0b_1111_0000 == theirbyte & 0b_1111_0000 {
+						eq_counter += 1;
+					}
+					break
+				}
+			}
+			return eq_counter
+		} else {
+			let mut i = 0;
+			while i < s {
+				if self.at(i) != them.at(i) { break; }
+				i += 1;
+			}
+			return i
 		}
-		i
 	}
 
 	/// Encode while nibble slice in prefixed hex notation, noting whether it `is_leaf`.
@@ -281,7 +303,6 @@ mod tests {
 	#[test]
 	fn shared() {
 		let n = NibbleSlice::new(D);
-
 		let other = &[0x01u8, 0x23, 0x01, 0x23, 0x45, 0x67];
 		let m = NibbleSlice::new(other);
 

--- a/patricia_trie/src/node_codec.rs
+++ b/patricia_trie/src/node_codec.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Generic trait for trie node encoding/decoding. Takes a `hashdb::Hasher` 
+//! Generic trait for trie node encoding/decoding. Takes a `hashdb::Hasher`
 //! to parametrize the hashes used in the codec.
 
 use hashdb::Hasher;
@@ -30,7 +30,7 @@ pub trait NodeCodec<H: Hasher>: Sized {
 
 	/// Null node type
 	const HASHED_NULL_NODE: H::Out;
-	
+
 	/// Decode bytes to a `Node`. Returns `Self::E` on failure.
 	fn decode(data: &[u8]) -> Result<Node, Self::Error>;
 
@@ -43,13 +43,13 @@ pub trait NodeCodec<H: Hasher>: Sized {
 	/// Returns an empty node
 	fn empty_node() -> ElasticArray1024<u8>;
 
-	/// Returns an encoded leaft node
+	/// Returns an encoded leaf node
 	fn leaf_node(partial: &[u8], value: &[u8]) -> ElasticArray1024<u8>;
 
 	/// Returns an encoded extension node
 	fn ext_node(partial: &[u8], child_ref: ChildReference<H::Out>) -> ElasticArray1024<u8>;
 
-	/// Returns an encoded branch node. Takes an iterator yielding `ChildReference<H::Out>` and an optional value
+	/// Returns an encoded branch node. Takes an iterator yielding `ChildReference<H::Out>` as an optional value
 	fn branch_node<I>(children: I, value: Option<ElasticArray128<u8>>) -> ElasticArray1024<u8>
 	where I: IntoIterator<Item=Option<ChildReference<H::Out>>>;
 }

--- a/patricia_trie/src/triedb.rs
+++ b/patricia_trie/src/triedb.rs
@@ -58,8 +58,8 @@ use std::marker::PhantomData;
 /// }
 /// ```
 pub struct TrieDB<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	db: &'db HashDB<H>,
@@ -70,8 +70,8 @@ where
 }
 
 impl<'db, H, C> TrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and `root`
@@ -94,7 +94,7 @@ where
 			.ok_or_else(|| Box::new(TrieError::InvalidStateRoot(*self.root)))
 	}
 
-	/// Given some node-describing data `node`, return the actual node RLP.
+	/// Given some node-describing data `node`, return the actual encoded node.
 	/// This could be a simple identity operation in the case that the node is sufficiently small, but
 	/// may require a database lookup.
 	fn get_raw_or_lookup(&'db self, node: &'db [u8]) -> Result<DBValue, H::Out, C::Error> {
@@ -132,8 +132,8 @@ where
 
 // This is for pretty debug output only
 struct TrieAwareDebugNode<'db, 'a, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H> + 'db
 {
 	trie: &'db TrieDB<'db, H, C>,
@@ -141,8 +141,8 @@ where
 }
 
 impl<'db, 'a, H, C> fmt::Debug for TrieAwareDebugNode<'db, 'a, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -180,8 +180,8 @@ where
 }
 
 impl<'db, H, C> fmt::Debug for TrieDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -319,13 +319,13 @@ impl<'a, H: Hasher, C: NodeCodec<H>> TrieDBIterator<'a, H, C> {
 		}
 	}
 
-	/// The present key.
+	/// The present key, converted back from nibbles to bytes. Allocates.
 	fn key(&self) -> Bytes {
 		// collapse the key_nibbles down to bytes.
 		let nibbles = &self.key_nibbles;
-		let mut i = 1;
-		let mut result = Bytes::with_capacity(nibbles.len() / 2);
 		let len = nibbles.len();
+		let mut result = Bytes::with_capacity(len / 2);
+		let mut i = 1;
 		while i < len {
 			result.push(nibbles[i - 1] * 16 + nibbles[i]);
 			i += 2;
@@ -441,7 +441,7 @@ mod tests {
 	#[test]
 	fn iterator_seek() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
-	
+
 		let mut memdb = MemoryDB::<KeccakHasher>::new();
 		let mut root = H256::new();
 		{
@@ -450,7 +450,7 @@ mod tests {
 				t.insert(x, x).unwrap();
 			}
 		}
-	
+
 		let t = TrieDB::new(&memdb, &root).unwrap();
 		let mut iter = t.iter().unwrap();
 		assert_eq!(iter.next().unwrap().unwrap(), (b"A".to_vec(), DBValue::from_slice(b"A")));


### PR DESCRIPTION
When finding the length of the common prefix of a key, compare byte-by-byte instead of nibble-by-nibble when possible (even length and offset).

Benchmarks:

```
 name                        master ns/iter  branch ns/iter  diff ns/iter   diff %  speedup
 nibble_common_prefix        10,841          6,063                 -4,778  -44.07%   x 1.79
 trie_insertions_32_mir_1k   2,276,636       2,275,602             -1,034   -0.05%   x 1.00
 trie_insertions_32_ran_1k   2,285,348       2,294,676              9,328    0.41%   x 1.00
 trie_insertions_random_mid  1,630,224       1,631,797              1,573    0.10%   x 1.00
 trie_insertions_six_high    1,692,403       1,685,423             -6,980   -0.41%   x 1.00
 trie_insertions_six_low     3,175,618       3,186,012             10,394    0.33%   x 1.00
 trie_insertions_six_mid     2,129,922       2,127,032             -2,890   -0.14%   x 1.00
 trie_iter                   1,584,255       1,590,210              5,955    0.38%   x 1.00
```

A bit unsure why the speedup does not show up in any other benchmark but I suspect it's either because we don't have very long/suitable common prefixes in the bench data or it gets drowned in the noise and comparing prefixes is simply not perf sensitive.