### PR TITLE
publish kvdb-rocksdb v0.1.4

### DIFF
--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by rocksDB"


### PR DESCRIPTION
To include https://github.com/paritytech/parity-common/pull/53 in the upcoming parity-ethereum release.