### PR TITLE
Add optional serialization feature via serde

### DIFF
--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -13,6 +13,8 @@ heapsize = { version = "0.4.2", optional = true }
 rustc-hex = { version = "2.0", default-features = false }
 quickcheck = { version = "0.6", optional = true }
 crunchy = "0.1"
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.6"
@@ -22,6 +24,7 @@ rustc-hex = "2.0"
 std = ["byteorder/std", "rustc-hex/std"]
 heapsizeof = ["heapsize"]
 impl_quickcheck_arbitrary = ["quickcheck"]
+serialize = ["serde", "serde_derive"]
 
 [[example]]
 name = "modular"

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -31,5 +31,11 @@ pub extern crate quickcheck;
 #[macro_use]
 extern crate crunchy;
 
+#[cfg(feature="serialize")]
+extern crate serde;
+#[cfg(feature="serialize")]
+#[macro_use]
+extern crate serde_derive;
+
 mod uint;
 pub use uint::*;

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -350,6 +350,7 @@ macro_rules! construct_uint {
 		/// Little-endian large integer type
 		#[repr(C)]
 		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+		#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 		pub struct $name(pub [u64; $n_words]);
 
 		impl AsRef<$name> for $name {


### PR DESCRIPTION
This change is required in order to provide a fluent way for `fleetwood` (and its dependency: `pwasm-abi`) to update and make `fleetwood` compile again. Also it is handy to have optional serde support.

The new feature is named `serialize` just as it was called in the deprecated `bigint` crate although `serde-1` might be a better choice.
