### PR TITLE
[fixed-hash] Add deprecations in favor of the upcoming 0.3 major version

### DIFF
--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-hash"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -9,7 +9,7 @@
 /// Return `s` without the `0x` at the beginning of it, if any.
 #[deprecated(
 	since = "0.2.5",
-	note = "implement this 3-liner yourself instead"
+	note = "out of scope for fixed-hash"
 )]
 pub fn clean_0x(s: &str) -> &str {
 	if s.starts_with("0x") {
@@ -126,7 +126,7 @@ macro_rules! construct_hash {
 			/// Assign self to be of the same value as a slice of bytes of length `len()`.
 			#[deprecated(
 				since = "0.2.5",
-				note = "unconventional API, will have a replacement in version 0.3"
+				note = "unconventional API, replaced by `assign_from_slice` in version 0.3"
 			)]
 			pub fn clone_from_slice(&mut self, src: &[u8]) -> usize {
 				let min = ::core::cmp::min($size, src.len());
@@ -137,7 +137,7 @@ macro_rules! construct_hash {
 			/// Convert a slice of bytes of length `len()` to an instance of this type.
 			#[deprecated(
 				since = "0.2.5",
-				note = "unconventional API, will have a replacement in version 0.3"
+				note = "unconventional API, replaced by `new_from_slice` in version 0.3"
 			)]
 			pub fn from_slice(src: &[u8]) -> Self {
 				let mut r = Self::new();
@@ -148,7 +148,7 @@ macro_rules! construct_hash {
 			/// Copy the data of this object into some mutable slice of length `len()`.
 			#[deprecated(
 				since = "0.2.5",
-				note = "simply use std slice API instead"
+				note = "use `std::slice` API instead"
 			)]
 			pub fn copy_to(&self, dest: &mut[u8]) {
 				let min = ::core::cmp::min($size, dest.len());
@@ -158,7 +158,7 @@ macro_rules! construct_hash {
 			/// Returns `true` if all bits set in `b` are also set in `self`.
 			#[deprecated(
 				since = "0.2.5",
-				note = "will be renamed in an upcoming version"
+				note = "will be renamed to `covers` in version 0.3"
 			)]
 			pub fn contains<'a>(&'a self, b: &'a Self) -> bool {
 				&(b & self) == b
@@ -172,7 +172,7 @@ macro_rules! construct_hash {
 			/// Returns the lowest 8 bytes interpreted as a BigEndian integer.
 			#[deprecated(
 				since = "0.2.5",
-				note = "will be renamed in an upcoming version"
+				note = "will be renamed to `low_u64_be` in version 0.3"
 			)]
 			pub fn low_u64(&self) -> u64 {
 				let mut ret = 0u64;
@@ -352,7 +352,7 @@ macro_rules! construct_hash {
 
 		#[deprecated(
 			since = "0.2.5",
-			note = "big-endian and little-endian confusion"
+			note = "will be removed because not big-/little-endian aware"
 		)]
 		impl From<u64> for $from {
 			fn from(mut value: u64) -> $from {
@@ -369,7 +369,7 @@ macro_rules! construct_hash {
 
 		#[deprecated(
 			since = "0.2.5",
-			note = "no proper error handling possible with out-of-bounds inputs"
+			note = "misses proper error handling; will be replaced by `new_from_slice` in version 0.3"
 		)]
 		impl<'a> From<&'a [u8]> for $from {
 			fn from(s: &'a [u8]) -> $from {

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -7,6 +7,10 @@
 // except according to those terms.
 
 /// Return `s` without the `0x` at the beginning of it, if any.
+#[deprecated(
+	since = "0.2.5",
+	note = "implement this 3-liner yourself instead"
+)]
 pub fn clean_0x(s: &str) -> &str {
 	if s.starts_with("0x") {
 		&s[2..]
@@ -40,6 +44,10 @@ macro_rules! construct_hash {
 			}
 		}
 
+		#[deprecated(
+			since = "0.2.5",
+			note = "use `as_ref` instead"
+		)]
 		impl ::core::ops::Deref for $from {
 			type Target = [u8];
 
@@ -70,6 +78,10 @@ macro_rules! construct_hash {
 			}
 		}
 
+		#[deprecated(
+			since = "0.2.5",
+			note = "use `as_mut` instead"
+		)]
 		impl ::core::ops::DerefMut for $from {
 			#[inline]
 			fn deref_mut(&mut self) -> &mut [u8] {
@@ -79,6 +91,10 @@ macro_rules! construct_hash {
 
 		impl $from {
 			/// Create a new, zero-initialised, instance.
+			#[deprecated(
+				since = "0.2.5",
+				note = "use `fixed_hash`::zero constructor instead"
+			)]
 			pub fn new() -> $from {
 				$from([0; $size])
 			}
@@ -89,6 +105,10 @@ macro_rules! construct_hash {
 			}
 
 			/// Get the size of this object in bytes.
+			#[deprecated(
+				since = "0.2.5",
+				note = "will be renamed to `len_bytes` to avoid confusion"
+			)]
 			pub fn len() -> usize {
 				$size
 			}
@@ -104,6 +124,10 @@ macro_rules! construct_hash {
 
 			#[inline]
 			/// Assign self to be of the same value as a slice of bytes of length `len()`.
+			#[deprecated(
+				since = "0.2.5",
+				note = "unconventional API, will have a replacement in version 0.3"
+			)]
 			pub fn clone_from_slice(&mut self, src: &[u8]) -> usize {
 				let min = ::core::cmp::min($size, src.len());
 				self.0[..min].copy_from_slice(&src[..min]);
@@ -111,6 +135,10 @@ macro_rules! construct_hash {
 			}
 
 			/// Convert a slice of bytes of length `len()` to an instance of this type.
+			#[deprecated(
+				since = "0.2.5",
+				note = "unconventional API, will have a replacement in version 0.3"
+			)]
 			pub fn from_slice(src: &[u8]) -> Self {
 				let mut r = Self::new();
 				r.clone_from_slice(src);
@@ -118,12 +146,20 @@ macro_rules! construct_hash {
 			}
 
 			/// Copy the data of this object into some mutable slice of length `len()`.
+			#[deprecated(
+				since = "0.2.5",
+				note = "simply use std slice API instead"
+			)]
 			pub fn copy_to(&self, dest: &mut[u8]) {
 				let min = ::core::cmp::min($size, dest.len());
 				dest[..min].copy_from_slice(&self.0[..min]);
 			}
 
 			/// Returns `true` if all bits set in `b` are also set in `self`.
+			#[deprecated(
+				since = "0.2.5",
+				note = "will be renamed in an upcoming version"
+			)]
 			pub fn contains<'a>(&'a self, b: &'a Self) -> bool {
 				&(b & self) == b
 			}
@@ -134,6 +170,10 @@ macro_rules! construct_hash {
 			}
 
 			/// Returns the lowest 8 bytes interpreted as a BigEndian integer.
+			#[deprecated(
+				since = "0.2.5",
+				note = "will be renamed in an upcoming version"
+			)]
 			pub fn low_u64(&self) -> u64 {
 				let mut ret = 0u64;
 				for i in 0..::core::cmp::min($size, 8) {
@@ -178,6 +218,7 @@ macro_rules! construct_hash {
 		}
 
 		impl Copy for $from {}
+
 		#[cfg_attr(feature="dev", allow(expl_impl_clone_on_copy))]
 		impl Clone for $from {
 			fn clone(&self) -> $from {
@@ -309,6 +350,10 @@ macro_rules! construct_hash {
 			fn default() -> Self { $from::new() }
 		}
 
+		#[deprecated(
+			since = "0.2.5",
+			note = "big-endian and little-endian confusion"
+		)]
 		impl From<u64> for $from {
 			fn from(mut value: u64) -> $from {
 				let mut ret = $from::new();
@@ -322,6 +367,10 @@ macro_rules! construct_hash {
 			}
 		}
 
+		#[deprecated(
+			since = "0.2.5",
+			note = "no proper error handling possible with out-of-bounds inputs"
+		)]
 		impl<'a> From<&'a [u8]> for $from {
 			fn from(s: &'a [u8]) -> $from {
 				$from::from_slice(s)


### PR DESCRIPTION
### NOTE

- The failing CI tests are a result of [this](https://github.com/rust-lang/rust/issues/55241) Rust compiler bug.
- Please merge so that we can continue work on the [other PR](https://github.com/paritytech/parity-common/pull/71) asap.

---

### Description

Pre `0.3` deprecations for `fixed-hash` crate as suggested by @dvdplm .

Note that deprecation of trait implementations do not work in general for Rust.
Note sure how to handle those, especially for the `Deref` and `DerefMut` trait implementations.

Also note that there will be some more trait implementation deprecations coming with the future `0.3` release. Especially for the conversions that have no error handling so far.