### PR TITLE
[WIP] Fixed hash 0.3 beta fixes

### DIFF
--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-hash"
-version = "0.3.0-beta.0"
+version = "0.3.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-hash"
-version = "0.3.0-beta.4"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -24,13 +24,7 @@ static_assertions = "0.2"
 libc = { version = "0.2", optional = true, default-features = false }
 
 [features]
-default = ["std", "libc", "rand-support", "rustc-hex-support", "byteorder-support"]
+default = ["std", "libc", "rand", "rustc-hex", "byteorder"]
 std = ["rustc-hex/std", "rand/std", "byteorder/std"]
-
-rustc-hex-support = ["rustc-hex"]
-rand-support = ["rand"]
-byteorder-support = ["byteorder"]
-heapsize-support = ["heapsize"]
-quickcheck-support = ["quickcheck"]
 
 api-dummy = [] # Feature used by docs.rs to display documentation of hash types

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-hash"
-version = "0.3.0-beta.3"
+version = "0.3.0-beta.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-hash"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-hash"
-version = "0.3.0-beta.2"
+version = "0.3.0-beta.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/fixed-hash/"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-features = ["heapsize-support", "quickcheck-support", "api-dummy"]
+features = ["heapsize", "quickcheck", "api-dummy"]
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }

--- a/fixed-hash/README.md
+++ b/fixed-hash/README.md
@@ -59,13 +59,13 @@ fixed-hash = { version = "0.3", default-features = false }
     - Enabled by default.
 - `libc`: Use `libc` for implementations of `PartialEq` and `Ord`.
     - Enabled by default.
-- `rand-support`: Provide API based on the `rand` crate.
+- `rand`: Provide API based on the `rand` crate.
     - Enabled by default.
-- `byteorder-support`: Provide API based on the `byteorder` crate.
+- `byteorder`: Provide API based on the `byteorder` crate.
     - Enabled by default.
-- `heapsize-support`: Provide `HeapsizeOf` implementation for hash types.
+- `heapsize`: Provide `HeapsizeOf` implementation for hash types.
     - Disabled by default.
-- `quickcheck-support`: Provide `quickcheck` implementation for hash types.
+- `quickcheck`: Provide `quickcheck` implementation for hash types.
     - Disabled by default.
 - `api-dummy`: Generate a dummy hash type for API documentation.
     - Enabled by default at `docs.rs`

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -292,6 +292,7 @@ macro_rules! construct_fixed_hash {
 		{
 			type Output = I::Output;
 
+			#[inline]
 			fn index(&self, index: I) -> &I::Output {
 				&self.as_bytes()[index]
 			}
@@ -301,6 +302,7 @@ macro_rules! construct_fixed_hash {
 		where
 			I: $crate::core_::slice::SliceIndex<[u8], Output = [u8]>
 		{
+			#[inline]
 			fn index_mut(&mut self, index: I) -> &mut I::Output {
 				&mut self.as_bytes_mut()[index]
 			}
@@ -750,7 +752,6 @@ macro_rules! impl_ops_for_hash {
 		$ops_tok:tt,
 		$ops_assign_tok:tt
 	) => {
-
 		impl<'r> $crate::core_::ops::$ops_assign_trait_name<&'r $impl_for> for $impl_for {
 			fn $ops_assign_fn_name(&mut self, rhs: &'r $impl_for) {
 				for (lhs, rhs) in self.as_bytes_mut().iter_mut().zip(rhs.as_bytes()) {
@@ -760,6 +761,7 @@ macro_rules! impl_ops_for_hash {
 		}
 
 		impl $crate::core_::ops::$ops_assign_trait_name<$impl_for> for $impl_for {
+			#[inline]
 			fn $ops_assign_fn_name(&mut self, rhs: $impl_for) {
 				*self $ops_assign_tok &rhs;
 			}
@@ -778,11 +780,11 @@ macro_rules! impl_ops_for_hash {
 		impl $crate::core_::ops::$ops_trait_name<$impl_for> for $impl_for {
 			type Output = $impl_for;
 
+			#[inline]
 			fn $ops_fn_name(self, rhs: Self) -> Self::Output {
 				&self $ops_tok &rhs
 			}
 		}
-
 	};
 }
 

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -54,7 +54,7 @@ macro_rules! construct_fixed_hash {
 		$visibility struct $name ([u8; $n_bytes]);
 
 		impl From<[u8; $n_bytes]> for $name {
-			/// Constructs a hash type from the given bytes.
+			/// Constructs a hash type from the given bytes array of fixed length.
 			///
 			/// # Note
 			///
@@ -62,6 +62,32 @@ macro_rules! construct_fixed_hash {
 			#[inline]
 			fn from(bytes: [u8; $n_bytes]) -> Self {
 				$name(bytes)
+			}
+		}
+
+		impl<'a> From<&'a [u8; $n_bytes]> for $name {
+			/// Constructs a hash type from the given reference
+			/// to the bytes array of fixed length. 
+			///
+			/// # Note
+			///
+			/// The given bytes are interpreted in big endian order.
+			#[inline]
+			fn from(bytes: &'a [u8; $n_bytes]) -> Self {
+				$name(*bytes)
+			}
+		}
+
+		impl<'a> From<&'a mut [u8; $n_bytes]> for $name {
+			/// Constructs a hash type from the given reference
+			/// to the mutable bytes array of fixed length. 
+			///
+			/// # Note
+			///
+			/// The given bytes are interpreted in big endian order.
+			#[inline]
+			fn from(bytes: &'a mut [u8; $n_bytes]) -> Self {
+				$name(*bytes)
 			}
 		}
 

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -145,7 +145,7 @@ macro_rules! construct_fixed_hash {
 			///
 			/// If the length of `src` and the number of bytes in `self` do not match.
 			pub fn assign_from_slice(&mut self, src: &[u8]) {
-				$crate::core::assert_eq!(src.len(), $n_bytes);
+				$crate::core_::assert_eq!(src.len(), $n_bytes);
 				self.as_bytes_mut().copy_from_slice(src);
 			}
 
@@ -159,7 +159,7 @@ macro_rules! construct_fixed_hash {
 			///
 			/// If the length of `src` and the number of bytes in `Self` do not match.
 			pub fn from_slice(src: &[u8]) -> Self {
-				$crate::core::assert_eq!(src.len(), $n_bytes);
+				$crate::core_::assert_eq!(src.len(), $n_bytes);
 				let mut ret = Self::zero();
 				ret.assign_from_slice(src);
 				ret
@@ -188,7 +188,7 @@ macro_rules! construct_fixed_hash {
 			/// If `n` is greater than the number of bytes in `self`.
 			#[inline]
 			fn least_significant_bytes(&self, n: usize) -> &[u8] {
-				$crate::core::assert_eq!(true, n <= Self::len_bytes());
+				$crate::core_::assert_eq!(true, n <= Self::len_bytes());
 				&self[(Self::len_bytes() - n)..]
 			}
 
@@ -197,7 +197,7 @@ macro_rules! construct_fixed_hash {
 				B: $crate::byteorder::ByteOrder
 			{
 				let mut buf = [0x0; 8];
-				let capped = $crate::core::cmp::min($n_bytes, 8);
+				let capped = $crate::core_::cmp::min($n_bytes, 8);
 				buf[(8 - capped)..].copy_from_slice(self.least_significant_bytes(capped));
 				B::read_u64(&buf)
 			}
@@ -241,7 +241,7 @@ macro_rules! construct_fixed_hash {
 			{
 				let mut buf = [0x0; 8];
 				B::write_u64(&mut buf, val);
-				let capped = $crate::core::cmp::min(Self::len_bytes(), 8);
+				let capped = $crate::core_::cmp::min(Self::len_bytes(), 8);
 				let mut bytes = [0x0; $n_bytes];
 				bytes[($n_bytes - capped)..].copy_from_slice(&buf[..capped]);
 				Self::from_slice(&bytes)
@@ -284,54 +284,54 @@ macro_rules! construct_fixed_hash {
 			}
 		}
 
-		impl $crate::core::fmt::Debug for $name {
-			fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
-				$crate::core::write!(f, "{:#x}", self)
+		impl $crate::core_::fmt::Debug for $name {
+			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
+				$crate::core_::write!(f, "{:#x}", self)
 			}
 		}
 
-		impl $crate::core::fmt::Display for $name {
-			fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
-				$crate::core::write!(f, "0x")?;
+		impl $crate::core_::fmt::Display for $name {
+			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
+				$crate::core_::write!(f, "0x")?;
 				for i in &self.0[0..2] {
-					$crate::core::write!(f, "{:02x}", i)?;
+					$crate::core_::write!(f, "{:02x}", i)?;
 				}
-				$crate::core::write!(f, "…")?;
+				$crate::core_::write!(f, "…")?;
 				for i in &self.0[$n_bytes - 2..$n_bytes] {
-					$crate::core::write!(f, "{:02x}", i)?;
+					$crate::core_::write!(f, "{:02x}", i)?;
 				}
 				Ok(())
 			}
 		}
 
-		impl $crate::core::fmt::LowerHex for $name {
-			fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
+		impl $crate::core_::fmt::LowerHex for $name {
+			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
 				if f.alternate() {
-					$crate::core::write!(f, "0x")?;
+					$crate::core_::write!(f, "0x")?;
 				}
 				for i in &self.0[..] {
-					$crate::core::write!(f, "{:02x}", i)?;
+					$crate::core_::write!(f, "{:02x}", i)?;
 				}
 				Ok(())
 			}
 		}
 
-		impl $crate::core::fmt::UpperHex for $name {
-			fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
+		impl $crate::core_::fmt::UpperHex for $name {
+			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
 				if f.alternate() {
-					$crate::core::write!(f, "0X")?;
+					$crate::core_::write!(f, "0X")?;
 				}
 				for i in &self.0[..] {
-					$crate::core::write!(f, "{:02X}", i)?;
+					$crate::core_::write!(f, "{:02X}", i)?;
 				}
 				Ok(())
 			}
 		}
 
-		impl $crate::core::marker::Copy for $name {}
+		impl $crate::core_::marker::Copy for $name {}
 
 		#[cfg_attr(feature = "dev", allow(expl_impl_clone_on_copy))]
-		impl $crate::core::clone::Clone for $name {
+		impl $crate::core_::clone::Clone for $name {
 			fn clone(&self) -> $name {
 				let mut ret = $name::zero();
 				ret.0.copy_from_slice(&self.0);
@@ -339,24 +339,24 @@ macro_rules! construct_fixed_hash {
 			}
 		}
 
-		impl $crate::core::cmp::Eq for $name {}
+		impl $crate::core_::cmp::Eq for $name {}
 
-		impl $crate::core::cmp::PartialOrd for $name {
-			fn partial_cmp(&self, other: &Self) -> Option<$crate::core::cmp::Ordering> {
+		impl $crate::core_::cmp::PartialOrd for $name {
+			fn partial_cmp(&self, other: &Self) -> Option<$crate::core_::cmp::Ordering> {
 				Some(self.cmp(other))
 			}
 		}
 
-		impl $crate::core::hash::Hash for $name {
-			fn hash<H>(&self, state: &mut H) where H: $crate::core::hash::Hasher {
+		impl $crate::core_::hash::Hash for $name {
+			fn hash<H>(&self, state: &mut H) where H: $crate::core_::hash::Hasher {
 				state.write(&self.0);
 				state.finish();
 			}
 		}
 
-		impl<I> $crate::core::ops::Index<I> for $name
+		impl<I> $crate::core_::ops::Index<I> for $name
 		where
-			I: $crate::core::slice::SliceIndex<[u8]>
+			I: $crate::core_::slice::SliceIndex<[u8]>
 		{
 			type Output = I::Output;
 
@@ -365,16 +365,16 @@ macro_rules! construct_fixed_hash {
 			}
 		}
 
-		impl<I> $crate::core::ops::IndexMut<I> for $name
+		impl<I> $crate::core_::ops::IndexMut<I> for $name
 		where
-			I: $crate::core::slice::SliceIndex<[u8], Output = [u8]>
+			I: $crate::core_::slice::SliceIndex<[u8], Output = [u8]>
 		{
 			fn index_mut(&mut self, index: I) -> &mut I::Output {
 				&mut self.as_bytes_mut()[index]
 			}
 		}
 
-		impl $crate::core::default::Default for $name {
+		impl $crate::core_::default::Default for $name {
 			#[inline]
 			fn default() -> Self {
 				Self::zero()
@@ -386,7 +386,7 @@ macro_rules! construct_fixed_hash {
 		impl_ops_for_hash!($name, BitXor, bitxor, BitXorAssign, bitxor_assign, ^, ^=);
 
 		#[cfg(all(feature = "libc", not(target_os = "unknown")))]
-		impl $crate::core::cmp::PartialEq for $name {
+		impl $crate::core_::cmp::PartialEq for $name {
 			#[inline]
 			fn eq(&self, other: &Self) -> bool {
 				unsafe {
@@ -400,8 +400,8 @@ macro_rules! construct_fixed_hash {
 		}
 
 		#[cfg(all(feature = "libc", not(target_os = "unknown")))]
-		impl $crate::core::cmp::Ord for $name {
-			fn cmp(&self, other: &Self) -> $crate::core::cmp::Ordering {
+		impl $crate::core_::cmp::Ord for $name {
+			fn cmp(&self, other: &Self) -> $crate::core_::cmp::Ordering {
 				let r = unsafe {
 					$crate::libc::memcmp(
 						self.as_ptr() as *const $crate::libc::c_void,
@@ -410,17 +410,17 @@ macro_rules! construct_fixed_hash {
 					)
 				};
 				if r < 0 {
-					return $crate::core::cmp::Ordering::Less;
+					return $crate::core_::cmp::Ordering::Less;
 				}
 				if r > 0 {
-					return $crate::core::cmp::Ordering::Greater;
+					return $crate::core_::cmp::Ordering::Greater;
 				}
-				$crate::core::cmp::Ordering::Equal
+				$crate::core_::cmp::Ordering::Equal
 			}
 		}
 
 		#[cfg(any(not(feature = "libc"), target_os = "unknown"))]
-		impl $crate::core::cmp::PartialEq for $name {
+		impl $crate::core_::cmp::PartialEq for $name {
 			#[inline]
 			fn eq(&self, other: &Self) -> bool {
 				self.as_bytes() == other.as_bytes()
@@ -428,9 +428,9 @@ macro_rules! construct_fixed_hash {
 		}
 
 		#[cfg(any(not(feature = "libc"), target_os = "unknown"))]
-		impl $crate::core::cmp::Ord for $name {
+		impl $crate::core_::cmp::Ord for $name {
 			#[inline]
-			fn cmp(&self, other: &Self) -> $crate::core::cmp::Ordering {
+			fn cmp(&self, other: &Self) -> $crate::core_::cmp::Ordering {
 				self.as_bytes().cmp(other.as_bytes())
 			}
 		}
@@ -487,7 +487,7 @@ macro_rules! construct_fixed_hash {
 		}
 
 		#[cfg(feature = "rustc-hex-support")]
-		impl $crate::core::str::FromStr for $name {
+		impl $crate::core_::str::FromStr for $name {
 			type Err = $crate::rustc_hex::FromHexError;
 
 			/// Creates a hash type instance from the given string.
@@ -502,7 +502,7 @@ macro_rules! construct_fixed_hash {
 			/// - Upon empty string input or invalid input length in general
 			fn from_str(
 				input: &str,
-			) -> $crate::core::result::Result<$name, $crate::rustc_hex::FromHexError> {
+			) -> $crate::core_::result::Result<$name, $crate::rustc_hex::FromHexError> {
 				use $crate::rustc_hex::FromHex;
 				let bytes: Vec<u8> = input.from_hex()?;
 				if bytes.len() != Self::len_bytes() {
@@ -547,7 +547,7 @@ macro_rules! impl_ops_for_hash {
 		$ops_assign_tok:tt
 	) => {
 
-		impl<'r> $crate::core::ops::$ops_assign_trait_name<&'r $impl_for> for $impl_for {
+		impl<'r> $crate::core_::ops::$ops_assign_trait_name<&'r $impl_for> for $impl_for {
 			fn $ops_assign_fn_name(&mut self, rhs: &'r $impl_for) {
 				for (lhs, rhs) in self.as_bytes_mut().iter_mut().zip(rhs.as_bytes()) {
 					*lhs $ops_assign_tok rhs;
@@ -555,13 +555,13 @@ macro_rules! impl_ops_for_hash {
 			}
 		}
 
-		impl $crate::core::ops::$ops_assign_trait_name<$impl_for> for $impl_for {
+		impl $crate::core_::ops::$ops_assign_trait_name<$impl_for> for $impl_for {
 			fn $ops_assign_fn_name(&mut self, rhs: $impl_for) {
 				*self $ops_assign_tok &rhs;
 			}
 		}
 
-		impl<'l, 'r> $crate::core::ops::$ops_trait_name<&'r $impl_for> for &'l $impl_for {
+		impl<'l, 'r> $crate::core_::ops::$ops_trait_name<&'r $impl_for> for &'l $impl_for {
 			type Output = $impl_for;
 
 			fn $ops_fn_name(self, rhs: &'r $impl_for) -> Self::Output {
@@ -571,7 +571,7 @@ macro_rules! impl_ops_for_hash {
 			}
 		}
 
-		impl $crate::core::ops::$ops_trait_name<$impl_for> for $impl_for {
+		impl $crate::core_::ops::$ops_trait_name<$impl_for> for $impl_for {
 			type Output = $impl_for;
 
 			fn $ops_fn_name(self, rhs: Self) -> Self::Output {
@@ -612,7 +612,7 @@ macro_rules! impl_fixed_hash_conversions {
 	($large_ty:ident, $small_ty:ident) => {
 		$crate::static_assertions::const_assert!(
 			VALID_SIZES;
-			$crate::core::mem::size_of::<$small_ty>() < $crate::core::mem::size_of::<$large_ty>()
+			$crate::core_::mem::size_of::<$small_ty>() < $crate::core_::mem::size_of::<$large_ty>()
 		);
 
 		impl From<$small_ty> for $large_ty {
@@ -620,7 +620,7 @@ macro_rules! impl_fixed_hash_conversions {
 				let large_ty_size = $large_ty::len_bytes();
 				let small_ty_size = $small_ty::len_bytes();
 
-				$crate::core::debug_assert!(
+				$crate::core_::debug_assert!(
 					large_ty_size > small_ty_size
 						&& large_ty_size % 2 == 0
 						&& small_ty_size % 2 == 0
@@ -638,7 +638,7 @@ macro_rules! impl_fixed_hash_conversions {
 				let large_ty_size = $large_ty::len_bytes();
 				let small_ty_size = $small_ty::len_bytes();
 
-				$crate::core::debug_assert!(
+				$crate::core_::debug_assert!(
 					large_ty_size > small_ty_size
 						&& large_ty_size % 2 == 0
 						&& small_ty_size % 2 == 0

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -295,7 +295,7 @@ macro_rules! construct_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `byteorder` crate feature in
 // a user crate.
-#[cfg(not(feature = "byteorder-support"))]
+#[cfg(not(feature = "byteorder"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_byteorder_for_fixed_hash {
@@ -309,7 +309,7 @@ macro_rules! impl_byteorder_for_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `byteorder` crate feature in
 // a user crate.
-#[cfg(feature = "byteorder-support")]
+#[cfg(feature = "byteorder")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_byteorder_for_fixed_hash {
@@ -428,7 +428,7 @@ macro_rules! impl_byteorder_for_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `rand` crate feature in
 // a user crate.
-#[cfg(not(feature = "rand-support"))]
+#[cfg(not(feature = "rand"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_rand_for_fixed_hash {
@@ -442,7 +442,7 @@ macro_rules! impl_rand_for_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `rand` crate feature in
 // a user crate.
-#[cfg(feature = "rand-support")]
+#[cfg(feature = "rand")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_rand_for_fixed_hash {
@@ -579,7 +579,7 @@ macro_rules! impl_libc_for_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `rustc-hex` crate feature in
 // a user crate.
-#[cfg(not(feature = "rustc-hex-support"))]
+#[cfg(not(feature = "rustc-hex"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_rustc_hex_for_fixed_hash {
@@ -593,7 +593,7 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `rustc-hex` crate feature in
 // a user crate.
-#[cfg(feature = "rustc-hex-support")]
+#[cfg(feature = "rustc-hex")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_rustc_hex_for_fixed_hash {
@@ -633,7 +633,7 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 // to work around the problems of introducing `heapsize` crate feature in
 // a user crate.
 #[cfg(not(
-	all(feature = "heapsize-support", not(target_os = "unknown"))
+	all(feature = "heapsize", not(target_os = "unknown"))
 ))]
 #[macro_export]
 #[doc(hidden)]
@@ -649,7 +649,7 @@ macro_rules! impl_heapsize_for_fixed_hash {
 // to work around the problems of introducing `heapsize` crate feature in
 // a user crate.
 #[cfg(
-	all(feature = "heapsize-support", not(target_os = "unknown"))
+	all(feature = "heapsize", not(target_os = "unknown"))
 )]
 #[macro_export]
 #[doc(hidden)]
@@ -671,7 +671,7 @@ macro_rules! impl_heapsize_for_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `quickcheck` crate feature in
 // a user crate.
-#[cfg(not(feature = "quickcheck-support"))]
+#[cfg(not(feature = "quickcheck"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_quickcheck_for_fixed_hash {
@@ -685,7 +685,7 @@ macro_rules! impl_quickcheck_for_fixed_hash {
 // Feature guarded macro definitions instead of feature guarded impl blocks
 // to work around the problems of introducing `quickcheck` crate feature in
 // a user crate.
-#[cfg(feature = "quickcheck-support")]
+#[cfg(feature = "quickcheck")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_quickcheck_for_fixed_hash {

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -119,7 +119,7 @@ macro_rules! construct_fixed_hash {
 
 			/// Returns the inner bytes array.
 			#[inline]
-			pub fn to_bytes(self) -> [u8; $n_bytes] {
+			pub fn to_fixed_bytes(self) -> [u8; $n_bytes] {
 				self.0
 			}
 

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -598,7 +598,6 @@ macro_rules! impl_ops_for_hash {
 ///
 /// ```
 /// #[macro_use] extern crate fixed_hash;
-/// #[macro_use] extern crate static_assertions;
 /// construct_fixed_hash!{ struct H160(20); }
 /// construct_fixed_hash!{ struct H256(32); }
 /// impl_fixed_hash_conversions!(H256, H160);

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -117,6 +117,18 @@ macro_rules! construct_fixed_hash {
 				&mut self.0
 			}
 
+			/// Extracts a reference to the byte array containing the entire fixed hash.
+			#[inline]
+			pub fn as_fixed_bytes(&self) -> &[u8; $n_bytes] {
+				&self.0
+			}
+
+			/// Extracts a reference to the byte array containing the entire fixed hash.
+			#[inline]
+			pub fn as_fixed_bytes_mut(&mut self) -> &mut [u8; $n_bytes] {
+				&mut self.0
+			}
+
 			/// Returns the inner bytes array.
 			#[inline]
 			pub fn to_fixed_bytes(self) -> [u8; $n_bytes] {

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -17,7 +17,7 @@ pub extern crate core as core_;
 #[doc(hidden)]
 pub extern crate libc;
 
-#[macro_use]
+#[macro_use(const_assert)]
 #[doc(hidden)]
 pub extern crate static_assertions;
 

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -26,7 +26,7 @@ pub extern crate static_assertions;
 #[doc(hidden)]
 pub use static_assertions::const_assert;
 
-#[cfg(feature = "byteorder-support")]
+#[cfg(feature = "byteorder")]
 #[doc(hidden)]
 pub extern crate byteorder;
 
@@ -34,19 +34,19 @@ pub extern crate byteorder;
 #[doc(hidden)]
 pub mod libc {}
 
-#[cfg(feature = "heapsize-support")]
+#[cfg(feature = "heapsize")]
 #[doc(hidden)]
 pub extern crate heapsize;
 
-#[cfg(feature = "rustc-hex-support")]
+#[cfg(feature = "rustc-hex")]
 #[doc(hidden)]
 pub extern crate rustc_hex;
 
-#[cfg(feature = "rand-support")]
+#[cfg(feature = "rand")]
 #[doc(hidden)]
 pub extern crate rand;
 
-#[cfg(feature = "quickcheck-support")]
+#[cfg(feature = "quickcheck")]
 #[doc(hidden)]
 pub extern crate quickcheck;
 

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+
 #[cfg(all(feature = "libc", not(target_os = "unknown")))]
 #[doc(hidden)]
 pub extern crate libc;
@@ -16,6 +17,9 @@ pub extern crate libc;
 #[doc(hidden)]
 pub extern crate static_assertions;
 
+// Export `const_assert` macro so that users of this crate do not
+// have to import the `static_assertions` crate themselves.
+pub use static_assertions::const_assert;
 #[cfg(feature = "std")]
 #[doc(hidden)]
 pub extern crate core;

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -23,6 +23,7 @@ pub extern crate static_assertions;
 
 // Export `const_assert` macro so that users of this crate do not
 // have to import the `static_assertions` crate themselves.
+#[doc(hidden)]
 pub use static_assertions::const_assert;
 
 #[cfg(feature = "byteorder-support")]

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -18,6 +18,9 @@ pub extern crate core as core_;
 pub extern crate libc;
 
 #[macro_use(const_assert)]
+#[allow(unused)] // This disables a warning for unused #[macro_use(..)]
+                 // which is incorrect since the compiler does not check
+                 // for all available configurations.
 #[doc(hidden)]
 pub extern crate static_assertions;
 

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -8,6 +8,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Re-export libcore using an alias so that the macros can work without
+// requiring `extern crate core` downstream.
+#[doc(hidden)]
+pub extern crate core as core_;
 
 #[cfg(all(feature = "libc", not(target_os = "unknown")))]
 #[doc(hidden)]
@@ -20,9 +24,6 @@ pub extern crate static_assertions;
 // Export `const_assert` macro so that users of this crate do not
 // have to import the `static_assertions` crate themselves.
 pub use static_assertions::const_assert;
-#[cfg(feature = "std")]
-#[doc(hidden)]
-pub extern crate core;
 
 #[cfg(feature = "byteorder-support")]
 #[doc(hidden)]

--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -283,7 +283,7 @@ mod from_str {
 
 	#[test]
 	fn valid() {
-		use core::str::FromStr;
+		use core_::str::FromStr;
 
 		assert_eq!(
 			H64::from_str("0123456789ABCDEF").unwrap(),
@@ -293,19 +293,19 @@ mod from_str {
 
 	#[test]
 	fn empty_str() {
-		use core::str::FromStr;
+		use core_::str::FromStr;
 		assert!(H64::from_str("").is_err())
 	}
 
 	#[test]
 	fn invalid_digits() {
-		use core::str::FromStr;
+		use core_::str::FromStr;
 		assert!(H64::from_str("Hello, World!").is_err())
 	}
 
 	#[test]
 	fn too_many_digits() {
-		use core::str::FromStr;
+		use core_::str::FromStr;
 		assert!(H64::from_str("0123456789ABCDEF0").is_err())
 	}
 }

--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -147,7 +147,7 @@ mod is_zero {
 	}
 }
 
-#[cfg(feature = "byteorder-support")]
+#[cfg(feature = "byteorder")]
 mod to_low_u64 {
 	use super::*;
 
@@ -199,7 +199,7 @@ mod to_low_u64 {
 	}
 }
 
-#[cfg(feature = "byteorder-support")]
+#[cfg(feature = "byteorder")]
 mod from_low_u64 {
 	use super::*;
 
@@ -247,7 +247,7 @@ mod from_low_u64 {
 	}
 }
 
-#[cfg(feature = "rand-support")]
+#[cfg(feature = "rand")]
 mod rand {
 	use super::*;
 	use rand::{SeedableRng, XorShiftRng};
@@ -277,7 +277,7 @@ mod rand {
 	}
 }
 
-#[cfg(feature = "rustc-hex-support")]
+#[cfg(feature = "rustc-hex")]
 mod from_str {
 	use super::*;
 
@@ -311,7 +311,7 @@ mod from_str {
 }
 
 #[cfg(all(
-	feature = "heapsize-support",
+	feature = "heapsize",
 	not(target_os = "unknown")
 ))]
 #[test]
@@ -368,7 +368,7 @@ fn from_h256_to_h160_lossy() {
 	assert_eq!(h160, expected);
 }
 
-#[cfg(all(feature = "std", feature = "byteorder-support"))]
+#[cfg(all(feature = "std", feature = "byteorder"))]
 #[test]
 fn display_and_debug() {
 	fn test_for(x: u64, hex: &'static str, display: &'static str) {


### PR DESCRIPTION
Fixes for the beta of the `0.3` release.

Fixes so far:

- Optional crate features of `fixed-hash` (e.g. `byteorder`, formerly known as `byteorder-support`) no longer leak into user crates. Done by https://github.com/paritytech/parity-common/pull/76/commits/1f94d2747d85c7650534f2b595d908a498d936b6.
- Crate `core` is now publicly exported as `core_`
    - Fixes a bug that `fixed-hash` 0.3.0-beta.0 wasn't usable in `no_std` environments
- Macro `const_assert` is now publicly exported (hidden docs)
    - This has the effect that users no longer need to import `static_assertions` themselves to have this macro in scope
- Add `Hash::to_bytes` method which is especially useful for efficient conversions between `fixed-hash` and `uint`.

**NOTE: THIS IS WORK IN PROGRESS! DO NOT MERGE!**