### PR TITLE
Maintenance of uint sub-crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ script:
   - cargo build --all
   - cargo test --all --exclude uint --exclude fixed-hash
   - cd fixed-hash/ && cargo test --all-features && cd ..
-  - cd uint/ && cargo test --features=std,impl_quickcheck_arbitrary --release && cd ..
+  - cd uint/ && cargo test --features=std,quickcheck-support --release && cd ..
   - cd hashdb/ && cargo test --no-default-features && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ script:
   - cargo build --all
   - cargo test --all --exclude uint --exclude fixed-hash
   - cd fixed-hash/ && cargo test --all-features && cd ..
-  - cd uint/ && cargo test --features=std,quickcheck-support --release && cd ..
+  - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
   - cd hashdb/ && cargo test --no-default-features && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,6 @@ build_script:
 test_script:
   - cargo test --all --features "%FEATURES%" --exclude uint --exclude fixed-hash
   - cd fixed-hash/ && cargo test --all-features && cd ..
-  - cd uint/ && cargo test --features=std,quickcheck-support --release && cd ..
+  - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
   - cd hashdb/ && cargo test --no-default-features && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,6 @@ build_script:
 test_script:
   - cargo test --all --features "%FEATURES%" --exclude uint --exclude fixed-hash
   - cd fixed-hash/ && cargo test --all-features && cd ..
-  - cd uint/ && cargo test --features=std,impl_quickcheck_arbitrary --release && cd ..
+  - cd uint/ && cargo test --features=std,quickcheck-support --release && cd ..
   - cd hashdb/ && cargo test --no-default-features && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -14,10 +14,6 @@ rustc-hex = { version = "2.0", default-features = false }
 quickcheck = { version = "0.6", optional = true }
 crunchy = "0.1"
 
-[dev-dependencies]
-quickcheck = "0.6"
-rustc-hex = "2.0"
-
 [features]
 default = ["std"]
 std = ["byteorder/std", "rustc-hex/std"]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -19,6 +19,7 @@ quickcheck = "0.6"
 rustc-hex = "2.0"
 
 [features]
+default = ["std"]
 std = ["byteorder/std", "rustc-hex/std"]
 heapsizeof = ["heapsize"]
 impl_quickcheck_arbitrary = ["quickcheck"]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -16,8 +16,9 @@ quickcheck = { version = "0.6", optional = true }
 crunchy = "0.2"
 
 [features]
-default = ["std"]
+default = ["std", "common"]
 std = ["byteorder/std", "rustc-hex/std"]
+common = []
 
 [[example]]
 name = "modular"

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -21,8 +21,8 @@ rustc-hex = "2.0"
 [features]
 default = ["std"]
 std = ["byteorder/std", "rustc-hex/std"]
-heapsizeof = ["heapsize"]
-impl_quickcheck_arbitrary = ["quickcheck"]
+heapsize-support = ["heapsize"]
+quickcheck-support = ["quickcheck"]
 
 [[example]]
 name = "modular"
@@ -31,4 +31,3 @@ required-features = ["std"]
 [[test]]
 name = "uint_tests"
 required-features = ["std"]
-

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -21,8 +21,6 @@ std = ["byteorder/std", "rustc-hex/std"]
 
 [[example]]
 name = "modular"
-required-features = ["std"]
 
 [[test]]
 name = "uint_tests"
-required-features = ["std"]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 readme = "README.md"
 

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -25,3 +25,4 @@ name = "modular"
 
 [[test]]
 name = "uint_tests"
+required-features = ["std", "common"]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 readme = "README.md"
 

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -13,11 +13,11 @@ byteorder = { version = "1", default-features = false }
 heapsize = { version = "0.4.2", optional = true }
 rustc-hex = { version = "2.0", default-features = false }
 quickcheck = { version = "0.6", optional = true }
-crunchy = "0.2"
+crunchy = { version = "0.2", default-features = true }
 
 [features]
 default = ["std", "common"]
-std = ["byteorder/std", "rustc-hex/std"]
+std = ["byteorder/std", "rustc-hex/std", "crunchy/std"]
 common = []
 
 [[example]]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -12,7 +12,7 @@ byteorder = { version = "1", default-features = false }
 heapsize = { version = "0.4.2", optional = true }
 rustc-hex = { version = "2.0", default-features = false }
 quickcheck = { version = "0.6", optional = true }
-crunchy = "0.1"
+crunchy = "0.2"
 
 [features]
 default = ["std"]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.5.0-beta.0"
+version = "0.5.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 readme = "README.md"
 

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.5.0"
+version = "0.5.0-beta.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 readme = "README.md"
 

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -18,8 +18,6 @@ crunchy = "0.2"
 [features]
 default = ["std"]
 std = ["byteorder/std", "rustc-hex/std"]
-heapsize-support = ["heapsize"]
-quickcheck-support = ["quickcheck"]
 
 [[example]]
 name = "modular"

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT/Apache-2.0"
 name = "uint"
 version = "0.4.1"
 authors = ["Parity Technologies <admin@parity.io>"]
+readme = "README.md"
 
 [dependencies]
 byteorder = { version = "1", default-features = false }

--- a/uint/README.md
+++ b/uint/README.md
@@ -1,8 +1,56 @@
-# Big unsigned integer types
+# Uint Big unsigned integer types
 
-Macros to implement large-but-fixed sized unsigned integer types.
-The functions here are designed to be fast.
+## Description
 
-The crate builds and exports two commonly used types: `U256` and `U512`. Other sizes can be constructed with `construct_uint!(NAME, SIZE_IN_WORDS)`, e.g. `construct_uint!(U128, 2);`.
+Provides facilities to construct big unsigned integer types.
+Also provides commonly used `U256` and `U512` out of the box.
 
-Run tests with `cargo test --features=std,impl_quickcheck_arbitrary --release`.
+The focus on the provided big unsigned integer types is performance and cross-platform availability.
+Support a very similar API as the built-in primitive integer types.
+
+## Usage
+
+In your `Cargo.toml` paste
+
+```
+uint = "0.5"
+```
+
+Construct your own big unsigned integer type as follows.
+
+```
+// U1024 with 1024 bits consisting of 16 x 64-bit words
+construct_uint!(U1024; 16);
+```
+
+## Tests
+
+### Basic tests
+
+```
+cargo test --release
+```
+
+### Basic tests + property tests
+
+```
+cargo test --release --features=quickcheck
+```
+
+### Benchmark tests
+
+```
+cargo bench
+```
+
+## Crate Features
+
+- `std`: Use Rust's standard library.
+	- Enables `byteorder/std`, `rustc-hex/std`
+	- Enabled by default.
+- `common`: Provide commonly used `U256` and `U512` big unsigned integer types.
+	- Enabled by default.
+- `quickcheck`: Enable quickcheck-style property testing
+	- Use with `cargo test --release --features=quickcheck`.
+- `heapsize`: Implement base trait of the `heapsizeof` crate
+	- Use with `cargo build --feature=heapsize`.

--- a/uint/README.md
+++ b/uint/README.md
@@ -13,7 +13,7 @@ Support a very similar API as the built-in primitive integer types.
 In your `Cargo.toml` paste
 
 ```
-uint = "0.5"
+uint = "0.5.0-beta"
 ```
 
 Construct your own big unsigned integer type as follows.

--- a/uint/README.md
+++ b/uint/README.md
@@ -1,4 +1,4 @@
-# Uint Big unsigned integer types
+# Uint
 
 ## Description
 

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -8,7 +8,7 @@
 
 //! Efficient large, fixed-size big integers and hashes.
 
-#![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
 pub extern crate byteorder;
@@ -17,7 +17,7 @@ pub extern crate byteorder;
 #[doc(hidden)]
 pub extern crate heapsize;
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 #[doc(hidden)]
 pub extern crate core;
 

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -13,7 +13,7 @@
 #[doc(hidden)]
 pub extern crate byteorder;
 
-#[cfg(feature="heapsize-support")]
+#[cfg(feature="heapsize")]
 #[doc(hidden)]
 pub extern crate heapsize;
 

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -24,7 +24,7 @@ pub extern crate core;
 #[doc(hidden)]
 pub extern crate rustc_hex;
 
-#[cfg(feature="quickcheck-support")]
+#[cfg(feature="quickcheck")]
 #[doc(hidden)]
 pub extern crate quickcheck;
 

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -32,10 +32,25 @@ pub extern crate quickcheck;
 #[macro_use]
 extern crate crunchy;
 
+#[macro_use]
 mod uint;
-
-#[cfg(feature = "common")]
 pub use uint::*;
 
-#[cfg(not(feature = "common"))]
-pub(crate) use uint::*;
+#[cfg(feature = "common")]
+mod common {
+	construct_uint!(U256, 4);
+	construct_uint!(U512, 8);
+
+	#[doc(hidden)]
+	impl U256 {
+		/// Multiplies two 256-bit integers to produce full 512-bit integer
+		/// No overflow possible
+		#[inline(always)]
+		pub fn full_mul(self, other: U256) -> U512 {
+			U512(uint_full_mul_reg!(U256, 4, self, other))
+		}
+	}
+}
+
+#[cfg(feature = "common")]
+pub use common::{U256, U512};

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -13,7 +13,7 @@
 #[doc(hidden)]
 pub extern crate byteorder;
 
-#[cfg(feature="heapsizeof")]
+#[cfg(feature="heapsize-support")]
 #[doc(hidden)]
 pub extern crate heapsize;
 
@@ -24,7 +24,7 @@ pub extern crate core;
 #[doc(hidden)]
 pub extern crate rustc_hex;
 
-#[cfg(feature="impl_quickcheck_arbitrary")]
+#[cfg(feature="quickcheck-support")]
 #[doc(hidden)]
 pub extern crate quickcheck;
 

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -32,4 +32,9 @@ pub extern crate quickcheck;
 extern crate crunchy;
 
 mod uint;
+
+#[cfg(feature = "common")]
 pub use uint::*;
+
+#[cfg(not(feature = "common"))]
+pub(crate) use uint::*;

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -17,9 +17,10 @@ pub extern crate byteorder;
 #[doc(hidden)]
 pub extern crate heapsize;
 
-#[cfg(feature = "std")]
+// Re-export libcore using an alias so that the macros can work without
+// requiring `extern crate core` downstream.
 #[doc(hidden)]
-pub extern crate core;
+pub extern crate core as core_;
 
 #[doc(hidden)]
 pub extern crate rustc_hex;

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -87,13 +87,13 @@ macro_rules! uint_overflowing_binop {
 		let $name(ref me) = $self_expr;
 		let $name(ref you) = $other;
 
-		let mut ret = unsafe { ::core::mem::uninitialized() };
+		let mut ret = unsafe { $crate::core_::mem::uninitialized() };
 		let ret_ptr = &mut ret as *mut [u64; $n_words] as *mut u64;
 		let mut carry = 0u64;
 
 		unroll! {
 			for i in 0..$n_words {
-				use ::core::ptr;
+				use $crate::core_::ptr;
 
 				if carry != 0 {
 					let (res1, overflow1) = ($fn)(me[i], you[i]);
@@ -208,7 +208,7 @@ macro_rules! uint_overflowing_mul_reg {
 		let ret: [u64; $n_words * 2] = uint_full_mul_reg!($name, $n_words, $self_expr, $other);
 
 		// The safety of this is enforced by the compiler
-		let ret: [[u64; $n_words]; 2] = unsafe { ::core::mem::transmute(ret) };
+		let ret: [[u64; $n_words]; 2] = unsafe { $crate::core_::mem::transmute(ret) };
 
 		// The compiler WILL NOT inline this if you remove this annotation.
 		#[inline(always)]
@@ -260,7 +260,7 @@ macro_rules! panic_on_overflow {
 #[doc(hidden)]
 macro_rules! impl_mul_from {
 	($name: ty, $other: ident) => {
-		impl ::core::ops::Mul<$other> for $name {
+		impl $crate::core_::ops::Mul<$other> for $name {
 			type Output = $name;
 
 			fn mul(self, other: $other) -> $name {
@@ -271,7 +271,7 @@ macro_rules! impl_mul_from {
 			}
 		}
 
-		impl<'a> ::core::ops::Mul<&'a $other> for $name {
+		impl<'a> $crate::core_::ops::Mul<&'a $other> for $name {
 			type Output = $name;
 
 			fn mul(self, other: &'a $other) -> $name {
@@ -282,7 +282,7 @@ macro_rules! impl_mul_from {
 			}
 		}
 
-		impl<'a> ::core::ops::Mul<&'a $other> for &'a $name {
+		impl<'a> $crate::core_::ops::Mul<&'a $other> for &'a $name {
 			type Output = $name;
 
 			fn mul(self, other: &'a $other) -> $name {
@@ -293,7 +293,7 @@ macro_rules! impl_mul_from {
 			}
 		}
 
-		impl<'a> ::core::ops::Mul<$other> for &'a $name {
+		impl<'a> $crate::core_::ops::Mul<$other> for &'a $name {
 			type Output = $name;
 
 			fn mul(self, other: $other) -> $name {
@@ -310,7 +310,7 @@ macro_rules! impl_mul_from {
 #[doc(hidden)]
 macro_rules! impl_mulassign_from {
 	($name: ident, $other: ident) => {
-		impl::core::ops::MulAssign<$other> for $name {
+		impl $crate::core_::ops::MulAssign<$other> for $name {
 			fn mul_assign(&mut self, other: $other) {
 				let result = *self * other;
 				*self = result
@@ -765,7 +765,7 @@ macro_rules! construct_uint {
 
 				let mut ret = [0; $n_words];
 				unsafe {
-					let ret_u8: &mut [u8; $n_words * 8] = ::core::mem::transmute(&mut ret);
+					let ret_u8: &mut [u8; $n_words * 8] = $crate::core_::mem::transmute(&mut ret);
 					let mut ret_ptr = ret_u8.as_mut_ptr();
 					let mut slice_ptr = slice.as_ptr().offset(slice.len() as isize - 1);
 					for _ in 0..slice.len() {
@@ -784,7 +784,7 @@ macro_rules! construct_uint {
 
 				let mut ret = [0; $n_words];
 				unsafe {
-					let ret_u8: &mut [u8; $n_words * 8] = ::core::mem::transmute(&mut ret);
+					let ret_u8: &mut [u8; $n_words * 8] = $crate::core_::mem::transmute(&mut ret);
 					ret_u8[0..slice.len()].copy_from_slice(&slice);
 				}
 
@@ -792,7 +792,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl From<$name> for [u8; $n_words * 8] {
+		impl $crate::core_::convert::From<$name> for [u8; $n_words * 8] {
 			fn from(number: $name) -> Self {
 				let mut arr = [0u8; $n_words * 8];
 				number.to_big_endian(&mut arr);
@@ -800,25 +800,25 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl From<[u8; $n_words * 8]> for $name {
+		impl $crate::core_::convert::From<[u8; $n_words * 8]> for $name {
 			fn from(bytes: [u8; $n_words * 8]) -> Self {
 				bytes[..].as_ref().into()
 			}
 		}
 
-		impl<'a> From<&'a [u8; $n_words * 8]> for $name {
+		impl<'a> $crate::core_::convert::From<&'a [u8; $n_words * 8]> for $name {
 			fn from(bytes: &[u8; $n_words * 8]) -> Self {
 				bytes[..].into()
 			}
 		}
 
-		impl Default for $name {
+		impl $crate::core_::default::Default for $name {
 			fn default() -> Self {
 				$name::zero()
 			}
 		}
 
-		impl From<u64> for $name {
+		impl $crate::core_::convert::From<u64> for $name {
 			fn from(value: u64) -> $name {
 				let mut ret = [0; $n_words];
 				ret[0] = value;
@@ -832,7 +832,7 @@ macro_rules! construct_uint {
 		impl_map_from!($name, u32, u64);
 		impl_map_from!($name, usize, u64);
 
-		impl From<i64> for $name {
+		impl $crate::core_::convert::From<i64> for $name {
 			fn from(value: i64) -> $name {
 				match value >= 0 {
 					true => From::from(value as u64),
@@ -847,13 +847,13 @@ macro_rules! construct_uint {
 		impl_map_from!($name, isize, i64);
 
 		// Converts from big endian representation of U256
-		impl<'a> From<&'a [u8]> for $name {
+		impl<'a> $crate::core_::convert::From<&'a [u8]> for $name {
 			fn from(bytes: &[u8]) -> $name {
 				Self::from_big_endian(bytes)
 			}
 		}
 
-		impl<T> ::core::ops::Add<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::Add<T> for $name where T: Into<$name> {
 			type Output = $name;
 
 			fn add(self, other: T) -> $name {
@@ -863,7 +863,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<'a, T> ::core::ops::Add<T> for &'a $name where T: Into<$name> {
+		impl<'a, T> $crate::core_::ops::Add<T> for &'a $name where T: Into<$name> {
 			type Output = $name;
 
 			fn add(self, other: T) -> $name {
@@ -871,7 +871,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl ::core::ops::AddAssign<$name> for $name {
+		impl $crate::core_::ops::AddAssign<$name> for $name {
 			fn add_assign(&mut self, other: $name) {
 				let (result, overflow) = self.overflowing_add(other);
 				panic_on_overflow!(overflow);
@@ -879,7 +879,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<T> ::core::ops::Sub<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::Sub<T> for $name where T: Into<$name> {
 			type Output = $name;
 
 			#[inline]
@@ -890,7 +890,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<'a, T> ::core::ops::Sub<T> for &'a $name where T: Into<$name> {
+		impl<'a, T> $crate::core_::ops::Sub<T> for &'a $name where T: Into<$name> {
 			type Output = $name;
 
 			fn sub(self, other: T) -> $name {
@@ -898,7 +898,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl ::core::ops::SubAssign<$name> for $name {
+		impl $crate::core_::ops::SubAssign<$name> for $name {
 			fn sub_assign(&mut self, other: $name) {
 				let (result, overflow) = self.overflowing_sub(other);
 				panic_on_overflow!(overflow);
@@ -907,7 +907,7 @@ macro_rules! construct_uint {
 		}
 
 		// specialization for u32
-		impl ::core::ops::Mul<u32> for $name {
+		impl $crate::core_::ops::Mul<u32> for $name {
 			type Output = $name;
 
 			fn mul(self, other: u32) -> $name {
@@ -917,7 +917,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<'a> ::core::ops::Mul<u32> for &'a $name {
+		impl<'a> $crate::core_::ops::Mul<u32> for &'a $name {
 			type Output = $name;
 
 			fn mul(self, other: u32) -> $name {
@@ -925,7 +925,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl ::core::ops::MulAssign<u32> for $name {
+		impl $crate::core_::ops::MulAssign<u32> for $name {
 			fn mul_assign(&mut self, other: u32) {
 				let result = *self * other;
 				*self = result
@@ -957,7 +957,7 @@ macro_rules! construct_uint {
 
 		impl_mulassign_from!($name, $name);
 
-		impl<T> ::core::ops::Div<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::Div<T> for $name where T: Into<$name> {
 			type Output = $name;
 
 			fn div(self, other: T) -> $name {
@@ -994,7 +994,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<'a, T> ::core::ops::Div<T> for &'a $name where T: Into<$name> {
+		impl<'a, T> $crate::core_::ops::Div<T> for &'a $name where T: Into<$name> {
 			type Output = $name;
 
 			fn div(self, other: T) -> $name {
@@ -1002,13 +1002,13 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<T> ::core::ops::DivAssign<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::DivAssign<T> for $name where T: Into<$name> {
 			fn div_assign(&mut self, other: T) {
 				*self = *self / other.into();
 			}
 		}
 
-		impl<T> ::core::ops::Rem<T> for $name where T: Into<$name> + Copy {
+		impl<T> $crate::core_::ops::Rem<T> for $name where T: Into<$name> + Copy {
 			type Output = $name;
 
 			fn rem(self, other: T) -> $name {
@@ -1017,7 +1017,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<'a, T> ::core::ops::Rem<T> for &'a $name where T: Into<$name>  + Copy {
+		impl<'a, T> $crate::core_::ops::Rem<T> for &'a $name where T: Into<$name>  + Copy {
 			type Output = $name;
 
 			fn rem(self, other: T) -> $name {
@@ -1025,14 +1025,14 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<T> ::core::ops::RemAssign<T> for $name where T: Into<$name> + Copy {
+		impl<T> $crate::core_::ops::RemAssign<T> for $name where T: Into<$name> + Copy {
 			fn rem_assign(&mut self, other: T) {
 				let times = *self / other;
 				*self -= times * other.into()
 			}
 		}
 
-		impl ::core::ops::BitAnd<$name> for $name {
+		impl $crate::core_::ops::BitAnd<$name> for $name {
 			type Output = $name;
 
 			#[inline]
@@ -1047,7 +1047,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl ::core::ops::BitXor<$name> for $name {
+		impl $crate::core_::ops::BitXor<$name> for $name {
 			type Output = $name;
 
 			#[inline]
@@ -1062,7 +1062,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl ::core::ops::BitOr<$name> for $name {
+		impl $crate::core_::ops::BitOr<$name> for $name {
 			type Output = $name;
 
 			#[inline]
@@ -1077,7 +1077,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl ::core::ops::Not for $name {
+		impl $crate::core_::ops::Not for $name {
 			type Output = $name;
 
 			#[inline]
@@ -1091,7 +1091,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<T> ::core::ops::Shl<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::Shl<T> for $name where T: Into<$name> {
 			type Output = $name;
 
 			fn shl(self, shift: T) -> $name {
@@ -1115,20 +1115,20 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<'a, T> ::core::ops::Shl<T> for &'a $name where T: Into<$name> {
+		impl<'a, T> $crate::core_::ops::Shl<T> for &'a $name where T: Into<$name> {
 			type Output = $name;
 			fn shl(self, shift: T) -> $name {
 				*self << shift
 			}
 		}
 
-		impl<T> ::core::ops::ShlAssign<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::ShlAssign<T> for $name where T: Into<$name> {
 			fn shl_assign(&mut self, shift: T) {
 				*self = *self << shift;
 			}
 		}
 
-		impl<T> ::core::ops::Shr<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::Shr<T> for $name where T: Into<$name> {
 			type Output = $name;
 
 			fn shr(self, shift: T) -> $name {
@@ -1154,35 +1154,35 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl<'a, T> ::core::ops::Shr<T> for &'a $name where T: Into<$name> {
+		impl<'a, T> $crate::core_::ops::Shr<T> for &'a $name where T: Into<$name> {
 			type Output = $name;
 			fn shr(self, shift: T) -> $name {
 				*self >> shift
 			}
 		}
 
-		impl<T> ::core::ops::ShrAssign<T> for $name where T: Into<$name> {
+		impl<T> $crate::core_::ops::ShrAssign<T> for $name where T: Into<$name> {
 			fn shr_assign(&mut self, shift: T) {
 				*self = *self >> shift;
 			}
 		}
 
-		impl Ord for $name {
-			fn cmp(&self, other: &$name) -> ::core::cmp::Ordering {
+		impl $crate::core_::cmp::Ord for $name {
+			fn cmp(&self, other: &$name) -> $crate::core_::cmp::Ordering {
 				let &$name(ref me) = self;
 				let &$name(ref you) = other;
 				let mut i = $n_words;
 				while i > 0 {
 					i -= 1;
-					if me[i] < you[i] { return ::core::cmp::Ordering::Less; }
-					if me[i] > you[i] { return ::core::cmp::Ordering::Greater; }
+					if me[i] < you[i] { return $crate::core_::cmp::Ordering::Less; }
+					if me[i] > you[i] { return $crate::core_::cmp::Ordering::Greater; }
 				}
-				::core::cmp::Ordering::Equal
+				$crate::core_::cmp::Ordering::Equal
 			}
 		}
 
-		impl PartialOrd for $name {
-			fn partial_cmp(&self, other: &$name) -> Option<::core::cmp::Ordering> {
+		impl $crate::core_::cmp::PartialOrd for $name {
+			fn partial_cmp(&self, other: &$name) -> Option<$crate::core_::cmp::Ordering> {
 				Some(self.cmp(other))
 			}
 		}
@@ -1200,16 +1200,16 @@ macro_rules! construct_uint {
 #[doc(hidden)]
 macro_rules! impl_std_for_uint {
 	($name: ident, $n_words: tt) => {
-		impl ::core::fmt::Debug for $name {
-			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-				::core::fmt::Display::fmt(self, f)
+		impl $crate::core_::fmt::Debug for $name {
+			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
+				$crate::core_::fmt::Display::fmt(self, f)
 			}
 		}
 
-		impl ::core::fmt::Display for $name {
-			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+		impl $crate::core_::fmt::Display for $name {
+			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
 				if self.is_zero() {
-					return write!(f, "0");
+					return $crate::core_::write!(f, "0");
 				}
 
 				let mut buf = [0_u8; $n_words*20];
@@ -1248,15 +1248,15 @@ macro_rules! impl_std_for_uint {
 			}
 		}
 
-		impl ::core::fmt::LowerHex for $name {
-			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+		impl $crate::core_::fmt::LowerHex for $name {
+			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
 				let &$name(ref data) = self;
 				if f.alternate() {
-					write!(f, "0x")?;
+					$crate::core_::write!(f, "0x")?;
 				}
 				// special case.
 				if self.is_zero() {
-					return write!(f, "0");
+					return $crate::core_::write!(f, "0");
 				}
 
 				let mut latch = false;
@@ -1268,7 +1268,7 @@ macro_rules! impl_std_for_uint {
 						}
 
 						if latch {
-							write!(f, "{:x}", nibble)?;
+							$crate::core_::write!(f, "{:x}", nibble)?;
 						}
 					}
 				}
@@ -1276,7 +1276,7 @@ macro_rules! impl_std_for_uint {
 			}
 		}
 
-		impl From<&'static str> for $name {
+		impl $crate::core_::convert::From<&'static str> for $name {
 			fn from(s: &'static str) -> Self {
 				s.parse().unwrap()
 			}
@@ -1284,7 +1284,7 @@ macro_rules! impl_std_for_uint {
 	}
 }
 
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_std_for_uint {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1346,16 +1346,3 @@ macro_rules! impl_quickcheck_arbitrary_for_uint {
 macro_rules! impl_quickcheck_arbitrary_for_uint {
 	($uint: ty, $n_bytes: tt) => {}
 }
-
-construct_uint!(U256, 4);
-construct_uint!(U512, 8);
-
-#[doc(hidden)]
-impl U256 {
-	/// Multiplies two 256-bit integers to produce full 512-bit integer
-	/// No overflow possible
-	#[inline(always)]
-	pub fn full_mul(self, other: U256) -> U512 {
-		U512(uint_full_mul_reg!(U256, 4, self, other))
-	}
-}

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -737,12 +737,6 @@ macro_rules! construct_uint {
 				}
 			}
 
-			/// Multiplication by u32.
-			#[deprecated(note = "Use Mul<u32> instead.")]
-			pub fn mul_u32(self, other: u32) -> Self {
-				self * other
-			}
-
 			/// Overflowing multiplication by u32.
 			fn overflowing_mul_u32(self, other: u32) -> (Self, bool) {
 				let $name(ref arr) = self;

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1314,7 +1314,7 @@ macro_rules! impl_std_for_uint {
 }
 
 
-#[cfg(feature="heapsize-support")]
+#[cfg(feature="heapsize")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_heapsize_for_uint {
@@ -1327,7 +1327,7 @@ macro_rules! impl_heapsize_for_uint {
 	}
 }
 
-#[cfg(not(feature="heapsize-support"))]
+#[cfg(not(feature="heapsize"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_heapsize_for_uint {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1314,7 +1314,7 @@ macro_rules! impl_std_for_uint {
 }
 
 
-#[cfg(feature="heapsizeof")]
+#[cfg(feature="heapsize-support")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_heapsize_for_uint {
@@ -1327,14 +1327,14 @@ macro_rules! impl_heapsize_for_uint {
 	}
 }
 
-#[cfg(not(feature="heapsizeof"))]
+#[cfg(not(feature="heapsize-support"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_heapsize_for_uint {
 	($name: ident) => {}
 }
 
-#[cfg(feature="impl_quickcheck_arbitrary")]
+#[cfg(feature="quickcheck-support")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_quickcheck_arbitrary_for_uint {
@@ -1367,7 +1367,7 @@ macro_rules! impl_quickcheck_arbitrary_for_uint {
 	}
 }
 
-#[cfg(not(feature="impl_quickcheck_arbitrary"))]
+#[cfg(not(feature="quickcheck-support"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_quickcheck_arbitrary_for_uint {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -759,8 +759,6 @@ macro_rules! construct_uint {
 				($name(ret), carry > 0)
 			}
 
-			impl_std_for_uint_internals!($name, $n_words);
-
 			/// Converts from big endian representation bytes in memory.
 			pub fn from_big_endian(slice: &[u8]) -> Self {
 				assert!($n_words * 8 >= slice.len());
@@ -1195,26 +1193,6 @@ macro_rules! construct_uint {
 		// uints use 64 bit (8 byte) words
 		impl_quickcheck_arbitrary_for_uint!($name, ($n_words * 8));
 	);
-}
-
-#[cfg(feature="std")]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! impl_std_for_uint_internals {
-	($name: ident, $n_words: tt) => {
-		/// Convert to hex string.
-		#[deprecated(note = "Use LowerHex instead.")]
-		pub fn to_hex(&self) -> String {
-			format!("{:x}", self)
-		}
-	}
-}
-
-#[cfg(not(feature="std"))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! impl_std_for_uint_internals {
-	($name: ident, $n_words: tt) => {}
 }
 
 #[cfg(feature="std")]

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1334,7 +1334,7 @@ macro_rules! impl_heapsize_for_uint {
 	($name: ident) => {}
 }
 
-#[cfg(feature="quickcheck-support")]
+#[cfg(feature="quickcheck")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_quickcheck_arbitrary_for_uint {
@@ -1367,7 +1367,7 @@ macro_rules! impl_quickcheck_arbitrary_for_uint {
 	}
 }
 
-#[cfg(not(feature="quickcheck-support"))]
+#[cfg(not(feature="quickcheck"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_quickcheck_arbitrary_for_uint {

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -4,7 +4,8 @@ extern crate core;
 extern crate uint;
 #[macro_use]
 extern crate crunchy;
-#[cfg(feature = "impl_quickcheck_arbitrary")]
+
+#[cfg(feature = "quickcheck-support")]
 #[macro_use]
 extern crate quickcheck;
 
@@ -1029,7 +1030,7 @@ fn trailing_zeros() {
 	assert_eq!(U256::from("0000000000000000000000000000000000000000000000000000000000000000").trailing_zeros(), 256);
 }
 
-#[cfg(feature="impl_quickcheck_arbitrary")]
+#[cfg(feature="quickcheck-support")]
 pub mod laws {
 	macro_rules! uint_laws {
 		($mod_name:ident, $uint_ty:ident) => {

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -5,7 +5,7 @@ extern crate uint;
 #[macro_use]
 extern crate crunchy;
 
-#[cfg(feature = "quickcheck-support")]
+#[cfg(feature = "quickcheck")]
 #[macro_use]
 extern crate quickcheck;
 
@@ -1030,7 +1030,7 @@ fn trailing_zeros() {
 	assert_eq!(U256::from("0000000000000000000000000000000000000000000000000000000000000000").trailing_zeros(), 256);
 }
 
-#[cfg(feature="quickcheck-support")]
+#[cfg(feature="quickcheck")]
 pub mod laws {
 	macro_rules! uint_laws {
 		($mod_name:ident, $uint_ty:ident) => {

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -2,12 +2,13 @@ extern crate core;
 
 #[macro_use]
 extern crate uint;
-#[macro_use]
-extern crate crunchy;
 
 #[cfg(feature = "quickcheck")]
 #[macro_use]
 extern crate quickcheck;
+
+#[cfg_attr(all(test, feature = "quickcheck"), macro_use(unroll))]
+extern crate crunchy;
 
 use core::u64::MAX;
 use core::str::FromStr;

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -316,16 +316,6 @@ fn uint256_mul32() {
 }
 
 #[test]
-#[allow(deprecated)]
-fn uint256_mul32_old() {
-	assert_eq!(U256::from(0u64).mul_u32(2), U256::from(0u64));
-	assert_eq!(U256::from(1u64).mul_u32(2), U256::from(2u64));
-	assert_eq!(U256::from(10u64).mul_u32(2), U256::from(20u64));
-	assert_eq!(U256::from(10u64).mul_u32(5), U256::from(50u64));
-	assert_eq!(U256::from(1000u64).mul_u32(50), U256::from(50000u64));
-}
-
-#[test]
 fn uint256_pow() {
 	assert_eq!(U256::from(10).pow(U256::from(0)), U256::from(1));
 	assert_eq!(U256::from(10).pow(U256::from(1)), U256::from(10));


### PR DESCRIPTION
### Summary

- Crate libcore is now publicly exported always as `core_`
    - Work-around for `#[no_std]` mode that does not export publicly by default
- Remove unused `dev-dependencies`
- Update `crunchy` from `0.1` to `0.2`
    - Also `crunchy` is no longer always compiled in `std` mode
- Enable `std` feature by default (as its being done in other `#[no_std]` crates
- Modernize `README`
- Add `common` feature
    - Makes `U256` and `U512` definitions publicly available
    - Enabled by default
    - Useful if you do not need those types in your crate
- Add `readme` field to `Cargo.toml`
- Remove deprecated items
    - `Uint::to_hex`
    - `Uint::mul_u32`