### PR TITLE
Allow private uint definition and crunchy convenience fix

### DIFF
--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -18,11 +18,10 @@ crunchy = { version = "0.2", default-features = true }
 [features]
 default = ["std"]
 std = ["byteorder/std", "rustc-hex/std", "crunchy/std"]
-common = []
 
 [[example]]
 name = "modular"
 
 [[test]]
 name = "uint_tests"
-required-features = ["std", "common"]
+required-features = ["std"]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -16,7 +16,7 @@ quickcheck = { version = "0.6", optional = true }
 crunchy = { version = "0.2", default-features = true }
 
 [features]
-default = ["std", "common"]
+default = ["std"]
 std = ["byteorder/std", "rustc-hex/std", "crunchy/std"]
 common = []
 

--- a/uint/benches/bigint.rs
+++ b/uint/benches/bigint.rs
@@ -16,9 +16,23 @@
 
 extern crate core;
 extern crate test;
+#[macro_use]
 extern crate uint;
 
-use uint::{U256, U512};
+construct_uint! {
+	pub struct U256(4);
+}
+
+construct_uint! {
+	pub struct U512(8);
+}
+
+impl U256 {
+	#[inline(always)]
+	pub fn full_mul(self, other: U256) -> U512 {
+		U512(uint_full_mul_reg!(U256, 4, self, other))
+	}
+}
 
 use test::{Bencher, black_box};
 

--- a/uint/examples/modular.rs
+++ b/uint/examples/modular.rs
@@ -10,12 +10,11 @@
 extern crate core;
 
 #[macro_use]
-extern crate crunchy;
-
-#[macro_use]
 extern crate uint;
 
-construct_uint!(U256, 4);
+construct_uint! {
+	pub struct U256(4);
+}
 
 fn main() {
 	// Example modular arithmetic using bigint U256 primitives

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -29,8 +29,8 @@ pub extern crate rustc_hex;
 #[doc(hidden)]
 pub extern crate quickcheck;
 
-#[macro_use]
 extern crate crunchy;
+pub use crunchy::unroll;
 
 #[macro_use]
 mod uint;
@@ -38,8 +38,15 @@ pub use uint::*;
 
 #[cfg(feature = "common")]
 mod common {
-	construct_uint!(U256, 4);
-	construct_uint!(U512, 8);
+	construct_uint! {
+		/// Little-endian 256-bit integer type.
+		pub struct U256(4);
+	}
+
+	construct_uint! {
+		/// Little-endian 512-bit integer type.
+		pub struct U512(8);
+	}
 
 	#[doc(hidden)]
 	impl U256 {

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -38,6 +38,8 @@ pub use uint::*;
 
 #[cfg(feature = "common")]
 mod common {
+	use super::unroll;
+
 	construct_uint! {
 		/// Little-endian 256-bit integer type.
 		pub struct U256(4);

--- a/uint/src/lib.rs
+++ b/uint/src/lib.rs
@@ -35,31 +35,3 @@ pub use crunchy::unroll;
 #[macro_use]
 mod uint;
 pub use uint::*;
-
-#[cfg(feature = "common")]
-mod common {
-	use super::unroll;
-
-	construct_uint! {
-		/// Little-endian 256-bit integer type.
-		pub struct U256(4);
-	}
-
-	construct_uint! {
-		/// Little-endian 512-bit integer type.
-		pub struct U512(8);
-	}
-
-	#[doc(hidden)]
-	impl U256 {
-		/// Multiplies two 256-bit integers to produce full 512-bit integer
-		/// No overflow possible
-		#[inline(always)]
-		pub fn full_mul(self, other: U256) -> U512 {
-			U512(uint_full_mul_reg!(U256, 4, self, other))
-		}
-	}
-}
-
-#[cfg(feature = "common")]
-pub use common::{U256, U512};

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -346,11 +346,12 @@ pub fn split_u128(a: u128) -> (u64, u64) {
 
 #[macro_export]
 macro_rules! construct_uint {
-	($name:ident, $n_words: tt) => (
+	( $(#[$attr:meta])* $visibility:vis struct $name:ident ( $n_words:tt ); ) => {
 		/// Little-endian large integer type
 		#[repr(C)]
+		$(#[$attr])*
 		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-		pub struct $name(pub [u64; $n_words]);
+		$visibility struct $name ([u64; $n_words]);
 
 		impl AsRef<$name> for $name {
 			fn as_ref(&self) -> &$name {
@@ -1271,7 +1272,7 @@ macro_rules! construct_uint {
 		// `$n_words * 8` because macro expects bytes and
 		// uints use 64 bit (8 byte) words
 		impl_quickcheck_arbitrary_for_uint!($name, ($n_words * 8));
-	);
+	}
 }
 
 #[cfg(feature = "std")]

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -351,7 +351,7 @@ macro_rules! construct_uint {
 		#[repr(C)]
 		$(#[$attr])*
 		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-		$visibility struct $name ([u64; $n_words]);
+		$visibility struct $name (pub [u64; $n_words]);
 
 		impl AsRef<$name> for $name {
 			fn as_ref(&self) -> &$name {

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -12,7 +12,15 @@ extern crate crunchy;
 
 use core::u64::MAX;
 use core::str::FromStr;
-use uint::{U256, U512, FromDecStrErr};
+use uint::{FromDecStrErr};
+
+construct_uint! {
+	pub struct U256(4);
+}
+
+construct_uint! {
+	pub struct U512(8);
+}
 
 #[test]
 fn uint256_checked_ops() {

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -1196,10 +1196,18 @@ pub mod laws {
 		}
 	}
 
-	construct_uint!(U64, 1);
-	construct_uint!(U256, 4);
-	construct_uint!(U512, 8);
-	construct_uint!(U1024, 16);
+	construct_uint! {
+		pub struct U64(1);
+	}
+	construct_uint! {
+		pub struct U256(4);
+	}
+	construct_uint! {
+		pub struct U512(8);
+	}
+	construct_uint! {
+		pub struct U1024(16);
+	}
 
 	uint_laws!(u64, U64);
 	uint_laws!(u256, U256);


### PR DESCRIPTION
* Use macro reexport feature so that crates that depends on uint doesn't need to declare crunchy dep any more.
* Change construct_uint definition to match `fixed-hash` so that users can add docs, visibility, and additional attributes.
* Remove `common` feature from default -- it's not usually used.