### PR TITLE
Bump primitive-types and uint version

### DIFF
--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 readme = "README.md"
 


### PR DESCRIPTION
Bump uint v0.6.1 and primitive-types v0.1.6 versions. Changeset does not modify existing interface so I think a patch release is okay.