### PR TITLE
update parity-codec for primitive types

### DIFF
--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/parity-common"
 description = "Parity Codec serialization support for uint and fixed hash."
 
 [dependencies]
-parity-codec = { version = "2.1", default-features = false }
+parity-codec = { version = "3.0", default-features = false }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
this is a breaking change as parity-codec is exposed