### PR TITLE
update impl-codec and update primitive-types

### DIFF
--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
@@ -10,7 +10,7 @@ description = "Primitive types shared by Ethereum and Substrate"
 fixed-hash = { version = "0.3", path = "../fixed-hash", default-features = false }
 uint = { version = "0.6", path = "../uint", default-features = false }
 impl-serde = { version = "0.1", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.1", path = "impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.2", path = "impls/codec", default-features = false, optional = true }
 impl-rlp = { version = "0.1", path = "impls/rlp", default-features = false, optional = true }
 
 [features]

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-codec"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
Primitive-types:2.0 is wrong and doesn't include codec 3.0... codec was a dependency of impl-codec which was a dependencie of primitive-types

This PR release impl-codec:0.2 and primitive-types:2.1 then I have to yank primitive-types:2.0