### PR TITLE
fix(serde deser): fix indexing into `str` bug

### DIFF
--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -81,7 +81,7 @@ pub fn deserialize_check_len<'de, D>(deserializer: D, len: ExpectedLen) -> Resul
 		}
 
 		fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-			if v.len() < 2 || &v[0..2] != "0x" {
+			if v.len() < 2 || !v.starts_with("0x") {
 				return Err(E::custom("prefix is missing"))
 			}
 

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -81,7 +81,7 @@ pub fn deserialize_check_len<'de, D>(deserializer: D, len: ExpectedLen) -> Resul
 		}
 
 		fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-			if v.len() < 2 || !v.starts_with("0x") {
+			if !v.starts_with("0x") {
 				return Err(E::custom("prefix is missing"))
 			}
 


### PR DESCRIPTION
[str](https://doc.rust-lang.org/std/primitive.str.html) consist of unicode characters which can be between 1-4 bytes
long and indexing assuming that all are 1 byte may panic