### PR TITLE
Extract `should_replace` from Scoring and supply pooled txs from same sender

### DIFF
--- a/transaction-pool/Cargo.toml
+++ b/transaction-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Generic transaction pool."
 name = "transaction-pool"
-version = "1.13.3"
+version = "2.0.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"

--- a/transaction-pool/src/lib.rs
+++ b/transaction-pool/src/lib.rs
@@ -96,7 +96,7 @@ pub use self::listener::{Listener, NoopListener};
 pub use self::options::Options;
 pub use self::pool::{Pool, PendingIterator, UnorderedIterator, Transaction};
 pub use self::ready::{Ready, Readiness};
-pub use self::scoring::{Scoring, ShouldReplace};
+pub use self::scoring::{Scoring, ShouldReplace, ReplaceTransaction};
 pub use self::status::{LightStatus, Status};
 pub use self::verifier::Verifier;
 

--- a/transaction-pool/src/lib.rs
+++ b/transaction-pool/src/lib.rs
@@ -85,6 +85,7 @@ mod listener;
 mod options;
 mod pool;
 mod ready;
+mod replace;
 mod status;
 mod transactions;
 mod verifier;
@@ -96,7 +97,8 @@ pub use self::listener::{Listener, NoopListener};
 pub use self::options::Options;
 pub use self::pool::{Pool, PendingIterator, UnorderedIterator, Transaction};
 pub use self::ready::{Ready, Readiness};
-pub use self::scoring::{Scoring, ShouldReplace, ReplaceTransaction};
+pub use self::replace::{ShouldReplace, ReplaceTransaction};
+pub use self::scoring::Scoring;
 pub use self::status::{LightStatus, Status};
 pub use self::verifier::Verifier;
 

--- a/transaction-pool/src/lib.rs
+++ b/transaction-pool/src/lib.rs
@@ -96,7 +96,7 @@ pub use self::listener::{Listener, NoopListener};
 pub use self::options::Options;
 pub use self::pool::{Pool, PendingIterator, UnorderedIterator, Transaction};
 pub use self::ready::{Ready, Readiness};
-pub use self::scoring::Scoring;
+pub use self::scoring::{Scoring, ShouldReplace};
 pub use self::status::{LightStatus, Status};
 pub use self::verifier::Verifier;
 

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -131,7 +131,9 @@ impl<T, S, L> Pool<T, S, L> where
 	/// NOTE: The transaction may push out some other transactions from the pool
 	/// either because of limits (see `Options`) or because `Scoring` decides that the transaction
 	/// replaces an existing transaction from that sender.
-	/// If any limit is reached the transaction with the lowest `Score` is evicted to make room.
+	///
+	/// If any limit is reached the transaction with the lowest `Score` will be compared with the
+	/// new transaction via the supplied `ShouldReplace` implementation and may be evicted.
 	///
 	/// The `Listener` will be informed on any drops or rejections.
 	pub fn import(&mut self, transaction: T, replace: &mut ShouldReplace<T>) -> error::Result<Arc<T>, T::Hash> {

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -133,7 +133,7 @@ impl<T, S, L> Pool<T, S, L> where
 	/// If any limit is reached the transaction with the lowest `Score` is evicted to make room.
 	///
 	/// The `Listener` will be informed on any drops or rejections.
-	pub fn import(&mut self, transaction: T, replace: &ShouldReplace<T>) -> error::Result<Arc<T>, T::Hash> {
+	pub fn import(&mut self, transaction: T, replace: &mut ShouldReplace<T>) -> error::Result<Arc<T>, T::Hash> {
 		let mem_usage = transaction.mem_usage();
 
 		if self.by_hash.contains_key(transaction.hash()) {
@@ -149,7 +149,7 @@ impl<T, S, L> Pool<T, S, L> where
 		// TODO [ToDr] Most likely move this after the transaction is inserted.
 		// Avoid using should_replace, but rather use scoring for that.
 		{
-			let remove_worst = |s: &mut Self, transaction| {
+			let mut remove_worst = |s: &mut Self, transaction| {
 				match s.remove_worst(transaction, replace) {
 					Err(err) => {
 						s.listener.rejected(transaction, &err);
@@ -283,22 +283,26 @@ impl<T, S, L> Pool<T, S, L> where
 	///
 	/// Returns `None` in case we couldn't decide if the transaction should replace the worst transaction or not.
 	/// In such case we will accept the transaction even though it is going to exceed the limit.
-	fn remove_worst(&mut self, transaction: &Transaction<T>, replace: &ShouldReplace<T>) -> error::Result<Option<Transaction<T>>, T::Hash> {
+	fn remove_worst(&mut self, transaction: &Transaction<T>, replace: &mut ShouldReplace<T>) -> error::Result<Option<Transaction<T>>, T::Hash> {
 		let to_remove = match self.worst_transactions.iter().next_back() {
 			// No elements to remove? and the pool is still full?
 			None => {
 				warn!("The pool is full but there are no transactions to remove.");
 				return Err(error::Error::TooCheapToEnter(transaction.hash().clone(), "unknown".into()))
 			},
-			Some(old) => match replace.should_replace(&old.transaction, transaction) {
-				// We can't decide which of them should be removed, so accept both.
-				scoring::Choice::InsertNew => None,
-				// New transaction is better than the worst one so we can replace it.
-				scoring::Choice::ReplaceOld => Some(old.clone()),
-				// otherwise fail
-				scoring::Choice::RejectNew => {
-					return Err(error::Error::TooCheapToEnter(transaction.hash().clone(), format!("{:#x}", old.score)))
-				},
+			Some(old) => {
+				// todo: [AJ] need to figure out what to pass in to determine readiness (existing sender txs required or not?) start from ShouldReplace
+				let sender_txs = self.transactions.get(transaction.sender()).map(|txs| txs.iter().as_slice());
+				match replace.should_replace(&old.transaction, transaction, sender_txs) {
+					// We can't decide which of them should be removed, so accept both.
+					scoring::Choice::InsertNew => None,
+					// New transaction is better than the worst one so we can replace it.
+					scoring::Choice::ReplaceOld => Some(old.clone()),
+					// otherwise fail
+					scoring::Choice::RejectNew => {
+						return Err(error::Error::TooCheapToEnter(transaction.hash().clone(), format!("{:#x}", old.score)))
+					},
+				}
 			},
 		};
 

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -294,13 +294,13 @@ impl<T, S, L> Pool<T, S, L> where
 				return Err(error::Error::TooCheapToEnter(transaction.hash().clone(), "unknown".into()))
 			},
 			Some(old) => {
-			let txs = &self.transactions;
-			let get_replace_tx = |tx| {
-				let sender_txs = txs.get(transaction.sender()).map(|txs| txs.iter().as_slice());
-				ReplaceTransaction::new(tx, sender_txs)
-			};
-			let old_replace = get_replace_tx(&old.transaction);
-			let new_replace = get_replace_tx(transaction);
+				let txs = &self.transactions;
+				let get_replace_tx = |tx| {
+					let sender_txs = txs.get(transaction.sender()).map(|txs| txs.iter().as_slice());
+					ReplaceTransaction::new(tx, sender_txs)
+				};
+				let old_replace = get_replace_tx(&old.transaction);
+				let new_replace = get_replace_tx(transaction);
 
 				match replace.should_replace(&old_replace, &new_replace) {
 					// We can't decide which of them should be removed, so accept both.

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -294,13 +294,13 @@ impl<T, S, L> Pool<T, S, L> where
 				return Err(error::Error::TooCheapToEnter(transaction.hash().clone(), "unknown".into()))
 			},
 			Some(old) => {
-                let txs = &self.transactions;
-                let get_replace_tx = |tx| {
-                    let sender_txs = txs.get(transaction.sender()).map(|txs| txs.iter().as_slice());
-                    ReplaceTransaction::new(tx, sender_txs)
-                };
-                let old_replace = get_replace_tx(&old.transaction);
-                let new_replace = get_replace_tx(transaction);
+			let txs = &self.transactions;
+			let get_replace_tx = |tx| {
+				let sender_txs = txs.get(transaction.sender()).map(|txs| txs.iter().as_slice());
+				ReplaceTransaction::new(tx, sender_txs)
+			};
+			let old_replace = get_replace_tx(&old.transaction);
+			let new_replace = get_replace_tx(transaction);
 
 				match replace.should_replace(&old_replace, &new_replace) {
 					// We can't decide which of them should be removed, so accept both.

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -295,9 +295,9 @@ impl<T, S, L> Pool<T, S, L> where
 			},
 			Some(old) => {
                 let txs = &self.transactions;
-                let get_replace_tx = |tx: &Transaction<T>| {
+                let get_replace_tx = |tx| {
                     let sender_txs = txs.get(transaction.sender()).map(|txs| txs.iter().as_slice());
-                    ReplaceTransaction::new(tx.clone(), sender_txs)
+                    ReplaceTransaction::new(tx, sender_txs)
                 };
                 let old_replace = get_replace_tx(&old.transaction);
                 let new_replace = get_replace_tx(transaction);

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -22,7 +22,8 @@ use error;
 use listener::{Listener, NoopListener};
 use options::Options;
 use ready::{Ready, Readiness};
-use scoring::{self, Scoring, ScoreWithRef, ShouldReplace, ReplaceTransaction};
+use replace::{ShouldReplace, ReplaceTransaction};
+use scoring::{self, Scoring, ScoreWithRef};
 use status::{LightStatus, Status};
 use transactions::{AddResult, Transactions};
 

--- a/transaction-pool/src/replace.rs
+++ b/transaction-pool/src/replace.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/transaction-pool/src/replace.rs
+++ b/transaction-pool/src/replace.rs
@@ -1,0 +1,53 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! When queue limits are reached, decide whether to replace an existing transaction from the pool
+
+use pool::Transaction;
+use scoring::Choice;
+
+/// Encapsulates a transaction to be compared, along with pooled transactions from the same sender
+pub struct ReplaceTransaction<'a, T> {
+    /// The transaction to be compared for replacement
+    pub transaction: Transaction<T>,
+    /// Other transactions currently in the pool for the same sender
+    pub pooled_by_sender: Option<&'a [Transaction<T>]>,
+}
+
+impl<'a, T> ReplaceTransaction<'a, T> {
+    /// Creates a new `ReplaceTransaction`
+    pub fn new(transaction: Transaction<T>, pooled_by_sender: Option<&'a [Transaction<T>]>) -> Self {
+        ReplaceTransaction {
+            transaction,
+            pooled_by_sender,
+        }
+    }
+}
+
+impl<'a, T> ::std::ops::Deref for ReplaceTransaction<'a, T> {
+    type Target = Transaction<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.transaction
+    }
+}
+
+/// Chooses whether a new transaction should replace an existing transaction if the pool is full.
+pub trait ShouldReplace<T> {
+    /// Decides if `new` should push out `old` transaction from the pool.
+    ///
+    /// NOTE returning `InsertNew` here can lead to some transactions being accepted above pool limits.
+    fn should_replace(&mut self, old: &ReplaceTransaction<T>, new: &ReplaceTransaction<T>) -> Choice;
+}

--- a/transaction-pool/src/replace.rs
+++ b/transaction-pool/src/replace.rs
@@ -22,14 +22,14 @@ use scoring::Choice;
 /// Encapsulates a transaction to be compared, along with pooled transactions from the same sender
 pub struct ReplaceTransaction<'a, T> {
     /// The transaction to be compared for replacement
-    pub transaction: Transaction<T>,
+    pub transaction: &'a Transaction<T>,
     /// Other transactions currently in the pool for the same sender
     pub pooled_by_sender: Option<&'a [Transaction<T>]>,
 }
 
 impl<'a, T> ReplaceTransaction<'a, T> {
     /// Creates a new `ReplaceTransaction`
-    pub fn new(transaction: Transaction<T>, pooled_by_sender: Option<&'a [Transaction<T>]>) -> Self {
+    pub fn new(transaction: &'a Transaction<T>, pooled_by_sender: Option<&'a [Transaction<T>]>) -> Self {
         ReplaceTransaction {
             transaction,
             pooled_by_sender,

--- a/transaction-pool/src/replace.rs
+++ b/transaction-pool/src/replace.rs
@@ -49,5 +49,5 @@ pub trait ShouldReplace<T> {
     /// Decides if `new` should push out `old` transaction from the pool.
     ///
     /// NOTE returning `InsertNew` here can lead to some transactions being accepted above pool limits.
-    fn should_replace(&mut self, old: &ReplaceTransaction<T>, new: &ReplaceTransaction<T>) -> Choice;
+    fn should_replace(&self, old: &ReplaceTransaction<T>, new: &ReplaceTransaction<T>) -> Choice;
 }

--- a/transaction-pool/src/scoring.rs
+++ b/transaction-pool/src/scoring.rs
@@ -105,11 +105,34 @@ pub trait Scoring<T>: fmt::Debug {
 	fn should_ignore_sender_limit(&self, _new: &T) -> bool { false }
 }
 
+pub struct ReplaceTransaction<'a, T> {
+    pub transaction: Transaction<T>,
+    pub pooled_by_sender: Option<&'a [Transaction<T>]>,
+}
+
+impl<'a, T> ReplaceTransaction<'a, T> {
+    pub fn new(transaction: Transaction<T>, pooled_by_sender: Option<&'a [Transaction<T>]>) -> Self {
+        ReplaceTransaction {
+            transaction,
+            pooled_by_sender,
+        }
+    }
+}
+
+impl<'a, T> ::std::ops::Deref for ReplaceTransaction<'a, T> {
+	type Target = Transaction<T>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.transaction
+	}
+}
+
+
 pub trait ShouldReplace<T> {
 	/// Decides if `new` should push out `old` transaction from the pool.
 	///
 	/// NOTE returning `InsertNew` here can lead to some transactions being accepted above pool limits.
-	fn should_replace(&mut self, old: &T, new: &T, old_sender_txs: Option<&[Transaction<T>]>) -> Choice;
+	fn should_replace(&mut self, old: &ReplaceTransaction<T>, new: &ReplaceTransaction<T>) -> Choice;
 }
 
 /// A score with a reference to the transaction.

--- a/transaction-pool/src/scoring.rs
+++ b/transaction-pool/src/scoring.rs
@@ -98,16 +98,18 @@ pub trait Scoring<T>: fmt::Debug {
 	/// (i.e. score at index `i` represents transaction at the same index)
 	fn update_scores(&self, txs: &[Transaction<T>], scores: &mut [Self::Score], change: Change<Self::Event>);
 
-	/// Decides if `new` should push out `old` transaction from the pool.
-	///
-	/// NOTE returning `InsertNew` here can lead to some transactions being accepted above pool limits.
-	fn should_replace(&self, old: &T, new: &T) -> Choice;
-
 	/// Decides if the transaction should ignore per-sender limit in the pool.
 	///
 	/// If you return `true` for given transaction it's going to be accepted even though
 	/// the per-sender limit is exceeded.
 	fn should_ignore_sender_limit(&self, _new: &T) -> bool { false }
+}
+
+pub trait ShouldReplace<T> {
+	/// Decides if `new` should push out `old` transaction from the pool.
+	///
+	/// NOTE returning `InsertNew` here can lead to some transactions being accepted above pool limits.
+	fn should_replace(&self, old: &T, new: &T) -> Choice;
 }
 
 /// A score with a reference to the transaction.

--- a/transaction-pool/src/scoring.rs
+++ b/transaction-pool/src/scoring.rs
@@ -109,7 +109,7 @@ pub trait ShouldReplace<T> {
 	/// Decides if `new` should push out `old` transaction from the pool.
 	///
 	/// NOTE returning `InsertNew` here can lead to some transactions being accepted above pool limits.
-	fn should_replace(&self, old: &T, new: &T) -> Choice;
+	fn should_replace(&mut self, old: &T, new: &T, old_sender_txs: Option<&[Transaction<T>]>) -> Choice;
 }
 
 /// A score with a reference to the transaction.

--- a/transaction-pool/src/tests/helpers.rs
+++ b/transaction-pool/src/tests/helpers.rs
@@ -18,9 +18,8 @@ use std::cmp;
 use std::collections::HashMap;
 
 use ethereum_types::{H160 as Sender, U256};
-use {pool, scoring, Scoring, ShouldReplace, Ready, Readiness};
+use {pool, scoring, Scoring, ShouldReplace, ReplaceTransaction, Ready, Readiness};
 use super::Transaction;
-use scoring::ReplaceTransaction;
 
 #[derive(Debug, Default)]
 pub struct DummyScoring {
@@ -75,10 +74,10 @@ impl Scoring<Transaction> for DummyScoring {
 }
 
 impl ShouldReplace<Transaction> for DummyScoring {
-	fn should_replace(&mut self, old: ReplaceTransaction<Transaction>, new: ReplaceTransaction<Transaction>) -> scoring::Choice {
+	fn should_replace(&mut self, old: &ReplaceTransaction<Transaction>, new: &ReplaceTransaction<Transaction>) -> scoring::Choice {
 		if self.always_insert {
 			scoring::Choice::InsertNew
-		} else if new.transaction().gas_price > old.transaction().gas_price {
+		} else if new.gas_price > old.gas_price {
 			scoring::Choice::ReplaceOld
 		} else {
 			scoring::Choice::RejectNew

--- a/transaction-pool/src/tests/helpers.rs
+++ b/transaction-pool/src/tests/helpers.rs
@@ -74,7 +74,7 @@ impl Scoring<Transaction> for DummyScoring {
 }
 
 impl ShouldReplace<Transaction> for DummyScoring {
-	fn should_replace(&self, old: &Transaction, new: &Transaction) -> scoring::Choice {
+	fn should_replace(&mut self, old: &Transaction, new: &Transaction, old_sender_txs: Option<&[pool::Transaction<Transaction>]>) -> scoring::Choice {
 		if self.always_insert {
 			scoring::Choice::InsertNew
 		} else if new.gas_price > old.gas_price {

--- a/transaction-pool/src/tests/helpers.rs
+++ b/transaction-pool/src/tests/helpers.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use ethereum_types::{H160 as Sender, U256};
 use {pool, scoring, Scoring, ShouldReplace, Ready, Readiness};
 use super::Transaction;
+use scoring::ReplaceTransaction;
 
 #[derive(Debug, Default)]
 pub struct DummyScoring {
@@ -74,10 +75,10 @@ impl Scoring<Transaction> for DummyScoring {
 }
 
 impl ShouldReplace<Transaction> for DummyScoring {
-	fn should_replace(&mut self, old: &Transaction, new: &Transaction, old_sender_txs: Option<&[pool::Transaction<Transaction>]>) -> scoring::Choice {
+	fn should_replace(&mut self, old: ReplaceTransaction<Transaction>, new: ReplaceTransaction<Transaction>) -> scoring::Choice {
 		if self.always_insert {
 			scoring::Choice::InsertNew
-		} else if new.gas_price > old.gas_price {
+		} else if new.transaction().gas_price > old.transaction().gas_price {
 			scoring::Choice::ReplaceOld
 		} else {
 			scoring::Choice::RejectNew

--- a/transaction-pool/src/tests/helpers.rs
+++ b/transaction-pool/src/tests/helpers.rs
@@ -74,7 +74,7 @@ impl Scoring<Transaction> for DummyScoring {
 }
 
 impl ShouldReplace<Transaction> for DummyScoring {
-	fn should_replace(&mut self, old: &ReplaceTransaction<Transaction>, new: &ReplaceTransaction<Transaction>) -> scoring::Choice {
+	fn should_replace(&self, old: &ReplaceTransaction<Transaction>, new: &ReplaceTransaction<Transaction>) -> scoring::Choice {
 		if self.always_insert {
 			scoring::Choice::InsertNew
 		} else if new.gas_price > old.gas_price {

--- a/transaction-pool/src/tests/helpers.rs
+++ b/transaction-pool/src/tests/helpers.rs
@@ -18,7 +18,7 @@ use std::cmp;
 use std::collections::HashMap;
 
 use ethereum_types::{H160 as Sender, U256};
-use {pool, scoring, Scoring, Ready, Readiness};
+use {pool, scoring, Scoring, ShouldReplace, Ready, Readiness};
 use super::Transaction;
 
 #[derive(Debug, Default)]
@@ -68,6 +68,12 @@ impl Scoring<Transaction> for DummyScoring {
 		}
 	}
 
+	fn should_ignore_sender_limit(&self, _new: &Transaction) -> bool {
+		self.always_insert
+	}
+}
+
+impl ShouldReplace<Transaction> for DummyScoring {
 	fn should_replace(&self, old: &Transaction, new: &Transaction) -> scoring::Choice {
 		if self.always_insert {
 			scoring::Choice::InsertNew
@@ -76,10 +82,6 @@ impl Scoring<Transaction> for DummyScoring {
 		} else {
 			scoring::Choice::RejectNew
 		}
-	}
-
-	fn should_ignore_sender_limit(&self, _new: &Transaction) -> bool {
-		self.always_insert
 	}
 }
 

--- a/transaction-pool/src/tests/mod.rs
+++ b/transaction-pool/src/tests/mod.rs
@@ -59,7 +59,7 @@ impl TestPool {
 
 fn import<S: Scoring<Transaction>, L: Listener<Transaction>>(txq: &mut Pool<Transaction, S, L>, tx: Transaction)
 	-> Result<Arc<Transaction>, Error<<Transaction as VerifiedTransaction>::Hash>> {
-	txq.import(tx, &DummyScoring::default())
+	txq.import(tx, &mut DummyScoring::default())
 }
 
 #[test]


### PR DESCRIPTION
`should_replace` does not use the computed score, and is actually called only on `import` (when pool limits are reached).

Further, we pass other pooled transactions from the respective senders of the `old` and `new` transactions which are being compared. This would allow an implementation to also compare the `Readiness` of the transactions when deciding if the `new` should push out the `old`.