### PR TITLE
Fix impl-rlp for uint in primitive-types

### DIFF
--- a/primitive-types/impls/rlp/src/lib.rs
+++ b/primitive-types/impls/rlp/src/lib.rs
@@ -21,7 +21,7 @@ macro_rules! impl_uint_rlp {
 		impl $crate::rlp::Encodable for $name {
 			fn rlp_append(&self, s: &mut $crate::rlp::RlpStream) {
 				let leading_empty_bytes = $size - (self.bits() + 7) / 8;
-				let mut buffer = [0u8; $size];
+				let mut buffer = [0u8; $size * 8];
 				self.to_big_endian(&mut buffer);
 				s.encoder().encode_value(&buffer[leading_empty_bytes..]);
 			}

--- a/primitive-types/impls/rlp/src/lib.rs
+++ b/primitive-types/impls/rlp/src/lib.rs
@@ -20,7 +20,7 @@ macro_rules! impl_uint_rlp {
 	($name: ident, $size: expr) => {
 		impl $crate::rlp::Encodable for $name {
 			fn rlp_append(&self, s: &mut $crate::rlp::RlpStream) {
-				let leading_empty_bytes = $size - (self.bits() + 7) / 8;
+				let leading_empty_bytes = $size * 8 - (self.bits() + 7) / 8;
 				let mut buffer = [0u8; $size * 8];
 				self.to_big_endian(&mut buffer);
 				s.encoder().encode_value(&buffer[leading_empty_bytes..]);
@@ -32,7 +32,7 @@ macro_rules! impl_uint_rlp {
 				rlp.decoder().decode_value(|bytes| {
 					if !bytes.is_empty() && bytes[0] == 0 {
 						Err($crate::rlp::DecoderError::RlpInvalidIndirection)
-					} else if bytes.len() <= $size {
+					} else if bytes.len() <= $size * 8 {
 						Ok($name::from(bytes))
 					} else {
 						Err($crate::rlp::DecoderError::RlpIsTooBig)

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -92,9 +92,9 @@ mod codec {
 mod rlp {
 	use super::*;
 
-	impl_uint_rlp!(U128, 2);
-	impl_uint_rlp!(U256, 4);
-	impl_uint_rlp!(U512, 8);
+	impl_uint_rlp!(U128, 16);
+	impl_uint_rlp!(U256, 32);
+	impl_uint_rlp!(U512, 64);
 
 	impl_fixed_hash_rlp!(H160, 20);
 	impl_fixed_hash_rlp!(H256, 32);

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -92,9 +92,9 @@ mod codec {
 mod rlp {
 	use super::*;
 
-	impl_uint_rlp!(U128, 16);
-	impl_uint_rlp!(U256, 32);
-	impl_uint_rlp!(U512, 64);
+	impl_uint_rlp!(U128, 2);
+	impl_uint_rlp!(U256, 4);
+	impl_uint_rlp!(U512, 8);
 
 	impl_fixed_hash_rlp!(H160, 20);
 	impl_fixed_hash_rlp!(H256, 32);


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

It should be like 

https://github.com/paritytech/parity-common/blob/c64e1b52e67d8426c6f19242de4dea6ed63074c4/rlp/src/impls.rs#L259-L263