### PR TITLE
Use EntropyRng instead of OsRng

### DIFF
--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -513,7 +513,7 @@ macro_rules! impl_rand_for_fixed_hash {
 
 			/// Assign `self` to a cryptographically random value.
 			pub fn randomize(&mut self) {
-				let mut rng = $crate::rand::OsRng::new().unwrap();
+				let mut rng = $crate::rand::rngs::EntropyRng::new();
 				self.randomize_using(&mut rng);
 			}
 


### PR DESCRIPTION
`EntropyRng` is also cryptographically secure, but will use jitter RNG (http://www.chronox.de/jent/doc/CPU-Jitter-NPTRNG.html) if the `OsRng` isn't available.