### PR TITLE
Bump fixed-hash to 0.3.2

### DIFF
--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-hash"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
To integrate #130.

Will publish once this PR is accepted and merged.