### PR TITLE
primitive-types: derive Debug, PartialEq, Eq for Error

### DIFF
--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -38,6 +38,7 @@ extern crate impl_rlp;
 use core::convert::TryFrom;
 
 /// Error type for conversion.
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
 	/// Overflow encountered.
 	Overflow,


### PR DESCRIPTION
deriving `Debug` makes it possible to write
```rust
U256::try_from(u512).expect(PROOF)
```
