### PR TITLE
Backports from https://github.com/paritytech/primitives/pull/15

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.6.0"
+version = "0.6.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT"
@@ -10,9 +10,9 @@ repository = "https://github.com/paritytech/parity-common"
 
 [dependencies]
 tiny-keccak = "1.4"
-crunchy = { version = "0.2.1", default-features = false, features = ["limit_256"] }
+crunchy = { version = "0.2", default-features = false, features = ["limit_256"] }
 fixed-hash = { path = "../fixed-hash", version = "0.3", default-features = false }
-impl-serde = { path = "../primitive-types/impls/serde", version = "0.1", default-features = false, optional = true }
+impl-serde = { path = "../primitive-types/impls/serde", version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = { version = "0.4" }

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"
@@ -11,7 +11,7 @@ ethbloom = { path = "../ethbloom", version = "0.6", default-features = false }
 fixed-hash = { path = "../fixed-hash", version = "0.3", default-features = false, features = ["byteorder", "rustc-hex"] }
 uint = { path = "../uint", version = "0.7", default-features = false }
 primitive-types = { path = "../primitive-types", version = "0.2", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
-impl-serde = { path = "../primitive-types/impls/serde", version = "0.1", default-features = false, optional = true }
+impl-serde = { path = "../primitive-types/impls/serde", version = "0.2", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.1", default-features = false }
 
 [dev-dependencies]

--- a/ethereum-types/tests/serde.rs
+++ b/ethereum-types/tests/serde.rs
@@ -104,3 +104,10 @@ fn test_invalid() {
 	assert!(ser::from_str::<H256>("\"0\"").unwrap_err().is_data());
 	assert!(ser::from_str::<H256>("\"10\"").unwrap_err().is_data());
 }
+
+#[test]
+fn test_invalid_char() {
+	const INVALID_STR: &str = "\"0x000000000000000000000000000000000000000000000000000000000000000g\"";
+	const EXPECTED_MSG: &str = "invalid hex character: g, at 65 at line 1 column 68";
+	assert_eq!(ser::from_str::<H256>(INVALID_STR).unwrap_err().to_string(), EXPECTED_MSG);
+}

--- a/ethereum-types/tests/serde.rs
+++ b/ethereum-types/tests/serde.rs
@@ -1,0 +1,106 @@
+// Copyright 2019 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate ethereum_types;
+extern crate serde_json;
+
+use ethereum_types::{U256, U512, H160, H256};
+use serde_json as ser;
+
+macro_rules! test {
+	($name: ident, $test_name: ident) => {
+		#[test]
+		fn $test_name() {
+			let tests = vec![
+				($name::from(0), "0x0"),
+				($name::from(1), "0x1"),
+				($name::from(2), "0x2"),
+				($name::from(10), "0xa"),
+				($name::from(15), "0xf"),
+				($name::from(15), "0xf"),
+				($name::from(16), "0x10"),
+				($name::from(1_000), "0x3e8"),
+				($name::from(100_000), "0x186a0"),
+				($name::from(u64::max_value()), "0xffffffffffffffff"),
+				($name::from(u64::max_value()) + $name::from(1u64), "0x10000000000000000"),
+			];
+
+			for (number, expected) in tests {
+				assert_eq!(format!("{:?}", expected), ser::to_string_pretty(&number).unwrap());
+				assert_eq!(number, ser::from_str(&format!("{:?}", expected)).unwrap());
+			}
+
+			// Invalid examples
+			assert!(ser::from_str::<$name>("\"0x\"").unwrap_err().is_data());
+			assert!(ser::from_str::<$name>("\"0xg\"").unwrap_err().is_data());
+			assert!(ser::from_str::<$name>("\"\"").unwrap_err().is_data());
+			assert!(ser::from_str::<$name>("\"10\"").unwrap_err().is_data());
+			assert!(ser::from_str::<$name>("\"0\"").unwrap_err().is_data());
+		}
+	}
+}
+
+test!(U256, test_u256);
+test!(U512, test_u512);
+
+#[test]
+fn test_large_values() {
+	assert_eq!(
+		ser::to_string_pretty(&!U256::zero()).unwrap(),
+		"\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
+	);
+	assert!(
+		ser::from_str::<U256>("\"0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"").unwrap_err().is_data()
+	);
+}
+
+#[test]
+fn test_h160() {
+	let tests = vec![
+		(H160::from_low_u64_be(0), "0x0000000000000000000000000000000000000000"),
+		(H160::from_low_u64_be(2), "0x0000000000000000000000000000000000000002"),
+		(H160::from_low_u64_be(15), "0x000000000000000000000000000000000000000f"),
+		(H160::from_low_u64_be(16), "0x0000000000000000000000000000000000000010"),
+		(H160::from_low_u64_be(1_000), "0x00000000000000000000000000000000000003e8"),
+		(H160::from_low_u64_be(100_000), "0x00000000000000000000000000000000000186a0"),
+		(H160::from_low_u64_be(u64::max_value()), "0x000000000000000000000000ffffffffffffffff"),
+	];
+
+	for (number, expected) in tests {
+		assert_eq!(format!("{:?}", expected), ser::to_string_pretty(&number).unwrap());
+		assert_eq!(number, ser::from_str(&format!("{:?}", expected)).unwrap());
+	}
+}
+
+#[test]
+fn test_h256() {
+	let tests = vec![
+		(H256::from_low_u64_be(0), "0x0000000000000000000000000000000000000000000000000000000000000000"),
+		(H256::from_low_u64_be(2), "0x0000000000000000000000000000000000000000000000000000000000000002"),
+		(H256::from_low_u64_be(15), "0x000000000000000000000000000000000000000000000000000000000000000f"),
+		(H256::from_low_u64_be(16), "0x0000000000000000000000000000000000000000000000000000000000000010"),
+		(H256::from_low_u64_be(1_000), "0x00000000000000000000000000000000000000000000000000000000000003e8"),
+		(H256::from_low_u64_be(100_000), "0x00000000000000000000000000000000000000000000000000000000000186a0"),
+		(H256::from_low_u64_be(u64::max_value()), "0x000000000000000000000000000000000000000000000000ffffffffffffffff"),
+	];
+
+	for (number, expected) in tests {
+		assert_eq!(format!("{:?}", expected), ser::to_string_pretty(&number).unwrap());
+		assert_eq!(number, ser::from_str(&format!("{:?}", expected)).unwrap());
+	}
+}
+
+#[test]
+fn test_invalid() {
+	assert!(ser::from_str::<H256>("\"0x000000000000000000000000000000000000000000000000000000000000000\"").unwrap_err().is_data());
+	assert!(ser::from_str::<H256>("\"0x000000000000000000000000000000000000000000000000000000000000000g\"").unwrap_err().is_data());
+	assert!(ser::from_str::<H256>("\"0x00000000000000000000000000000000000000000000000000000000000000000\"").unwrap_err().is_data());
+	assert!(ser::from_str::<H256>("\"\"").unwrap_err().is_data());
+	assert!(ser::from_str::<H256>("\"0\"").unwrap_err().is_data());
+	assert!(ser::from_str::<H256>("\"10\"").unwrap_err().is_data());
+}

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
@@ -9,7 +9,7 @@ description = "Primitive types shared by Ethereum and Substrate"
 [dependencies]
 fixed-hash = { version = "0.3", path = "../fixed-hash", default-features = false }
 uint = { version = "0.7", path = "../uint", default-features = false }
-impl-serde = { version = "0.1", path = "impls/serde", default-features = false, optional = true }
+impl-serde = { version = "0.2", path = "impls/serde", default-features = false, optional = true }
 impl-codec = { version = "0.2", path = "impls/codec", default-features = false, optional = true }
 impl-rlp = { version = "0.1", path = "impls/rlp", default-features = false, optional = true }
 

--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-serde"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
@@ -8,4 +8,3 @@ description = "Serde serialization support for uint and fixed hash."
 
 [dependencies]
 serde = "1.0"
-rustc-hex = "2"

--- a/primitive-types/impls/serde/src/lib.rs
+++ b/primitive-types/impls/serde/src/lib.rs
@@ -29,12 +29,12 @@ macro_rules! impl_uint_serde {
 
 		impl<'de> $crate::serde::Deserialize<'de> for $name {
 			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: $crate::serde::Deserializer<'de> {
-                let mut bytes = [0u8; $len * 8];
+				let mut bytes = [0u8; $len * 8];
 				let wrote = $crate::serialize::deserialize_check_len(
 					deserializer,
 					$crate::serialize::ExpectedLen::Between(0, &mut bytes)
 				)?;
-                Ok(bytes[0..wrote].into())
+				Ok(bytes[0..wrote].into())
 			}
 		}
 	}

--- a/primitive-types/impls/serde/src/lib.rs
+++ b/primitive-types/impls/serde/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Parity Technologies
+// Copyright 2015-2019 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -12,9 +12,6 @@
 pub extern crate serde;
 
 #[doc(hidden)]
-pub extern crate rustc_hex;
-
-#[doc(hidden)]
 pub mod serialize;
 
 /// Add Serde serialization support to an integer created by `construct_uint!`.
@@ -23,16 +20,21 @@ macro_rules! impl_uint_serde {
 	($name: ident, $len: expr) => {
 		impl $crate::serde::Serialize for $name {
 			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: $crate::serde::Serializer {
+				let mut slice = [0u8; 2 + 2 * $len * 8];
 				let mut bytes = [0u8; $len * 8];
 				self.to_big_endian(&mut bytes);
-				$crate::serialize::serialize_uint(&bytes, serializer)
+				$crate::serialize::serialize_uint(&mut slice, &bytes, serializer)
 			}
 		}
 
 		impl<'de> $crate::serde::Deserialize<'de> for $name {
 			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: $crate::serde::Deserializer<'de> {
-				$crate::serialize::deserialize_check_len(deserializer, $crate::serialize::ExpectedLen::Between(0, $len * 8))
-					.map(|x| (&*x).into())
+                let mut bytes = [0u8; $len * 8];
+				let wrote = $crate::serialize::deserialize_check_len(
+					deserializer,
+					$crate::serialize::ExpectedLen::Between(0, &mut bytes)
+				)?;
+                Ok(bytes[0..wrote].into())
 			}
 		}
 	}
@@ -44,14 +46,19 @@ macro_rules! impl_fixed_hash_serde {
 	($name: ident, $len: expr) => {
 		impl $crate::serde::Serialize for $name {
 			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: $crate::serde::Serializer {
-				$crate::serialize::serialize(&self.0, serializer)
+				let mut slice = [0u8; 2 + 2 * $len];
+				$crate::serialize::serialize(&mut slice, &self.0, serializer)
 			}
 		}
 
 		impl<'de> $crate::serde::Deserialize<'de> for $name {
 			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: $crate::serde::Deserializer<'de> {
-				$crate::serialize::deserialize_check_len(deserializer, $crate::serialize::ExpectedLen::Exact($len))
-					.map(|x| $name::from_slice(&x))
+				let mut bytes = [0u8; $len];
+				$crate::serialize::deserialize_check_len(
+					deserializer,
+					$crate::serialize::ExpectedLen::Exact(&mut bytes)
+				)?;
+				Ok($name(bytes))
 			}
 		}
 	}

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Parity Technologies
+// Copyright 2015-2019 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,21 +7,45 @@
 // except according to those terms.
 
 use std::fmt;
-
 use serde::{de, Serializer, Deserializer};
 
+static CHARS: &'static[u8] = b"0123456789abcdef";
+
+fn to_hex<'a>(v: &'a mut [u8], bytes: &[u8], skip_leading_zero: bool) -> &'a str {
+	assert!(v.len() > 1 + bytes.len() * 2);
+
+	v[0] = b'0';
+	v[1] = b'x';
+
+	let mut idx = 2;
+	let first_nibble = bytes[0] >> 4;
+	if first_nibble != 0 || !skip_leading_zero {
+		v[idx] = CHARS[first_nibble as usize];
+		idx += 1;
+	}
+	v[idx] = CHARS[(bytes[0] & 0xf) as usize];
+	idx += 1;
+
+	for &byte in bytes.iter().skip(1) {
+		v[idx] = CHARS[(byte >> 4) as usize];
+		v[idx + 1] = CHARS[(byte & 0xf) as usize];
+		idx += 2;
+	}
+
+	::std::str::from_utf8(&v[0..idx]).expect("All characters are coming from CHARS")
+}
+
 /// Serializes a slice of bytes.
-pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> where
+pub fn serialize<S>(slice: &mut [u8], bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> where
 	S: Serializer,
 {
-	let hex: String = ::rustc_hex::ToHex::to_hex(bytes);
-	serializer.serialize_str(&format!("0x{}", hex))
+	serializer.serialize_str(to_hex(slice, bytes, false))
 }
 
 /// Serialize a slice of bytes as uint.
 ///
 /// The representation will have all leading zeros trimmed.
-pub fn serialize_uint<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> where
+pub fn serialize_uint<S>(slice: &mut [u8], bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> where
 	S: Serializer,
 {
 	let non_zero = bytes.iter().take_while(|b| **b == 0).count();
@@ -30,51 +54,38 @@ pub fn serialize_uint<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 		return serializer.serialize_str("0x0");
 	}
 
-	let hex: String = ::rustc_hex::ToHex::to_hex(bytes);
-	let has_leading_zero = !hex.is_empty() && &hex[0..1] == "0";
-	serializer.serialize_str(
-		&format!("0x{}", if has_leading_zero { &hex[1..] } else { &hex })
-	)
+	serializer.serialize_str(to_hex(slice, bytes, true))
 }
 
 /// Expected length of bytes vector.
-#[derive(PartialEq, Eq, Debug)]
-pub enum ExpectedLen {
-	/// Any length in bytes.
-	Any,
+#[derive(Debug, PartialEq, Eq)]
+pub enum ExpectedLen<'a> {
 	/// Exact length in bytes.
-	Exact(usize),
-	/// A bytes length between (min; max].
-	Between(usize, usize),
+	Exact(&'a mut [u8]),
+	/// A bytes length between (min; slice.len()].
+	Between(usize, &'a mut [u8]),
 }
 
-impl fmt::Display for ExpectedLen {
+impl<'a> fmt::Display for ExpectedLen<'a> {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
-			ExpectedLen::Any => write!(fmt, "even length"),
-			ExpectedLen::Exact(v) => write!(fmt, "length of {}", v * 2),
-			ExpectedLen::Between(min, max) => write!(fmt, "length between ({}; {}]", min * 2, max * 2),
+			ExpectedLen::Exact(ref v) => write!(fmt, "length of {}", v.len() * 2),
+            ExpectedLen::Between(min, ref v) => write!(fmt, "length between ({}; {}]", min * 2, v.len() * 2),
 		}
 	}
 }
 
-/// Deserialize into vector of bytes.
-pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error> where
-	D: Deserializer<'de>,
-{
-	deserialize_check_len(deserializer, ExpectedLen::Any)
-}
-
 /// Deserialize into vector of bytes with additional size check.
-pub fn deserialize_check_len<'de, D>(deserializer: D, len: ExpectedLen) -> Result<Vec<u8>, D::Error> where
+/// Returns number of bytes written.
+pub fn deserialize_check_len<'a, 'de, D>(deserializer: D, len: ExpectedLen<'a>) -> Result<usize, D::Error> where
 	D: Deserializer<'de>,
 {
-	struct Visitor {
-		len: ExpectedLen,
+	struct Visitor<'a> {
+		len: ExpectedLen<'a>,
 	}
 
-	impl<'a> de::Visitor<'a> for Visitor {
-		type Value = Vec<u8>;
+	impl<'a, 'b> de::Visitor<'b> for Visitor<'a> {
+		type Value = usize;
 
 		fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
 			write!(formatter, "a 0x-prefixed hex string with {}", self.len)
@@ -86,10 +97,8 @@ pub fn deserialize_check_len<'de, D>(deserializer: D, len: ExpectedLen) -> Resul
 			}
 
 			let is_len_valid = match self.len {
-				// just make sure that we have all nibbles
-				ExpectedLen::Any => v.len() % 2 == 0,
-				ExpectedLen::Exact(len) => v.len() == 2 * len + 2,
-				ExpectedLen::Between(min, max) => v.len() <= 2 * max + 2 && v.len() > 2 * min + 2,
+				ExpectedLen::Exact(ref slice) => v.len() == 2 * slice.len() + 2,
+				ExpectedLen::Between(min, ref slice) => v.len() <= 2 * slice.len() + 2 && v.len() > 2 * min + 2,
 			};
 
 			if !is_len_valid {
@@ -97,24 +106,45 @@ pub fn deserialize_check_len<'de, D>(deserializer: D, len: ExpectedLen) -> Resul
 			}
 
 			let bytes = match self.len {
-				ExpectedLen::Between(..) if v.len() % 2 != 0 => {
-					::rustc_hex::FromHex::from_hex(&*format!("0{}", &v[2..]))
-				},
-				_ => ::rustc_hex::FromHex::from_hex(&v[2..])
+				ExpectedLen::Exact(slice) => slice,
+				ExpectedLen::Between(_, slice) => slice,
 			};
 
-			fn format_err(e: ::rustc_hex::FromHexError) -> String {
-				format!("invalid hex value: {:?}", e)
+			let mut modulus = v.len() % 2;
+			let mut buf = 0;
+			let mut pos = 0;
+			for (idx, byte) in v.bytes().enumerate().skip(2) {
+				buf <<= 4;
+
+				match byte {
+					b'A'...b'F' => buf |= byte - b'A' + 10,
+					b'a'...b'f' => buf |= byte - b'a' + 10,
+					b'0'...b'9' => buf |= byte - b'0',
+					b' '|b'\r'|b'\n'|b'\t' => {
+						buf >>= 4;
+						continue
+					}
+					_ => {
+						let ch = v.bytes().skip(idx).next().unwrap() as char;
+						return Err(E::custom(&format!("invalid hex character: {}, at {}", ch, idx)))
+					}
+				}
+
+				modulus += 1;
+				if modulus == 2 {
+					modulus = 0;
+					bytes[pos] = buf;
+					pos += 1;
+				}
 			}
 
-			bytes.map_err(|e| E::custom(format_err(e)))
+			Ok(pos)
 		}
 
 		fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
 			self.visit_str(&v)
 		}
 	}
-	// TODO [ToDr] Use raw bytes if we switch to RLP / binencoding
-	// (visit_bytes, visit_bytes_buf)
+
 	deserializer.deserialize_str(Visitor { len })
 }

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -70,7 +70,7 @@ impl<'a> fmt::Display for ExpectedLen<'a> {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			ExpectedLen::Exact(ref v) => write!(fmt, "length of {}", v.len() * 2),
-            ExpectedLen::Between(min, ref v) => write!(fmt, "length between ({}; {}]", min * 2, v.len() * 2),
+			ExpectedLen::Between(min, ref v) => write!(fmt, "length between ({}; {}]", min * 2, v.len() * 2),
 		}
 	}
 }

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -124,8 +124,8 @@ pub fn deserialize_check_len<'a, 'de, D>(deserializer: D, len: ExpectedLen<'a>) 
 						buf >>= 4;
 						continue
 					}
-					_ => {
-						let ch = v.bytes().skip(idx).next().unwrap() as char;
+					b => {
+						let ch = char::from(b);
 						return Err(E::custom(&format!("invalid hex character: {}, at {}", ch, idx)))
 					}
 				}


### PR DESCRIPTION
Somehow these commits [1](https://github.com/paritytech/parity-common/commit/942fbf392b267c84520e4d8d890fc5a2c0cca8d9) [2](https://github.com/paritytech/parity-common/commit/13209866425e1705b2f38659b197d73b2ed4031d) [3](https://github.com/paritytech/parity-common/commit/90a3ada499a8d84009975e57e23ad03917d062ca) were lost in a migration. This PR brings them back.

Also fixes error message in deserialization (d4716c595640d2de52cd9ccc1fe1c2b9d77aa12b) and bumps versions.

Closes #108 