### PR TITLE
Restore the previous API to allow variable size keys for Hmac operations

### DIFF
--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -132,12 +132,14 @@ impl VerifyKey<Sha512> {
 pub fn verify<T>(key: &VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
 	match &key.0 {
 		KeyInner::Sha256(key_bytes) => {
-			let mut ctx = Hmac::<rsha2::Sha256>::new_varkey(key_bytes).unwrap();
+			let mut ctx = Hmac::<rsha2::Sha256>::new_varkey(key_bytes)
+				.expect("always returns Ok; qed");
 			ctx.input(data);
 			ctx.verify(sig).is_ok()
 		},
 		KeyInner::Sha512(key_bytes) => {
-			let mut ctx = Hmac::<rsha2::Sha512>::new_varkey(key_bytes).unwrap();
+			let mut ctx = Hmac::<rsha2::Sha512>::new_varkey(key_bytes)
+				.expect("always returns Ok; qed");
 			ctx.input(data);
 			ctx.verify(sig).is_ok()
 		},

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use digest::{Sha256, Sha512};
-use rdigest::generic_array::{GenericArray, typenum::U32, typenum::U64, typenum::U128};
+use rdigest::generic_array::{GenericArray, typenum::U32, typenum::U64};
 use rhmac::{Hmac, Mac as _};
 use rsha2;
 use std::marker::PhantomData;

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -78,8 +78,23 @@ enum SignerInner {
 impl<T> Signer<T> {
 	pub fn with(key: &SigKey<T>) -> Signer<T> {
 		match &key.0 {
-			KeyInner::Sha256(key_bytes) => Signer(SignerInner::Sha256(Hmac::<rsha2::Sha256>::new_varkey(key_bytes).unwrap()), PhantomData),
-			KeyInner::Sha512(key_bytes) => Signer(SignerInner::Sha512(Hmac::<rsha2::Sha512>::new_varkey(key_bytes).unwrap()), PhantomData),
+			KeyInner::Sha256(key_bytes) => {
+				Signer(
+					SignerInner::Sha256(
+						Hmac::<rsha2::Sha256>::new_varkey(key_bytes)
+							.expect("always returns Ok; qed")
+					),
+					PhantomData
+				)
+			},
+			KeyInner::Sha512(key_bytes) => {
+				Signer(
+					SignerInner::Sha512(
+						Hmac::<rsha2::Sha512>::new_varkey(key_bytes)
+							.expect("always returns Ok; qed")
+					), PhantomData
+				)
+			},
 		}
 	}
 

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -44,19 +44,20 @@ impl<T> Deref for Signature<T> {
 pub struct SigKey<T>(KeyInner, PhantomData<T>);
 
 enum KeyInner {
-	Sha256(GenericArray<u8, U64>),
-	Sha512(GenericArray<u8, U128>),
+	Sha256(rhmac::Hmac<rsha2::Sha256>),
+	Sha512(rhmac::Hmac<rsha2::Sha512>),
 }
 
 impl SigKey<Sha256> {
 	pub fn sha256(key: &[u8]) -> SigKey<Sha256> {
-		SigKey(KeyInner::Sha256(*GenericArray::from_slice(key)), PhantomData)
+		SigKey(KeyInner::Sha256(Hmac::<rsha2::Sha256>::new_varkey(key).unwrap()), PhantomData)
 	}
 }
 
 impl SigKey<Sha512> {
 	pub fn sha512(key: &[u8]) -> SigKey<Sha512> {
-		SigKey(KeyInner::Sha512(*GenericArray::from_slice(key)), PhantomData)
+		SigKey(KeyInner::Sha512(Hmac::<rsha2::Sha512>::new_varkey(key).unwrap()), PhantomData)
+
 	}
 }
 
@@ -78,8 +79,8 @@ enum SignerInner {
 impl<T> Signer<T> {
 	pub fn with(key: &SigKey<T>) -> Signer<T> {
 		match &key.0 {
-			KeyInner::Sha256(k) => Signer(SignerInner::Sha256(Hmac::new(k)), PhantomData),
-			KeyInner::Sha512(k) => Signer(SignerInner::Sha512(Hmac::new(k)), PhantomData),
+			KeyInner::Sha256(k) => Signer(SignerInner::Sha256(k.clone()), PhantomData),
+			KeyInner::Sha512(k) => Signer(SignerInner::Sha512(k.clone()), PhantomData),
 		}
 	}
 
@@ -103,29 +104,27 @@ pub struct VerifyKey<T>(KeyInner, PhantomData<T>);
 
 impl VerifyKey<Sha256> {
 	pub fn sha256(key: &[u8]) -> VerifyKey<Sha256> {
-		VerifyKey(KeyInner::Sha256(*GenericArray::from_slice(key)), PhantomData)
+		VerifyKey(KeyInner::Sha256(Hmac::<rsha2::Sha256>::new_varkey(key).unwrap()), PhantomData)
 	}
 }
 
 impl VerifyKey<Sha512> {
 	pub fn sha512(key: &[u8]) -> VerifyKey<Sha512> {
-		VerifyKey(KeyInner::Sha512(*GenericArray::from_slice(key)), PhantomData)
+		VerifyKey(KeyInner::Sha512(Hmac::<rsha2::Sha512>::new_varkey(key).unwrap()), PhantomData)
 	}
 }
 
 /// Verify HMAC signature of `data`.
-pub fn verify<T>(k: &VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
-	match &k.0 {
-		KeyInner::Sha256(k) => {
-			let mut ctxt = Hmac::<rsha2::Sha256>::new(k);
-			ctxt.input(data);
-			ctxt.verify(sig).is_ok()
-		}
-		KeyInner::Sha512(k) => {
-			let mut ctxt = Hmac::<rsha2::Sha512>::new(k);
-			ctxt.input(data);
-			ctxt.verify(sig).is_ok()
-		}
+pub fn verify<T>(k: VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
+	match k.0 {
+		KeyInner::Sha256(mut ctx) => {
+			ctx.input(data);
+			ctx.verify(sig).is_ok();
+		},
+		KeyInner::Sha512(mut ctx) => {
+			ctx.input(data);
+			ctx.verify(sig).is_ok();
+		},
 	}
 }
 

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -115,15 +115,17 @@ impl VerifyKey<Sha512> {
 }
 
 /// Verify HMAC signature of `data`.
-pub fn verify<T>(k: VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
-	match k.0 {
-		KeyInner::Sha256(mut ctx) => {
-			ctx.input(data);
-			ctx.verify(sig).is_ok();
+pub fn verify<T>(key: &VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
+	match &key.0 {
+		KeyInner::Sha256(ctx) => {
+			let mut ctx2 = ctx.clone();
+			ctx2.input(data);
+			ctx2.verify(sig).is_ok();
 		},
-		KeyInner::Sha512(mut ctx) => {
-			ctx.input(data);
-			ctx.verify(sig).is_ok();
+		KeyInner::Sha512(ctx) => {
+			let mut ctx2 = ctx.clone();
+			ctx2.input(data);
+			ctx2.verify(sig).is_ok();
 		},
 	}
 }

--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -43,6 +43,6 @@ fn simple_mac_and_verify() {
 	assert_eq!(&sig2[..], &sign(&sig_key2, &big_input[..])[..]);
 	let verif_key1 = VerifyKey::sha256(&key1[..]);
 	let verif_key2 = VerifyKey::sha512(&key2[..]);
-	assert!(verify(verif_key1, &input[..], &sig1[..]));
-	assert!(verify(verif_key2, &big_input[..], &sig2[..]));
+	assert!(verify(&verif_key1, &input[..], &sig1[..]));
+	assert!(verify(&verif_key2, &big_input[..], &sig2[..]));
 }

--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -43,7 +43,6 @@ fn simple_mac_and_verify() {
 	assert_eq!(&sig2[..], &sign(&sig_key2, &big_input[..])[..]);
 	let verif_key1 = VerifyKey::sha256(&key1[..]);
 	let verif_key2 = VerifyKey::sha512(&key2[..]);
-	assert!(verify(&verif_key1, &input[..], &sig1[..]));
-	assert!(verify(&verif_key2, &big_input[..], &sig2[..]));
-
+	assert!(verify(verif_key1, &input[..], &sig1[..]));
+	assert!(verify(verif_key2, &big_input[..], &sig2[..]));
 }


### PR DESCRIPTION
Replaces https://github.com/paritytech/parity-common/pull/151

After https://github.com/paritytech/parity-common/pull/139 consuming code need to provide a 64/128 bytes long key to instantiate a `SigKey<T>` which is cumbersome and undesired. In this PR the input key is stored as bytes until any HMAC operations need to be performed.