### PR TITLE
[parity-crypto] zero memory for hmac signing keys

### DIFF
--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -28,3 +28,4 @@ constant_time_eq = "0.1.3"
 
 [dev-dependencies]
 criterion = "0.2"
+hex-literal = "0.2"

--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -25,6 +25,7 @@ aes-ctr = "0.3.0"
 block-modes = "0.3.3"
 pbkdf2 = "0.3.0"
 constant_time_eq = "0.1.3"
+memzero = "0.1"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/parity-crypto/src/digest.rs
+++ b/parity-crypto/src/digest.rs
@@ -63,8 +63,11 @@ pub fn ripemd160(data: &[u8]) -> Digest<Ripemd160> {
 	hasher.finish()
 }
 
+#[derive(Debug)]
 pub enum Sha256 {}
+#[derive(Debug)]
 pub enum Sha512 {}
+#[derive(Debug)]
 pub enum Ripemd160 {}
 
 /// Stateful digest computation.

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -132,12 +132,14 @@ impl VerifyKey<Sha512> {
 pub fn verify<T>(key: &VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
 	match &key.0 {
 		KeyInner::Sha256(key_bytes) => {
-			let mut ctx = Hmac::<rsha2::Sha256>::new_varkey(key_bytes).unwrap();
+			let mut ctx = Hmac::<rsha2::Sha256>::new_varkey(key_bytes)
+				.expect("always returns Ok; qed");
 			ctx.input(data);
 			ctx.verify(sig).is_ok()
 		},
 		KeyInner::Sha512(key_bytes) => {
-			let mut ctx = Hmac::<rsha2::Sha512>::new_varkey(key_bytes).unwrap();
+			let mut ctx = Hmac::<rsha2::Sha512>::new_varkey(key_bytes)
+				.expect("always returns Ok; qed");
 			ctx.input(data);
 			ctx.verify(sig).is_ok()
 		},

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use digest::{Sha256, Sha512};
-use rdigest::generic_array::{GenericArray, typenum::U32, typenum::U64, typenum::U128};
+use rdigest::generic_array::{GenericArray, typenum::U32, typenum::U64};
 use rhmac::{Hmac, Mac as _};
 use rsha2;
 use std::marker::PhantomData;

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -78,8 +78,23 @@ enum SignerInner {
 impl<T> Signer<T> {
 	pub fn with(key: &SigKey<T>) -> Signer<T> {
 		match &key.0 {
-			KeyInner::Sha256(key_bytes) => Signer(SignerInner::Sha256(Hmac::<rsha2::Sha256>::new_varkey(key_bytes).unwrap()), PhantomData),
-			KeyInner::Sha512(key_bytes) => Signer(SignerInner::Sha512(Hmac::<rsha2::Sha512>::new_varkey(key_bytes).unwrap()), PhantomData),
+			KeyInner::Sha256(key_bytes) => {
+				Signer(
+					SignerInner::Sha256(
+						Hmac::<rsha2::Sha256>::new_varkey(key_bytes)
+							.expect("always returns Ok; qed")
+					),
+					PhantomData
+				)
+			},
+			KeyInner::Sha512(key_bytes) => {
+				Signer(
+					SignerInner::Sha512(
+						Hmac::<rsha2::Sha512>::new_varkey(key_bytes)
+							.expect("always returns Ok; qed")
+					), PhantomData
+				)
+			},
 		}
 	}
 

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -44,19 +44,20 @@ impl<T> Deref for Signature<T> {
 pub struct SigKey<T>(KeyInner, PhantomData<T>);
 
 enum KeyInner {
-	Sha256(GenericArray<u8, U64>),
-	Sha512(GenericArray<u8, U128>),
+	Sha256(rhmac::Hmac<rsha2::Sha256>),
+	Sha512(rhmac::Hmac<rsha2::Sha512>),
 }
 
 impl SigKey<Sha256> {
 	pub fn sha256(key: &[u8]) -> SigKey<Sha256> {
-		SigKey(KeyInner::Sha256(*GenericArray::from_slice(key)), PhantomData)
+		SigKey(KeyInner::Sha256(Hmac::<rsha2::Sha256>::new_varkey(key).unwrap()), PhantomData)
 	}
 }
 
 impl SigKey<Sha512> {
 	pub fn sha512(key: &[u8]) -> SigKey<Sha512> {
-		SigKey(KeyInner::Sha512(*GenericArray::from_slice(key)), PhantomData)
+		SigKey(KeyInner::Sha512(Hmac::<rsha2::Sha512>::new_varkey(key).unwrap()), PhantomData)
+
 	}
 }
 
@@ -78,8 +79,8 @@ enum SignerInner {
 impl<T> Signer<T> {
 	pub fn with(key: &SigKey<T>) -> Signer<T> {
 		match &key.0 {
-			KeyInner::Sha256(k) => Signer(SignerInner::Sha256(Hmac::new(k)), PhantomData),
-			KeyInner::Sha512(k) => Signer(SignerInner::Sha512(Hmac::new(k)), PhantomData),
+			KeyInner::Sha256(k) => Signer(SignerInner::Sha256(k.clone()), PhantomData),
+			KeyInner::Sha512(k) => Signer(SignerInner::Sha512(k.clone()), PhantomData),
 		}
 	}
 
@@ -103,29 +104,27 @@ pub struct VerifyKey<T>(KeyInner, PhantomData<T>);
 
 impl VerifyKey<Sha256> {
 	pub fn sha256(key: &[u8]) -> VerifyKey<Sha256> {
-		VerifyKey(KeyInner::Sha256(*GenericArray::from_slice(key)), PhantomData)
+		VerifyKey(KeyInner::Sha256(Hmac::<rsha2::Sha256>::new_varkey(key).unwrap()), PhantomData)
 	}
 }
 
 impl VerifyKey<Sha512> {
 	pub fn sha512(key: &[u8]) -> VerifyKey<Sha512> {
-		VerifyKey(KeyInner::Sha512(*GenericArray::from_slice(key)), PhantomData)
+		VerifyKey(KeyInner::Sha512(Hmac::<rsha2::Sha512>::new_varkey(key).unwrap()), PhantomData)
 	}
 }
 
 /// Verify HMAC signature of `data`.
-pub fn verify<T>(k: &VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
-	match &k.0 {
-		KeyInner::Sha256(k) => {
-			let mut ctxt = Hmac::<rsha2::Sha256>::new(k);
-			ctxt.input(data);
-			ctxt.verify(sig).is_ok()
-		}
-		KeyInner::Sha512(k) => {
-			let mut ctxt = Hmac::<rsha2::Sha512>::new(k);
-			ctxt.input(data);
-			ctxt.verify(sig).is_ok()
-		}
+pub fn verify<T>(k: VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
+	match k.0 {
+		KeyInner::Sha256(mut ctx) => {
+			ctx.input(data);
+			ctx.verify(sig).is_ok();
+		},
+		KeyInner::Sha512(mut ctx) => {
+			ctx.input(data);
+			ctx.verify(sig).is_ok();
+		},
 	}
 }
 

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -115,15 +115,17 @@ impl VerifyKey<Sha512> {
 }
 
 /// Verify HMAC signature of `data`.
-pub fn verify<T>(k: VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
-	match k.0 {
-		KeyInner::Sha256(mut ctx) => {
-			ctx.input(data);
-			ctx.verify(sig).is_ok();
+pub fn verify<T>(key: &VerifyKey<T>, data: &[u8], sig: &[u8]) -> bool {
+	match &key.0 {
+		KeyInner::Sha256(ctx) => {
+			let mut ctx2 = ctx.clone();
+			ctx2.input(data);
+			ctx2.verify(sig).is_ok();
 		},
-		KeyInner::Sha512(mut ctx) => {
-			ctx.input(data);
-			ctx.verify(sig).is_ok();
+		KeyInner::Sha512(ctx) => {
+			let mut ctx2 = ctx.clone();
+			ctx2.input(data);
+			ctx2.verify(sig).is_ok();
 		},
 	}
 }

--- a/parity-crypto/src/hmac/mod.rs
+++ b/parity-crypto/src/hmac/mod.rs
@@ -22,8 +22,10 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 /// HMAC signature.
+#[derive(Debug)]
 pub struct Signature<T>(HashInner, PhantomData<T>);
 
+#[derive(Debug)]
 enum HashInner {
 	Sha256(GenericArray<u8, U32>),
 	Sha512(GenericArray<u8, U64>),

--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-
 use super::*;
+use hex_literal::hex;
+
 #[test]
 fn simple_mac_and_verify() {
 	let input = b"Some bytes";
@@ -45,4 +46,155 @@ fn simple_mac_and_verify() {
 	let verif_key2 = VerifyKey::sha512(&key2[..]);
 	assert!(verify(&verif_key1, &input[..], &sig1[..]));
 	assert!(verify(&verif_key2, &big_input[..], &sig2[..]));
+}
+
+fn check_test_vector(
+	key: &[u8],
+	data: &[u8],
+	expected_256: &[u8],
+	expected_512: &[u8],
+) {
+	// Sha-256
+	let sig_key = SigKey::sha256(&key);
+	let mut signer = Signer::with(&sig_key);
+	signer.update(&data);
+	let signature = signer.sign();
+	assert_eq!(&signature[..], expected_256);
+	assert_eq!(&signature[..], &sign(&sig_key, data)[..]);
+	let ver_key = VerifyKey::sha256(&key);
+	assert!(verify(&ver_key, data,&signature));
+
+	// Sha-512
+	let sig_key = SigKey::sha512(&key);
+	let mut signer = Signer::with(&sig_key);
+	signer.update(&data);
+	let signature = signer.sign();
+	assert_eq!(&signature[..], expected_512);
+	assert_eq!(&signature[..], &sign(&sig_key, data)[..]);
+	let ver_key = VerifyKey::sha512(&key);
+	assert!(verify(&ver_key, data,&signature));
+}
+
+#[test]
+fn ietf_test_vectors() {
+	// Test vectors from https://tools.ietf.org/html/rfc4231.html#section-4
+
+	// Test Case 1
+	check_test_vector(
+		&hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+		&hex!("4869205468657265"),
+		&hex!("
+			b0344c61d8db38535ca8afceaf0bf12b
+			881dc200c9833da726e9376c2e32cff7"),
+		&hex!("
+			87aa7cdea5ef619d4ff0b4241a1d6cb0
+			2379f4e2ce4ec2787ad0b30545e17cde
+			daa833b7d6b8a702038b274eaea3f4e4
+			be9d914eeb61f1702e696c203a126854")
+	);
+
+	// Test Case 2
+	check_test_vector(
+		&hex!("4a656665"),
+		&hex!("7768617420646f2079612077616e7420666f72206e6f7468696e673f"),
+		&hex!("
+			5bdcc146bf60754e6a042426089575c7
+			5a003f089d2739839dec58b964ec3843"),
+		&hex!("
+			164b7a7bfcf819e2e395fbe73b56e0a3
+			87bd64222e831fd610270cd7ea250554
+			9758bf75c05a994a6d034f65f8f0e6fd
+			caeab1a34d4a6b4b636e070a38bce737")
+	);
+	// Test Case 3
+	check_test_vector(
+		&hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		&hex!("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+		&hex!("
+			773ea91e36800e46854db8ebd09181a7
+			2959098b3ef8c122d9635514ced565fe"),
+		&hex!("
+			fa73b0089d56a284efb0f0756c890be9
+			b1b5dbdd8ee81a3655f83e33b2279d39
+			bf3e848279a722c806b485a47e67c807
+			b946a337bee8942674278859e13292fb")
+	);
+
+	// Test Case 4
+	check_test_vector(
+		&hex!("0102030405060708090a0b0c0d0e0f10111213141516171819"),
+		&hex!("
+			cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd
+			cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd
+			cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd
+			cdcd"),
+		&hex!("
+			82558a389a443c0ea4cc819899f2083a
+			85f0faa3e578f8077a2e3ff46729665b"),
+		&hex!("
+			b0ba465637458c6990e5a8c5f61d4af7
+			e576d97ff94b872de76f8050361ee3db
+			a91ca5c11aa25eb4d679275cc5788063
+			a5f19741120c4f2de2adebeb10a298dd")
+	);
+
+	// Test Case 6
+	check_test_vector(
+		&hex!("
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaa"),
+		&hex!("
+			54657374205573696e67204c61726765
+			72205468616e20426c6f636b2d53697a
+			65204b6579202d2048617368204b6579
+			204669727374"),
+		&hex!("
+			60e431591ee0b67f0d8a26aacbf5b77f
+			8e0bc6213728c5140546040f0ee37f54"),
+		&hex!("
+			80b24263c7c1a3ebb71493c1dd7be8b4
+			9b46d1f41b4aeec1121b013783f8f352
+			6b56d037e05f2598bd0fd2215d6a1e52
+			95e64f73f63f0aec8b915a985d786598")
+	);
+
+	// Test Case 7
+	check_test_vector(
+		&hex!("
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+			aaaaaa"),
+		&hex!("
+			54686973206973206120746573742075
+			73696e672061206c6172676572207468
+			616e20626c6f636b2d73697a65206b65
+			7920616e642061206c61726765722074
+			68616e20626c6f636b2d73697a652064
+			6174612e20546865206b6579206e6565
+			647320746f2062652068617368656420
+			6265666f7265206265696e6720757365
+			642062792074686520484d414320616c
+			676f726974686d2e"),
+		&hex!("
+			9b09ffa71b942fcb27635fbcd5b0e944
+			bfdc63644f0713938a7f51535c3a35e2"),
+		&hex!("
+			e37b6a775dc87dbaa4dfa9f96e5e3ffd
+			debd71f8867289865df5a32d20cdc944
+			b6022cac3c4982b10d5eeb55c3e4de15
+			134676fb6de0446065c97440fa8c6a58")
+	);
 }

--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -202,15 +202,17 @@ fn ietf_test_vectors() {
 #[test]
 fn secrets_are_zeroed_on_drop() {
 	let ptr: *const KeyInner;
+	let zeros = KeyInner::Sha256(DisposableBox::from_slice(&[0u8; 6][..]));
+	let expected = KeyInner::Sha256(DisposableBox::from_slice(b"sikrit"));
 	{
 		let secret = b"sikrit";
 		let signing_key = SigKey::sha256(secret);
 		ptr = &signing_key.0;
 		unsafe {
-			assert_eq!(*ptr, KeyInner::Sha256(DisposableBox::from_slice(b"sikrit")));
+			assert_eq!(*ptr, expected);
 		}
 	}
 	unsafe {
-		assert_eq!(*ptr, KeyInner::Sha256(DisposableBox::from_slice(&[0u8;6][..])));
+		assert_eq!(*ptr, zeros);
 	}
 }

--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -43,6 +43,6 @@ fn simple_mac_and_verify() {
 	assert_eq!(&sig2[..], &sign(&sig_key2, &big_input[..])[..]);
 	let verif_key1 = VerifyKey::sha256(&key1[..]);
 	let verif_key2 = VerifyKey::sha512(&key2[..]);
-	assert!(verify(verif_key1, &input[..], &sig1[..]));
-	assert!(verify(verif_key2, &big_input[..], &sig2[..]));
+	assert!(verify(&verif_key1, &input[..], &sig1[..]));
+	assert!(verify(&verif_key2, &big_input[..], &sig2[..]));
 }

--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -43,7 +43,6 @@ fn simple_mac_and_verify() {
 	assert_eq!(&sig2[..], &sign(&sig_key2, &big_input[..])[..]);
 	let verif_key1 = VerifyKey::sha256(&key1[..]);
 	let verif_key2 = VerifyKey::sha512(&key2[..]);
-	assert!(verify(&verif_key1, &input[..], &sig1[..]));
-	assert!(verify(&verif_key2, &big_input[..], &sig2[..]));
-
+	assert!(verify(verif_key1, &input[..], &sig1[..]));
+	assert!(verify(verif_key2, &big_input[..], &sig2[..]));
 }

--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -198,3 +198,19 @@ fn ietf_test_vectors() {
 			134676fb6de0446065c97440fa8c6a58")
 	);
 }
+
+#[test]
+fn secrets_are_zeroed_on_drop() {
+	let ptr: *const KeyInner;
+	{
+		let secret = b"sikrit";
+		let signing_key = SigKey::sha256(secret);
+		ptr = &signing_key.0;
+		unsafe {
+			assert_eq!(*ptr, KeyInner::Sha256(DisposableBox::from_slice(b"sikrit")));
+		}
+	}
+	unsafe {
+		assert_eq!(*ptr, KeyInner::Sha256(DisposableBox::from_slice(&[0u8;6][..])));
+	}
+}

--- a/parity-crypto/src/lib.rs
+++ b/parity-crypto/src/lib.rs
@@ -29,6 +29,7 @@ extern crate aes_ctr;
 extern crate block_modes;
 extern crate pbkdf2 as rpbkdf2;
 extern crate constant_time_eq;
+extern crate memzero;
 
 #[cfg(test)]
 extern crate hex_literal;

--- a/parity-crypto/src/lib.rs
+++ b/parity-crypto/src/lib.rs
@@ -30,6 +30,11 @@ extern crate block_modes;
 extern crate pbkdf2 as rpbkdf2;
 extern crate constant_time_eq;
 
+#[cfg(test)]
+#[macro_use]
+extern crate hex_literal;
+
+
 pub mod aes;
 pub mod error;
 pub mod scrypt;


### PR DESCRIPTION
Builds on https://github.com/paritytech/parity-common/pull/156

The main reason for the `DisposableBox` is to enable some testing. I'm really not sure if [the test](https://github.com/paritytech/parity-common/pull/157/files#diff-e80bd3823ad0c7b97d4b737df4e518afR203) added is actually meaningful but I couldn't come up with anything better. Input appreciated. 