### PR TITLE
[keccak-hash] Bump version

### DIFF
--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hash"
-version = "0.1.3"
+version = "0.2.0"
 description = "`keccak-hash` is a set of utility functions to facilitate working with Keccak hashes (256/512 bits long)."
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 
 [dependencies]
 tiny-keccak = "1.4"
-primitive-types = { path = "../primitive-types", version = "0.2" }
+primitive-types = "0.2"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 
 [dependencies]
 tiny-keccak = "1.4"
-primitive-types = "0.2"
+primitive-types = { path = "../primitive-types", version = "0.2" }
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
~~In the switch to depend on `primitive-types` a local dependency was used (`{ path = "../primitive-types" }`). And a new version was never published, which causes trouble for depending crates higher up the stack.~~

Bump to 0.2.0

~~Question: should the version be `0.2` here? I think so.~~