### PR TITLE
Make ethereum-types more compatible with 0.4.2

### DIFF
--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -19,8 +19,13 @@ construct_fixed_hash!{ pub struct H128(16); }
 impl_fixed_hash_rlp!(H128, 16);
 #[cfg(feature = "serialize")] impl_fixed_hash_serde!(H128, 16);
 
-pub use primitive_types::H160;
-pub use primitive_types::H256;
+construct_fixed_hash!{ pub struct H160(20); }
+impl_fixed_hash_rlp!(H160, 20);
+#[cfg(feature = "serialize")] impl_fixed_hash_serde!(H160, 20);
+
+construct_fixed_hash!{ pub struct H256(32); }
+impl_fixed_hash_rlp!(H256, 32);
+#[cfg(feature = "serialize")] impl_fixed_hash_serde!(H256, 32);
 
 construct_fixed_hash!{ pub struct H264(33); }
 impl_fixed_hash_rlp!(H264, 33);
@@ -55,6 +60,34 @@ impl_uint_conversions!(H128, U128);
 impl_uint_conversions!(H256, U256);
 impl_uint_conversions!(H512, U512);
 
+impl From<H160> for H256 {
+	fn from(value: H160) -> H256 {
+		let mut ret = H256::zero();
+		ret.0[12..32].copy_from_slice(value.as_bytes());
+		ret
+	}
+}
+
+impl<'a> From<&'a H160> for H256 {
+	fn from(value: &'a H160) -> H256 {
+		let mut ret = H256::zero();
+		ret.0[12..32].copy_from_slice(value.as_bytes());
+		ret
+	}
+}
+
+impl From<u64> for H160 {
+	fn from(val: u64) -> Self {
+		H160::from_low_u64_be(val)
+	}
+}
+
+impl From<u64> for H256 {
+	fn from(val: u64) -> Self {
+		H256::from_low_u64_be(val)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::{H160, H256};
@@ -63,13 +96,13 @@ mod tests {
 	#[test]
 	fn test_serialize_h160() {
 		let tests = vec![
-			(H160::from_low_u64_be(0), "0x0000000000000000000000000000000000000000"),
-			(H160::from_low_u64_be(2), "0x0000000000000000000000000000000000000002"),
-			(H160::from_low_u64_be(15), "0x000000000000000000000000000000000000000f"),
-			(H160::from_low_u64_be(16), "0x0000000000000000000000000000000000000010"),
-			(H160::from_low_u64_be(1_000), "0x00000000000000000000000000000000000003e8"),
-			(H160::from_low_u64_be(100_000), "0x00000000000000000000000000000000000186a0"),
-			(H160::from_low_u64_be(u64::max_value()), "0x000000000000000000000000ffffffffffffffff"),
+			(H160::from(0), "0x0000000000000000000000000000000000000000"),
+			(H160::from(2), "0x0000000000000000000000000000000000000002"),
+			(H160::from(15), "0x000000000000000000000000000000000000000f"),
+			(H160::from(16), "0x0000000000000000000000000000000000000010"),
+			(H160::from(1_000), "0x00000000000000000000000000000000000003e8"),
+			(H160::from(100_000), "0x00000000000000000000000000000000000186a0"),
+			(H160::from(u64::max_value()), "0x000000000000000000000000ffffffffffffffff"),
 		];
 
 		for (number, expected) in tests {
@@ -81,13 +114,13 @@ mod tests {
 	#[test]
 	fn test_serialize_h256() {
 		let tests = vec![
-			(H256::from_low_u64_be(0), "0x0000000000000000000000000000000000000000000000000000000000000000"),
-			(H256::from_low_u64_be(2), "0x0000000000000000000000000000000000000000000000000000000000000002"),
-			(H256::from_low_u64_be(15), "0x000000000000000000000000000000000000000000000000000000000000000f"),
-			(H256::from_low_u64_be(16), "0x0000000000000000000000000000000000000000000000000000000000000010"),
-			(H256::from_low_u64_be(1_000), "0x00000000000000000000000000000000000000000000000000000000000003e8"),
-			(H256::from_low_u64_be(100_000), "0x00000000000000000000000000000000000000000000000000000000000186a0"),
-			(H256::from_low_u64_be(u64::max_value()), "0x000000000000000000000000000000000000000000000000ffffffffffffffff"),
+			(H256::from(0), "0x0000000000000000000000000000000000000000000000000000000000000000"),
+			(H256::from(2), "0x0000000000000000000000000000000000000000000000000000000000000002"),
+			(H256::from(15), "0x000000000000000000000000000000000000000000000000000000000000000f"),
+			(H256::from(16), "0x0000000000000000000000000000000000000000000000000000000000000010"),
+			(H256::from(1_000), "0x00000000000000000000000000000000000000000000000000000000000003e8"),
+			(H256::from(100_000), "0x00000000000000000000000000000000000000000000000000000000000186a0"),
+			(H256::from(u64::max_value()), "0x000000000000000000000000000000000000000000000000ffffffffffffffff"),
 		];
 
 		for (number, expected) in tests {

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -90,7 +90,7 @@ impl From<u64> for H256 {
 
 impl From<H256> for H160 {
 	fn from(value: H256) -> H160 {
-		let mut ret = H160::new();
+		let mut ret = H160::zero();
 		ret.0.copy_from_slice(&value[12..32]);
 		ret
 	}

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -88,6 +88,14 @@ impl From<u64> for H256 {
 	}
 }
 
+impl From<H256> for H160 {
+	fn from(value: H256) -> H160 {
+		let mut ret = H160::new();
+		ret.0.copy_from_slice(&value[12..32]);
+		ret
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::{H160, H256};


### PR DESCRIPTION
Ref: https://github.com/paritytech/parity-ethereum/pull/10670

I know some conversions were deprecated and then removed for a reason, but we need them in parity-ethereum anyway.