### PR TITLE
[rlp] Add no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
+  - cd rlp/ && cargo test --no-default-features && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ script:
   - cargo check --all --tests
   - cargo build --all
   - cargo test --all --exclude uint --exclude fixed-hash
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd parity-bytes/ && cargo build --no-default-features && cd ..;
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    cd parity-bytes/ && cargo build --no-default-features && cd ..;
+    cd rlp/ && cargo test --no-default-features && cd ..;
     fi
   - cd fixed-hash/ && cargo test --all-features && cd ..
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
-  - cd rlp/ && cargo test --no-default-features && cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,4 @@ test_script:
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
+  - cd rlp/ && cargo test --no-default-features && cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,3 @@ test_script:
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
   - cd plain_hasher/ && cargo test --no-default-features && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
-  - cd rlp/ && cargo test --no-default-features && cd ..

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -5,12 +5,15 @@ description = "Recursive-length prefix encoding, decoding, and compression"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT/Apache-2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
-byteorder = "1.0"
-rustc-hex = {version = "2.0", default-features = false }
+byteorder = { version = "1", default-features = false }
+rustc-hex = { version = "2.0", default-features = false }
 
-[dev-dependencies]
-hex-literal = "0.1"
-primitive-types = { path = "../primitive-types", version = "0.3", features = ["impl-rlp"] }
-
+[features]
+default = ["std"]
+std = [
+    "byteorder/std",
+    "rustc-hex/std",
+]

--- a/rlp/benches/rlp.rs
+++ b/rlp/benches/rlp.rs
@@ -14,11 +14,8 @@
 
 #![feature(test)]
 
-extern crate ethereum_types;
-extern crate rlp;
 extern crate test;
 
-use ethereum_types::U256;
 use rlp::{RlpStream, Rlp};
 use test::Bencher;
 
@@ -39,29 +36,6 @@ fn bench_decode_u64_value(b: &mut Bencher) {
 		let data = vec![0x88, 0x10, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
 		let rlp = Rlp::new(&data);
 		let _: u64 = rlp.as_val().unwrap();
-	});
-}
-
-#[bench]
-fn bench_stream_u256_value(b: &mut Bencher) {
-	b.iter(|| {
-		// u256
-		let mut stream = RlpStream::new();
-		let uint: U256 = "8090a0b0c0d0e0f00910203040506077000000000000000100000000000012f0".into();
-		stream.append(&uint);
-		let _ = stream.out();
-	});
-}
-
-#[bench]
-fn bench_decode_u256_value(b: &mut Bencher) {
-	b.iter(|| {
-		// u256
-		let data = vec![0xa0, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0x09, 0x10, 0x20,
-		                0x30, 0x40, 0x50, 0x60, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0xf0];
-		let rlp = Rlp::new(&data);
-		let _ : U256 = rlp.as_val().unwrap();
 	});
 }
 
@@ -106,13 +80,13 @@ fn bench_stream_1000_empty_lists(b: &mut Bencher) {
 fn bench_decode_1000_values(b: &mut Bencher) {
 	let mut stream = RlpStream::new_list(1000);
 	for _ in 0..1000 {
-		stream.append(&U256::from(1));
+		stream.append(&1u64);
 	}
 	let data= stream.out();
 	b.iter(|| {
 		let rlp = Rlp::new(&data);
 		for i in 0..1000 {
-			let _: U256 = rlp.val_at(i).unwrap();
+			let _: u64 = rlp.val_at(i).unwrap();
 		}
 	});
 }

--- a/rlp/src/error.rs
+++ b/rlp/src/error.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt;
+use core::fmt;
+#[cfg(feature = "std")]
 use std::error::Error as StdError;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -36,6 +37,7 @@ pub enum DecoderError {
 	Custom(&'static str),
 }
 
+#[cfg(feature = "std")]
 impl StdError for DecoderError {
 	fn description(&self) -> &str {
 		"builder error"

--- a/rlp/src/impls.rs
+++ b/rlp/src/impls.rs
@@ -13,10 +13,12 @@ use core::iter::{once, empty};
 
 use byteorder::{ByteOrder, BigEndian};
 
-use crate::error::DecoderError;
-use crate::rlpin::Rlp;
-use crate::stream::RlpStream;
-use crate::traits::{Encodable, Decodable};
+use crate::{
+	error::DecoderError,
+	rlpin::Rlp,
+	stream::RlpStream,
+	traits::{Encodable, Decodable},
+};
 
 pub fn decode_usize(bytes: &[u8]) -> Result<usize, DecoderError> {
 	match bytes.len() {

--- a/rlp/src/impls.rs
+++ b/rlp/src/impls.rs
@@ -6,12 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{mem, str};
-use std::iter::{once, empty};
+#[cfg(not(feature = "std"))]
+use alloc::{borrow::ToOwned, vec::Vec, string::String};
+use core::{mem, str};
+use core::iter::{once, empty};
+
 use byteorder::{ByteOrder, BigEndian};
-use traits::{Encodable, Decodable};
-use stream::RlpStream;
-use {Rlp, DecoderError};
+
+use super::error::DecoderError;
+use super::rlpin::Rlp;
+use super::stream::RlpStream;
+use super::traits::{Encodable, Decodable};
 
 pub fn decode_usize(bytes: &[u8]) -> Result<usize, DecoderError> {
 	match bytes.len() {

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -32,11 +32,10 @@
 //! * You want to get view onto rlp-slice.
 //! * You don't want to decode whole rlp at once.
 
-extern crate byteorder;
-extern crate rustc_hex;
-#[cfg(test)]
-#[macro_use]
-extern crate hex_literal;
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 mod traits;
 mod error;
@@ -44,12 +43,14 @@ mod rlpin;
 mod stream;
 mod impls;
 
-use std::borrow::Borrow;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::borrow::Borrow;
 
-pub use error::DecoderError;
-pub use traits::{Decodable, Encodable};
-pub use rlpin::{Rlp, RlpIterator, PayloadInfo, Prototype};
-pub use stream::RlpStream;
+pub use self::error::DecoderError;
+pub use self::rlpin::{Rlp, RlpIterator, PayloadInfo, Prototype};
+pub use self::stream::RlpStream;
+pub use self::traits::{Decodable, Encodable};
 
 /// The RLP encoded empty data (used to mean "null value").
 pub const NULL_RLP: [u8; 1] = [0x80; 1];

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -6,11 +6,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cell::Cell;
-use std::fmt;
+#[cfg(not(feature = "std"))]
+use alloc::{vec::Vec, string::String};
+use core::cell::Cell;
+use core::fmt;
+
 use rustc_hex::ToHex;
-use impls::decode_usize;
-use {Decodable, DecoderError};
+
+use super::error::DecoderError;
+use super::impls::decode_usize;
+use super::traits::Decodable;
 
 /// rlp offset
 #[derive(Copy, Clone, Debug)]
@@ -387,11 +392,13 @@ impl<'a> BasicDecoder<'a> {
 
 #[cfg(test)]
 mod tests {
-	use {Rlp, DecoderError};
+	#[cfg(not(feature = "std"))]
+	use alloc::format;
+	use super::*;
 
 	#[test]
 	fn test_rlp_display() {
-		let data = hex!("f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+		let data: Vec<u8> = rustc_hex::FromHex::from_hex("f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").unwrap();
 		let rlp = Rlp::new(&data);
 		assert_eq!(format!("{}", rlp), "[\"0x05\", \"0x010efbef67941f79b2\", \"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"]");
 	}

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -7,15 +7,17 @@
 // except according to those terms.
 
 #[cfg(not(feature = "std"))]
-use alloc::{vec::Vec, string::String};
+use alloc::{string::String, vec::Vec};
 use core::cell::Cell;
 use core::fmt;
 
 use rustc_hex::ToHex;
 
-use crate::error::DecoderError;
-use crate::impls::decode_usize;
-use crate::traits::Decodable;
+use crate::{
+	error::DecoderError,
+	impls::decode_usize,
+	traits::Decodable,
+};
 
 /// rlp offset
 #[derive(Copy, Clone, Debug)]
@@ -387,31 +389,5 @@ impl<'a> BasicDecoder<'a> {
 		} else {
 			Err(DecoderError::RlpExpectedToBeData)
 		}
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	#[cfg(not(feature = "std"))]
-	use alloc::{format, vec::Vec};
-	use super::{Rlp, DecoderError};
-
-	fn hex(s: &str) -> Vec<u8> {
-		rustc_hex::FromHex::from_hex(s).unwrap()
-	}
-
-	#[test]
-	fn test_rlp_display() {
-		let data = hex("f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
-		let rlp = Rlp::new(&data);
-		assert_eq!(format!("{}", rlp), "[\"0x05\", \"0x010efbef67941f79b2\", \"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"]");
-	}
-
-	#[test]
-	fn length_overflow() {
-		let bs = [0xbf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xe5];
-		let rlp = Rlp::new(&bs);
-		let res: Result<u8, DecoderError> = rlp.as_val();
-		assert_eq!(Err(DecoderError::RlpInvalidLength), res);
 	}
 }

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -6,9 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::Borrow;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+
 use byteorder::{ByteOrder, BigEndian};
-use traits::Encodable;
+
+use super::traits::Encodable;
 
 #[derive(Debug, Copy, Clone)]
 struct ListInfo {

--- a/rlp/src/traits.rs
+++ b/rlp/src/traits.rs
@@ -7,7 +7,12 @@
 // except according to those terms.
 
 //! Common RLP traits
-use {DecoderError, Rlp, RlpStream};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::error::DecoderError;
+use super::rlpin::Rlp;
+use super::stream::RlpStream;
 
 /// RLP decodable trait
 pub trait Decodable: Sized {

--- a/rlp/src/traits.rs
+++ b/rlp/src/traits.rs
@@ -10,9 +10,11 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::error::DecoderError;
-use crate::rlpin::Rlp;
-use crate::stream::RlpStream;
+use crate::{
+	error::DecoderError,
+	rlpin::Rlp,
+	stream::RlpStream,
+};
 
 /// RLP decodable trait
 pub trait Decodable: Sized {

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -9,13 +9,28 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{vec::Vec, string::String};
+use alloc::{format, string::String, vec::Vec};
 use core::{fmt, cmp};
 
 use rlp::{Encodable, Decodable, Rlp, RlpStream, DecoderError};
 
 fn hex(s: &str) -> Vec<u8> {
 	rustc_hex::FromHex::from_hex(s).unwrap()
+}
+
+#[test]
+fn test_rlp_display() {
+	let data = hex("f84d0589010efbef67941f79b2a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+	let rlp = Rlp::new(&data);
+	assert_eq!(format!("{}", rlp), "[\"0x05\", \"0x010efbef67941f79b2\", \"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"]");
+}
+
+#[test]
+fn length_overflow() {
+	let bs = [0xbf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xe5];
+	let rlp = Rlp::new(&bs);
+	let res: Result<u8, DecoderError> = rlp.as_val();
+	assert_eq!(Err(DecoderError::RlpInvalidLength), res);
 }
 
 #[test]

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -248,21 +248,6 @@ fn decode_untrusted_u64() {
 	run_decode_tests(tests);
 }
 
-//#[test]
-//fn decode_untrusted_u256() {
-//	let tests = vec![DTestPair(U256::from(0u64), vec![0x80u8]),
-//					 DTestPair(U256::from(0x1000000u64), vec![0x84, 0x01, 0x00, 0x00, 0x00]),
-//					 DTestPair(U256::from(0xffffffffu64),
-//							   vec![0x84, 0xff, 0xff, 0xff, 0xff]),
-//					 DTestPair(("8090a0b0c0d0e0f00910203040506077000000000000\
-//											   000100000000000012f0").into(),
-//							   vec![0xa0, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0,
-//									0x09, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x77, 0x00,
-//									0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-//									0x00, 0x00, 0x00, 0x00, 0x12, 0xf0])];
-//	run_decode_tests(tests);
-//}
-
 #[test]
 fn decode_untrusted_str() {
 	let tests = vec![DTestPair("cat".to_owned(), vec![0x83, b'c', b'a', b't']),
@@ -281,17 +266,6 @@ fn decode_untrusted_str() {
 									b'e', b'l', b'i', b't'])];
 	run_decode_tests(tests);
 }
-
-//#[test]
-//fn decode_untrusted_address() {
-//	let tests = vec![
-//		DTestPair(H160::from(FromHex::from_hex("ef2d6d194084c2de36e0dabfce45d046b37d1106").unwrap()),
-//				  vec![0x94, 0xef, 0x2d, 0x6d, 0x19, 0x40, 0x84, 0xc2, 0xde,
-//							 0x36, 0xe0, 0xda, 0xbf, 0xce, 0x45, 0xd0, 0x46,
-//							 0xb3, 0x7d, 0x11, 0x06])
-//	];
-//	run_decode_tests(tests);
-//}
 
 #[test]
 fn decode_untrusted_vector_u64() {


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

# What have I changed?

- Add `no_std` support for `rlp` crate
- Migrate `rlp` crate to 2018 edition
- Remove some test cases that depend on `primitive-types` (These test cases should be added to `primitive-types` instead of `rlp`)