### PR TITLE
Fix deprecation warning

### DIFF
--- a/parity-path/Cargo.toml
+++ b/parity-path/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Path utilities"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 dirs = "2.0.0"

--- a/parity-path/Cargo.toml
+++ b/parity-path/Cargo.toml
@@ -8,4 +8,4 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-home = "0.3.4"
+home = "0.5"

--- a/parity-path/Cargo.toml
+++ b/parity-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-path"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Path utilities"

--- a/parity-path/Cargo.toml
+++ b/parity-path/Cargo.toml
@@ -7,3 +7,4 @@ description = "Path utilities"
 license = "GPL-3.0"
 
 [dependencies]
+dirs = "2.0.0"

--- a/parity-path/Cargo.toml
+++ b/parity-path/Cargo.toml
@@ -8,4 +8,4 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-dirs = "2.0.0"
+home = "0.3.4"

--- a/parity-path/src/lib.rs
+++ b/parity-path/src/lib.rs
@@ -15,14 +15,17 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Path utilities
+extern crate dirs;
 use std::path::Path;
 use std::path::PathBuf;
+
+use dirs::home_dir;
 
 #[cfg(target_os = "macos")]
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = home_dir().expect("Failed to get home dir");
 	home.push("Library");
 	home.push(name);
 	home
@@ -32,7 +35,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = home_dir().expect("Failed to get home dir");
 	home.push("AppData");
 	home.push("Roaming");
 	home.push(name);
@@ -43,7 +46,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = home_dir().expect("Failed to get home dir");
 	home.push(format!(".{}", name.to_lowercase()));
 	home
 }

--- a/parity-path/src/lib.rs
+++ b/parity-path/src/lib.rs
@@ -18,7 +18,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use dirs::home_dir;
+use home::home_dir;
 
 #[cfg(target_os = "macos")]
 /// Get the config path for application `name`.

--- a/parity-path/src/lib.rs
+++ b/parity-path/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Path utilities
-extern crate dirs;
 use std::path::Path;
 use std::path::PathBuf;
 


### PR DESCRIPTION
Use the `dirs` crate as suggested. Upgrade to the 2018 edition.