### PR TITLE
Add no_std support for fixed-hash with feature `rustc-hex`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ script:
   - cargo check --all --tests
   - cargo build --all
   - cargo test --all --exclude uint --exclude fixed-hash
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cd parity-bytes/ && cargo build --no-default-features && cd ..;
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    cd parity-bytes/ && cargo build --no-default-features && cd ..;
+    cd fixed-hash/ && cargo test --no-default-features --features="rustc-hex,byteorder" && cd..;
     fi
   - cd fixed-hash/ && cargo test --all-features && cd ..
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -654,6 +654,8 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 			fn from_str(
 				input: &str,
 			) -> $crate::core_::result::Result<$name, $crate::rustc_hex::FromHexError> {
+				#[cfg(not(feature = "std"))]
+				use $crate::alloc_::vec::Vec;
 				use $crate::rustc_hex::FromHex;
 				let bytes: Vec<u8> = input.from_hex()?;
 				if bytes.len() != Self::len_bytes() {

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -8,6 +8,12 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Re-export liballoc using an alias so that the macros can work without
+// requiring `extern crate alloc` downstream.
+#[cfg(not(feature = "std"))]
+#[doc(hidden)]
+pub extern crate alloc as alloc_;
+
 // Re-export libcore using an alias so that the macros can work without
 // requiring `extern crate core` downstream.
 #[doc(hidden)]


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

Run `cargo test --no-default-features --features="rustc-hex"`  in `fixed-hash` directory.

Before:
```
...
error[E0412]: cannot find type `Vec` in this scope
   --> fixed-hash/src/hash.rs:658:16
    |
658 |                 let bytes: Vec<u8> = input.from_hex()?;
    |                            ^^^ not found in this scope
    | 
   ::: fixed-hash/src/tests.rs:5:1
    |
5   | construct_fixed_hash!{ struct H256(32); }
    | ----------------------------------------- in this macro invocation

error: aborting due to 5 previous errors

For more information about this error, try `rustc --explain E0412`.
```

After: Tests passed.