### PR TITLE
[parity-util-mem] remove Memzero

### DIFF
--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "parity-util-mem"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Collection of memory related utilities"
 license = "GPL-3.0"
 
 [dependencies]
-clear_on_drop = "0.2"
 cfg-if = "0.1.6"
 malloc_size_of_derive = "0.1.0"
 dlmalloc = { version = "0.1", features = ["global"], optional = true }

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -31,9 +31,6 @@ extern crate alloc;
 
 extern crate malloc_size_of_derive as malloc_size_derive;
 
-use std::ops::{Deref, DerefMut};
-
-use std::ptr;
 
 cfg_if! {
 	if #[cfg(all(
@@ -90,42 +87,6 @@ pub use malloc_size::{
 	MallocSizeOf,
 };
 pub use allocators::MallocSizeOfExt;
-
-/// Wrapper to zero out memory when dropped.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Memzero<T: AsMut<[u8]>> {
-	mem: T,
-}
-
-impl<T: AsMut<[u8]>> From<T> for Memzero<T> {
-	fn from(mem: T) -> Memzero<T> {
-		Memzero { mem }
-	}
-}
-
-impl<T: AsMut<[u8]>> Drop for Memzero<T> {
-	fn drop(&mut self) {
-		unsafe {
-			for byte_ref in self.mem.as_mut() {
-				ptr::write_volatile(byte_ref, 0)
-			}
-		}
-	}
-}
-
-impl<T: AsMut<[u8]>> Deref for Memzero<T> {
-	type Target = T;
-
-	fn deref(&self) -> &Self::Target {
-		&self.mem
-	}
-}
-
-impl<T: AsMut<[u8]>> DerefMut for Memzero<T> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.mem
-	}
-}
 
 #[cfg(feature = "std")]
 #[cfg(test)]


### PR DESCRIPTION
Closes #181. **This is a breaking change.**
We could probably reexport zeroize's `Zeroizing` as `Memzero`, but I don't see any benefits of that. Also I'm in favor of Single Responsibility Principle and if a crate wants to (only) use `zeroize` functionality, it doesn't have to depend on allocator stuff.