### PR TITLE
[triehash] update hash-db and bump version to 0.7

### DIFF
--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "triehash"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
 license = "GPL-3.0"
 
 [dependencies]
-hash-db = "0.12.3"
+hash-db = "0.14"
 rlp = { version = "0.4", path = "../rlp" }
 
 [dev-dependencies]
-keccak-hasher = "0.12.3"
+keccak-hasher = "0.14"
 tiny-keccak = "1.4.2"
 ethereum-types = { version = "0.7", path = "../ethereum-types" }
 hex-literal = "0.2"


### PR DESCRIPTION
cc https://github.com/paritytech/trie/pull/22

This is needed for updating `parity-util-mem` to 0.2 in parity-ethereum.