### PR TITLE
Update codec + new version of primitive-types

### DIFF
--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -10,7 +10,7 @@ description = "Ethereum types"
 ethbloom = { path = "../ethbloom", version = "0.7", default-features = false }
 fixed-hash = { path = "../fixed-hash", version = "0.4", default-features = false, features = ["byteorder", "rustc-hex"] }
 uint = { path = "../uint", version = "0.8", default-features = false }
-primitive-types = { path = "../primitive-types", version = "0.4", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.5", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.2", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
 

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 
 [dependencies]
 tiny-keccak = "1.4"
-primitive-types = { path = "../primitive-types", version = "0.4" }
+primitive-types = { path = "../primitive-types", version = "0.5" }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
@@ -10,7 +10,7 @@ description = "Primitive types shared by Ethereum and Substrate"
 fixed-hash = { version = "0.4", path = "../fixed-hash", default-features = false }
 uint = { version = "0.8", path = "../uint", default-features = false }
 impl-serde = { version = "0.2", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.3", path = "impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.4", path = "impls/codec", default-features = false, optional = true }
 impl-rlp = { version = "0.2", path = "impls/rlp", default-features = false, optional = true }
 
 [features]

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "impl-codec"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
 description = "Parity Codec serialization support for uint and fixed hash."
 
 [dependencies]
-parity-codec = { version = "4.0", default-features = false }
+parity-scale-codec = { version = "1.0.3", default-features = false }
 
 [features]
 default = ["std"]
-std = ["parity-codec/std"]
+std = ["parity-scale-codec/std"]

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -27,7 +27,7 @@ macro_rules! impl_uint_codec {
 
 		impl $crate::codec::Decode for $name {
 			fn decode<I: $crate::codec::Input>(input: &mut I)
-				-> Result<Self, $crate::codec::Error>
+				-> core::result::Result<Self, $crate::codec::Error>
 			{
 				<[u8; $len * 8] as $crate::codec::Decode>::decode(input)
 					.map(|b| $name::from_little_endian(&b))
@@ -47,7 +47,7 @@ macro_rules! impl_fixed_hash_codec {
 		}
 		impl $crate::codec::Decode for $name {
 			fn decode<I: $crate::codec::Input>(input: &mut I)
-				-> Result<Self, $crate::codec::Error>
+				-> core::result::Result<Self, $crate::codec::Error>
 			{
 				<[u8; $len] as $crate::codec::Decode>::decode(input).map($name)
 			}

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -11,7 +11,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
-pub extern crate parity_codec as codec;
+pub extern crate parity_scale_codec as codec;
 
 /// Add Parity Codec serialization support to an integer created by `construct_uint!`.
 #[macro_export]
@@ -26,7 +26,9 @@ macro_rules! impl_uint_codec {
 		}
 
 		impl $crate::codec::Decode for $name {
-			fn decode<I: $crate::codec::Input>(input: &mut I) -> Option<Self> {
+			fn decode<I: $crate::codec::Input>(input: &mut I)
+				-> Result<Self, $crate::codec::Error>
+			{
 				<[u8; $len * 8] as $crate::codec::Decode>::decode(input)
 					.map(|b| $name::from_little_endian(&b))
 			}
@@ -44,7 +46,9 @@ macro_rules! impl_fixed_hash_codec {
 			}
 		}
 		impl $crate::codec::Decode for $name {
-			fn decode<I: $crate::codec::Input>(input: &mut I) -> Option<Self> {
+			fn decode<I: $crate::codec::Input>(input: &mut I)
+				-> Result<Self, $crate::codec::Error>
+			{
 				<[u8; $len] as $crate::codec::Decode>::decode(input).map($name)
 			}
 		}

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -9,7 +9,7 @@
 //! Primitive types shared by Substrate and Parity Ethereum.
 //!
 //! Those are uint types `U128`, `U256` and `U512`, and fixed hash types `H160`,
-//! `H256` and `H512`, with optional serde serialization, parity-codec and
+//! `H256` and `H512`, with optional serde serialization, parity-scale-codec and
 //! rlp encoding.
 
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -12,4 +12,4 @@ rustc-hex = {version = "2.0", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.2"
-primitive-types = { path = "../primitive-types", version = "0.4", features = ["impl-rlp"] }
+primitive-types = { path = "../primitive-types", version = "0.5", features = ["impl-rlp"] }


### PR DESCRIPTION
no need to bump version of ethereum-types, keccack-hash because major release is not published.

After merge I add tag and publish versions