### PR TITLE
Impl encodelike

### DIFF
--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
@@ -10,7 +10,7 @@ description = "Primitive types shared by Ethereum and Substrate"
 fixed-hash = { version = "0.4", path = "../fixed-hash", default-features = false }
 uint = { version = "0.8", path = "../uint", default-features = false }
 impl-serde = { version = "0.2", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.4", path = "impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.4.1", path = "impls/codec", default-features = false, optional = true }
 impl-rlp = { version = "0.2", path = "impls/rlp", default-features = false, optional = true }
 
 [features]

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-codec"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -25,6 +25,8 @@ macro_rules! impl_uint_codec {
 			}
 		}
 
+		impl $crate::codec::EncodeLike for $name {}
+
 		impl $crate::codec::Decode for $name {
 			fn decode<I: $crate::codec::Input>(input: &mut I)
 				-> core::result::Result<Self, $crate::codec::Error>
@@ -45,6 +47,9 @@ macro_rules! impl_fixed_hash_codec {
 				self.0.using_encoded(f)
 			}
 		}
+
+		impl $crate::codec::EncodeLike for $name {}
+
 		impl $crate::codec::Decode for $name {
 			fn decode<I: $crate::codec::Input>(input: &mut I)
 				-> core::result::Result<Self, $crate::codec::Error>


### PR DESCRIPTION
I actually forget to implement EncodeLike for some types.

although this is not super needed as EncodeLike is implemented for a reference to them.

Also I don't plan to publish now except it someone say so.

I updated PrimitiveTypes so one that depends on primitive can update in its cargo toml without having to import impl-codec. (or he can just do cargo update -p impl-codec but then information is not in cargo.toml anymore)