### PR TITLE
Modified AsRef impl for U-type macros

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -424,6 +424,7 @@ macro_rules! construct_uint {
 		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 		$visibility struct $name (pub [u64; $n_words]);
 
+		/// Get a reference to the underlying little-endian words. 
 		impl AsRef<[u64]> for $name {
 			#[inline]
 			fn as_ref(&self) -> &[u64] {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -424,9 +424,10 @@ macro_rules! construct_uint {
 		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 		$visibility struct $name (pub [u64; $n_words]);
 
-		impl AsRef<$name> for $name {
-			fn as_ref(&self) -> &$name {
-				&self
+		impl AsRef<[u64]> for $name {
+            #[inline]
+			fn as_ref(&self) -> &[u64] {
+				&self.0
 			}
 		}
 

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -425,7 +425,7 @@ macro_rules! construct_uint {
 		$visibility struct $name (pub [u64; $n_words]);
 
 		impl AsRef<[u64]> for $name {
-		#[inline]
+			#[inline]
 			fn as_ref(&self) -> &[u64] {
 				&self.0
 			}

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -425,7 +425,7 @@ macro_rules! construct_uint {
 		$visibility struct $name (pub [u64; $n_words]);
 
 		impl AsRef<[u64]> for $name {
-            #[inline]
+		#[inline]
 			fn as_ref(&self) -> &[u64] {
 				&self.0
 			}


### PR DESCRIPTION
- Potential bug with current implementation that led to unused API
- Replaced with useful internal getter for &[u64] types

Fixes: #195