### PR TITLE
Introduce `ContractAddress` newtype instead of scheme enum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
     cd parity-bytes/ && cargo build --no-default-features && cd ..;
     cd fixed-hash/ && cargo test --no-default-features --features="rustc-hex,byteorder" && cd ..;
     cd keccak-hash/ && cargo test --no-default-features && cd ..;
+    cd contract-address/ && cargo test --features=external_doc && cd ..;
     fi
   - cd fixed-hash/ && cargo test --all-features && cd ..
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..

--- a/contract-address/Cargo.toml
+++ b/contract-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-address"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/contract-address/README.md
+++ b/contract-address/README.md
@@ -8,11 +8,10 @@ Create an ethereum address from sender and nonce.
 
 ```rust
 use contract_address::{
-	Address, U256, contract_address, CreateContractAddress,
+	Address, U256, ContractAddress
 };
 use std::str::FromStr;
 
-let scheme = CreateContractAddress::FromSenderAndNonce;
 let sender = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
-let (address, _code_hash) = contract_address(scheme, &sender, &U256::zero(), &[]);
+let contract_address = ContractAddress::from_sender_and_nonce(&sender, &U256::zero());
 ```

--- a/contract-address/src/lib.rs
+++ b/contract-address/src/lib.rs
@@ -15,90 +15,118 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(feature = "external_doc", feature(external_doc))]
-
 #![cfg_attr(feature = "external_doc", doc(include = "../README.md"))]
 
 pub use ethereum_types::{Address, H256, U256};
 use keccak_hash::keccak;
 use rlp::RlpStream;
+use std::ops::Deref;
 
-/// Specifies how an address is calculated for a new contract.
+/// Represents an ethereum contract address
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
-pub enum CreateContractAddress {
-	/// Address is calculated from sender and nonce. pWASM `create` scheme.
-	FromSenderAndNonce,
-	/// Address is calculated from sender, salt and code hash. pWASM `create2` scheme and EIP-1014 CREATE2 scheme.
-	FromSenderSaltAndCodeHash(H256),
-	/// Address is calculated from code hash and sender. Used by pwasm create ext.
-	FromSenderAndCodeHash,
+pub struct ContractAddress(Address);
+
+impl ContractAddress {
+    /// Computes the address of a contract from the sender's address and the transaction nonce
+    pub fn from_sender_and_nonce(sender: &Address, nonce: &U256) -> Self {
+        let mut stream = RlpStream::new_list(2);
+        stream.append(sender);
+        stream.append(nonce);
+
+        ContractAddress(Address::from(keccak(stream.as_raw())))
+    }
+
+    /// Computes the address of a contract from the sender's address, the salt and code hash
+    ///
+    /// pWASM `create2` scheme and EIP-1014 CREATE2 scheme
+    pub fn from_sender_salt_and_code(sender: &Address, salt: H256, code: &[u8]) -> (Self, H256) {
+        let code_hash = keccak(code);
+        let mut buffer = [0u8; 1 + 20 + 32 + 32];
+        buffer[0] = 0xff;
+        &mut buffer[1..(1 + 20)].copy_from_slice(&sender[..]);
+        &mut buffer[(1 + 20)..(1 + 20 + 32)].copy_from_slice(&salt[..]);
+        &mut buffer[(1 + 20 + 32)..].copy_from_slice(&code_hash[..]);
+
+        (
+            ContractAddress(Address::from(keccak(&buffer[..]))),
+            code_hash,
+        )
+    }
+
+    /// Computes the address of a contract from the sender's address and the code hash
+    ///
+    /// Used by pwasm create ext.
+    pub fn from_sender_and_code(sender: &Address, code: &[u8]) -> (Self, H256) {
+        let code_hash = keccak(code);
+        let mut buffer = [0u8; 20 + 32];
+        &mut buffer[..20].copy_from_slice(&sender[..]);
+        &mut buffer[20..].copy_from_slice(&code_hash[..]);
+
+        (
+            ContractAddress(Address::from(keccak(&buffer[..]))),
+            code_hash,
+        )
+    }
 }
 
-/// Returns new address created from address, nonce, and code hash
-pub fn contract_address(
-	address_scheme: CreateContractAddress,
-	sender: &Address,
-	nonce: &U256,
-	code: &[u8],
-) -> (Address, Option<H256>) {
-	match address_scheme {
-		CreateContractAddress::FromSenderAndNonce => {
-			let mut stream = RlpStream::new_list(2);
-			stream.append(sender);
-			stream.append(nonce);
-			(From::from(keccak(stream.as_raw())), None)
-		},
-		CreateContractAddress::FromSenderSaltAndCodeHash(salt) => {
-			let code_hash = keccak(code);
-			let mut buffer = [0u8; 1 + 20 + 32 + 32];
-			buffer[0] = 0xff;
-			&mut buffer[1..(1+20)].copy_from_slice(&sender[..]);
-			&mut buffer[(1+20)..(1+20+32)].copy_from_slice(&salt[..]);
-			&mut buffer[(1+20+32)..].copy_from_slice(&code_hash[..]);
-			(From::from(keccak(&buffer[..])), Some(code_hash))
-		},
-		CreateContractAddress::FromSenderAndCodeHash => {
-			let code_hash = keccak(code);
-			let mut buffer = [0u8; 20 + 32];
-			&mut buffer[..20].copy_from_slice(&sender[..]);
-			&mut buffer[20..].copy_from_slice(&code_hash[..]);
-			(From::from(keccak(&buffer[..])), Some(code_hash))
-		},
-	}
+impl Deref for ContractAddress {
+    type Target = Address;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<ContractAddress> for Address {
+    fn from(contract_address: ContractAddress) -> Self {
+        contract_address.0
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use std::str::FromStr;
+    use super::*;
+    use std::str::FromStr;
 
-	#[test]
-	fn test_from_sender_and_nonce() {
-		let sender = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
-		let expected = Address::from_str("3f09c73a5ed19289fb9bdc72f1742566df146f56").unwrap();
-		let scheme = CreateContractAddress::FromSenderAndNonce;
-		assert_eq!(expected, contract_address(scheme, &sender, &U256::from(88), &[]).0);
-	}
+    #[test]
+    fn test_from_sender_and_nonce() {
+        let sender = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
+        let expected = Address::from_str("3f09c73a5ed19289fb9bdc72f1742566df146f56").unwrap();
 
-	#[test]
-	fn test_from_sender_salt_and_code_hash() {
-		let sender = Address::zero();
-		let expected_address = Address::from_str("e33c0c7f7df4809055c3eba6c09cfe4baf1bd9e0").unwrap();
-		let expected_code_hash = H256::from_str("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").ok();
-		let scheme = CreateContractAddress::FromSenderSaltAndCodeHash(H256::zero());
-		let (x, y) = contract_address(scheme, &sender, &U256::zero(), &[]);
-		assert_eq!(expected_address, x);
-		assert_eq!(expected_code_hash, y);
-	}
+        let actual = ContractAddress::from_sender_and_nonce(&sender, &U256::from(88));
 
-	#[test]
-	fn test_from_sender_and_code_hash() {
-		let code = [0u8, 1, 2, 3];
-		let sender = Address::from_str("0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d").unwrap();
-		let expected_address = Address::from_str("064417880f5680b141ed7fcac031aad40df080b0").unwrap();
-		let expected_code_hash = H256::from_str("d98f2e8134922f73748703c8e7084d42f13d2fa1439936ef5a3abcf5646fe83f").ok();
-		let scheme = CreateContractAddress::FromSenderAndCodeHash;
-		let (x, y) = contract_address(scheme, &sender, &U256::zero(), &code);
-		assert_eq!(expected_address, x);
-		assert_eq!(expected_code_hash, y);
-	}
+        assert_eq!(Address::from(actual), expected);
+    }
+
+    #[test]
+    fn test_from_sender_salt_and_code_hash() {
+        let sender = Address::zero();
+        let expected_address =
+            Address::from_str("e33c0c7f7df4809055c3eba6c09cfe4baf1bd9e0").unwrap();
+        let expected_code_hash =
+            H256::from_str("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+                .unwrap();
+
+        let (contract_address, code_hash) =
+            ContractAddress::from_sender_salt_and_code(&sender, H256::zero(), &[]);
+
+        assert_eq!(Address::from(contract_address), expected_address);
+        assert_eq!(code_hash, expected_code_hash);
+    }
+
+    #[test]
+    fn test_from_sender_and_code_hash() {
+        let code = [0u8, 1, 2, 3];
+        let sender = Address::from_str("0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d").unwrap();
+        let expected_address =
+            Address::from_str("064417880f5680b141ed7fcac031aad40df080b0").unwrap();
+        let expected_code_hash =
+            H256::from_str("d98f2e8134922f73748703c8e7084d42f13d2fa1439936ef5a3abcf5646fe83f")
+                .unwrap();
+
+        let (contract_address, code_hash) = ContractAddress::from_sender_and_code(&sender, &code);
+
+        assert_eq!(Address::from(contract_address), expected_address);
+        assert_eq!(code_hash, expected_code_hash);
+    }
 }

--- a/contract-address/src/lib.rs
+++ b/contract-address/src/lib.rs
@@ -39,33 +39,25 @@ impl ContractAddress {
     /// Computes the address of a contract from the sender's address, the salt and code hash
     ///
     /// pWASM `create2` scheme and EIP-1014 CREATE2 scheme
-    pub fn from_sender_salt_and_code(sender: &Address, salt: H256, code: &[u8]) -> (Self, H256) {
-        let code_hash = keccak(code);
+    pub fn from_sender_salt_and_code(sender: &Address, salt: H256, code_hash: H256) -> Self {
         let mut buffer = [0u8; 1 + 20 + 32 + 32];
         buffer[0] = 0xff;
         &mut buffer[1..(1 + 20)].copy_from_slice(&sender[..]);
         &mut buffer[(1 + 20)..(1 + 20 + 32)].copy_from_slice(&salt[..]);
         &mut buffer[(1 + 20 + 32)..].copy_from_slice(&code_hash[..]);
 
-        (
-            ContractAddress(Address::from(keccak(&buffer[..]))),
-            code_hash,
-        )
+        ContractAddress(Address::from(keccak(&buffer[..])))
     }
 
     /// Computes the address of a contract from the sender's address and the code hash
     ///
     /// Used by pwasm create ext.
-    pub fn from_sender_and_code(sender: &Address, code: &[u8]) -> (Self, H256) {
-        let code_hash = keccak(code);
+    pub fn from_sender_and_code(sender: &Address, code_hash: H256) -> Self {
         let mut buffer = [0u8; 20 + 32];
         &mut buffer[..20].copy_from_slice(&sender[..]);
         &mut buffer[20..].copy_from_slice(&code_hash[..]);
 
-        (
-            ContractAddress(Address::from(keccak(&buffer[..]))),
-            code_hash,
-        )
+        ContractAddress(Address::from(keccak(&buffer[..])))
     }
 }
 
@@ -101,32 +93,29 @@ mod tests {
     #[test]
     fn test_from_sender_salt_and_code_hash() {
         let sender = Address::zero();
-        let expected_address =
-            Address::from_str("e33c0c7f7df4809055c3eba6c09cfe4baf1bd9e0").unwrap();
-        let expected_code_hash =
+        let code_hash =
             H256::from_str("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
                 .unwrap();
+        let expected_address =
+            Address::from_str("e33c0c7f7df4809055c3eba6c09cfe4baf1bd9e0").unwrap();
 
-        let (contract_address, code_hash) =
-            ContractAddress::from_sender_salt_and_code(&sender, H256::zero(), &[]);
+        let contract_address =
+            ContractAddress::from_sender_salt_and_code(&sender, H256::zero(), code_hash);
 
         assert_eq!(Address::from(contract_address), expected_address);
-        assert_eq!(code_hash, expected_code_hash);
     }
 
     #[test]
     fn test_from_sender_and_code_hash() {
-        let code = [0u8, 1, 2, 3];
         let sender = Address::from_str("0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d").unwrap();
-        let expected_address =
-            Address::from_str("064417880f5680b141ed7fcac031aad40df080b0").unwrap();
-        let expected_code_hash =
+        let code_hash =
             H256::from_str("d98f2e8134922f73748703c8e7084d42f13d2fa1439936ef5a3abcf5646fe83f")
                 .unwrap();
+        let expected_address =
+            Address::from_str("064417880f5680b141ed7fcac031aad40df080b0").unwrap();
 
-        let (contract_address, code_hash) = ContractAddress::from_sender_and_code(&sender, &code);
+        let contract_address = ContractAddress::from_sender_and_code(&sender, code_hash);
 
         assert_eq!(Address::from(contract_address), expected_address);
-        assert_eq!(code_hash, expected_code_hash);
     }
 }


### PR DESCRIPTION
Not all variants of scheme used all the parameters of the previous `contract_address` function, yet they still needed to be passed.

I took a shot at redesigning the interface of this crate to allow for the most convenient usage.

Let me know what you think!

The two methods `from_sender_salt_and_code` and `from_sender_and_code` both return a tuple with the computed hash. I don't know how these methods are actually being used, so I don't know if we actually need that return value. It seems a bit odd to me because it looks like the hash is an implementation detail of how to compute the address and should be hidden inside the function.