### PR TITLE
[triehash] update hash-db, bump version

### DIFF
--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "triehash"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
 license = "GPL-3.0"
 
 [dependencies]
-hash-db = "0.14"
+hash-db = "0.15"
 rlp = { version = "0.4", path = "../rlp" }
 
 [dev-dependencies]
-keccak-hasher = "0.14"
+keccak-hasher = "0.15"
 tiny-keccak = "1.4.2"
 ethereum-types = { version = "0.7", path = "../ethereum-types" }
 hex-literal = "0.2"


### PR DESCRIPTION
This is a prerequisite for upgrading parity-util-mem in parity-ethereum.