### PR TITLE
Speed up hex serialization and fix warnings

### DIFF
--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -9,7 +9,7 @@ description = "Primitive types shared by Ethereum and Substrate"
 [dependencies]
 fixed-hash = { version = "0.4", path = "../fixed-hash", default-features = false }
 uint = { version = "0.8", path = "../uint", default-features = false }
-impl-serde = { version = "0.2", path = "impls/serde", default-features = false, optional = true }
+impl-serde = { version = "0.2.1", path = "impls/serde", default-features = false, optional = true }
 impl-codec = { version = "0.4.1", path = "impls/codec", default-features = false, optional = true }
 impl-rlp = { version = "0.2", path = "impls/rlp", default-features = false, optional = true }
 

--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -8,3 +8,12 @@ description = "Serde serialization support for uint and fixed hash."
 
 [dependencies]
 serde = "1.0"
+
+[dev-dependencies]
+criterion = "0.3.0"
+uint = "0.8.1"
+serde_json = "1.0.40"
+
+[[bench]]
+name = "impl_serde"
+harness = false

--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-serde"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"

--- a/primitive-types/impls/serde/benches/impl_serde.rs
+++ b/primitive-types/impls/serde/benches/impl_serde.rs
@@ -1,0 +1,57 @@
+// Copyright 2019 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! benchmarking for impl_serde
+//! should be started with:
+//! ```bash
+//! cargo bench
+//! ```
+
+#[macro_use]
+extern crate criterion;
+#[macro_use]
+extern crate uint;
+#[macro_use]
+extern crate impl_serde;
+extern crate serde_json;
+
+construct_uint! {
+	pub struct U256(4);
+}
+
+impl_uint_serde!(U256, 4);
+
+use criterion::{black_box, Criterion, ParameterizedBenchmark};
+
+criterion_group!(
+	impl_serde,
+	u256_to_hex,
+);
+criterion_main!(impl_serde);
+
+fn u256_to_hex(c: &mut Criterion) {
+	c.bench(
+		"u256_to_hex",
+		ParameterizedBenchmark::new(
+			"",
+			|b, x| {
+				b.iter(|| {
+					black_box(serde_json::to_string(&x))
+				})
+			},
+			vec![
+				U256::from(0),
+				U256::from(100),
+				U256::from(u32::max_value()),
+				U256::from(u64::max_value()),
+				U256::from(u128::max_value()),
+				U256([1, 2, 3, 4]),
+			],
+		),
+	);
+}

--- a/primitive-types/impls/serde/src/lib.rs
+++ b/primitive-types/impls/serde/src/lib.rs
@@ -47,7 +47,7 @@ macro_rules! impl_fixed_hash_serde {
 		impl $crate::serde::Serialize for $name {
 			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: $crate::serde::Serializer {
 				let mut slice = [0u8; 2 + 2 * $len];
-				$crate::serialize::serialize(&mut slice, &self.0, serializer)
+				$crate::serialize::serialize_raw(&mut slice, &self.0, serializer)
 			}
 		}
 

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -84,7 +84,8 @@ impl<'a> fmt::Display for ExpectedLen<'a> {
 	}
 }
 
-/// Deserialize into vector of bytes.  This DOES NOT guard against DoS attacks!
+/// Deserialize into vector of bytes.  This will allocate an O(n) intermediate
+/// string.
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error> where
 	D: Deserializer<'de>,
 {

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -11,7 +11,6 @@ use serde::{de, Serializer, Deserializer};
 
 static CHARS: &'static[u8] = b"0123456789abcdef";
 
-// FIXME this is inefficient.
 fn to_hex<'a>(v: &'a mut [u8], bytes: &[u8], skip_leading_zero: bool) -> &'a str {
 	assert!(v.len() > 1 + bytes.len() * 2);
 
@@ -33,7 +32,7 @@ fn to_hex<'a>(v: &'a mut [u8], bytes: &[u8], skip_leading_zero: bool) -> &'a str
 		idx += 2;
 	}
 
-	// SAFETY: all characters come from CHARS array.
+	// SAFETY: all characters come either from CHARS or "0x", therefore valid UTF8
 	unsafe { std::str::from_utf8_unchecked(&v[0..idx]) }
 }
 


### PR DESCRIPTION
This uses unsafe code (with a proof of safety) to speed up
serialization.  It also fixes a warning due to a deprecated `...` range
pattern.