### PR TITLE
[impl-serde] add a uint bench

### DIFF
--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -8,3 +8,12 @@ description = "Serde serialization support for uint and fixed hash."
 
 [dependencies]
 serde = "1.0"
+
+[dev-dependencies]
+criterion = "0.3.0"
+uint = "0.8.1"
+serde_json = "1.0.40"
+
+[[bench]]
+name = "impl_serde"
+harness = false

--- a/primitive-types/impls/serde/benches/impl_serde.rs
+++ b/primitive-types/impls/serde/benches/impl_serde.rs
@@ -1,0 +1,57 @@
+// Copyright 2019 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! benchmarking for impl_serde
+//! should be started with:
+//! ```bash
+//! cargo bench
+//! ```
+
+#[macro_use]
+extern crate criterion;
+#[macro_use]
+extern crate uint;
+#[macro_use]
+extern crate impl_serde;
+extern crate serde_json;
+
+construct_uint! {
+	pub struct U256(4);
+}
+
+impl_uint_serde!(U256, 4);
+
+use criterion::{black_box, Criterion, ParameterizedBenchmark};
+
+criterion_group!(
+	impl_serde,
+	u256_to_hex,
+);
+criterion_main!(impl_serde);
+
+fn u256_to_hex(c: &mut Criterion) {
+	c.bench(
+		"u256_to_hex",
+		ParameterizedBenchmark::new(
+			"",
+			|b, x| {
+				b.iter(|| {
+					black_box(serde_json::to_string(&x))
+				})
+			},
+			vec![
+				U256::from(0),
+				U256::from(100),
+				U256::from(u32::max_value()),
+				U256::from(u64::max_value()),
+				U256::from(u128::max_value()),
+				U256([1, 2, 3, 4]),
+			],
+		),
+	);
+}


### PR DESCRIPTION
This PR adds a u256 serde bench to #208.
Demi's brach seems faster by 3-15% on u256 :
```
u256_to_hex//0          time:   [38.087 ns 38.175 ns 38.271 ns]                            
                        change: [-2.3863% -1.5812% -0.9421%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
u256_to_hex//100        time:   [40.901 ns 40.992 ns 41.087 ns]                              
                        change: [-12.317% -11.367% -10.697%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe
u256_to_hex//4294967295 time:   [45.961 ns 46.160 ns 46.459 ns]                                     
                        change: [-15.873% -15.432% -14.964%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
u256_to_hex//18446744073709551615                                                                            
                        time:   [52.170 ns 52.283 ns 52.404 ns]
                        change: [-10.915% -10.565% -10.202%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
u256_to_hex//340282366920938463463374607431768211455                                                                            
                        time:   [66.595 ns 66.722 ns 66.844 ns]
                        change: [-9.9015% -9.6131% -9.3351%] (p = 0.00 < 0.05)
                        Performance has improved.
u256_to_hex//25108406941546723056364004793593481054836439088298861789185                                                                            
                        time:   [86.697 ns 86.972 ns 87.321 ns]
                        change: [-3.4843% -2.8598% -2.1879%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

```