### PR TITLE
[plain_hasher] Migrate to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
     fi
   - cd fixed-hash/ && cargo test --all-features && cd ..
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
-  - cd plain_hasher/ && cargo test --no-default-features && cd ..
+  - cd plain_hasher/ && cargo test --no-default-features && cargo test --benches && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
   - cd parity-util-mem/ && cargo test --features=jemalloc-global && cd ..
   - cd parity-util-mem/ && cargo test --features=mimalloc-global && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
     fi
   - cd fixed-hash/ && cargo test --all-features && cd ..
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
-  - cd plain_hasher/ && cargo test --no-default-features && cargo test --benches && cd ..
+  - cd plain_hasher/ && cargo test --no-default-features && cargo check --benches && cd ..
   - cd parity-bytes/ && cargo test --no-default-features && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
   - cd parity-util-mem/ && cargo test --features=jemalloc-global && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
     fi
   - cd fixed-hash/ && cargo test --all-features && cd ..
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
-  - cd plain_hasher/ && cargo test --no-default-features && cargo test --benches -- --bench && cd ..
+  - cd plain_hasher/ && cargo test --no-default-features && cargo test --benches && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
   - cd parity-util-mem/ && cargo test --features=jemalloc-global && cd ..
   - cd parity-util-mem/ && cargo test --features=mimalloc-global && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
     fi
   - cd fixed-hash/ && cargo test --all-features && cd ..
   - cd uint/ && cargo test --features=std,quickcheck --release && cd ..
-  - cd plain_hasher/ && cargo test --no-default-features && cargo test --benches && cd ..
+  - cd plain_hasher/ && cargo test --no-default-features && cargo test --benches -- --bench && cd ..
   - cd parity-util-mem/ && cargo test --features=estimate-heapsize && cd ..
   - cd parity-util-mem/ && cargo test --features=jemalloc-global && cd ..
   - cd parity-util-mem/ && cargo test --features=mimalloc-global && cd ..

--- a/plain_hasher/Cargo.toml
+++ b/plain_hasher/Cargo.toml
@@ -6,11 +6,19 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 keywords = ["hash", "hasher"]
 homepage = "https://github.com/paritytech/parity-common"
-categories = [ "no-std"]
+categories = ["no-std"]
+edition = "2018"
 
 [dependencies]
-crunchy = { version = "0.2.1", default-features = false }
+crunchy = { version = "0.2", default-features = false }
+
+[dev-dependencies]
+criterion = "0.3"
 
 [features]
 default = ["std"]
 std = ["crunchy/std"]
+
+[[bench]]
+name = "bench"
+harness = false

--- a/plain_hasher/benches/bench.rs
+++ b/plain_hasher/benches/bench.rs
@@ -14,36 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![feature(test)]
-
-extern crate test;
-extern crate plain_hasher;
-
-use std::hash::Hasher;
 use std::collections::hash_map::DefaultHasher;
-use test::{Bencher, black_box};
+use std::hash::Hasher;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 use plain_hasher::PlainHasher;
 
-#[bench]
-fn write_plain_hasher(b: &mut Bencher) {
-	b.iter(|| {
-		let n: u8 = black_box(100);
-		(0..n).fold(PlainHasher::default(), |mut old, new| {
-			let bb = black_box([new; 32]);
-			old.write(&bb as &[u8]);
+fn bench_write_hasher(c: &mut Criterion) {
+	c.bench_function("write_plain_hasher", |b| b.iter(|| {
+		(0..100u8).fold(PlainHasher::default(), |mut old, new| {
+			let bb = [new; 32];
+			old.write(&bb);
 			old
 		});
-	});
+	}));
+	c.bench_function("write_default_hasher", |b| b.iter(|| {
+		(0..100u8).fold(DefaultHasher::default(), |mut old, new| {
+			let bb = [new; 32];
+			old.write(&bb);
+			old
+		});
+	}));
 }
 
-#[bench]
-fn write_default_hasher(b: &mut Bencher) {
-	b.iter(|| {
-		let n: u8 = black_box(100);
-		(0..n).fold(DefaultHasher::default(), |mut old, new| {
-			let bb = black_box([new; 32]);
-			old.write(&bb as &[u8]);
-			old
-		});
-	});
-}
+criterion_group!(benches, bench_write_hasher);
+criterion_main!(benches);

--- a/plain_hasher/src/lib.rs
+++ b/plain_hasher/src/lib.rs
@@ -16,13 +16,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[macro_use]
-extern crate crunchy;
+use core::hash::Hasher;
 
-#[cfg(feature = "std")]
-extern crate core;
+use crunchy::unroll;
 
-use core::hash;
 /// Hasher that just takes 8 bytes of the provided value.
 /// May only be used for keys which are 32 bytes.
 #[derive(Default)]
@@ -30,7 +27,7 @@ pub struct PlainHasher {
 	prefix: u64,
 }
 
-impl hash::Hasher for PlainHasher {
+impl Hasher for PlainHasher {
 	#[inline]
 	fn finish(&self) -> u64 {
 		self.prefix
@@ -57,8 +54,7 @@ impl hash::Hasher for PlainHasher {
 
 #[cfg(test)]
 mod tests {
-	use core::hash::Hasher;
-	use super::PlainHasher;
+	use super::*;
 
 	#[test]
 	fn it_works() {


### PR DESCRIPTION
# What I have changed

- Migrate `plain_hasher` crate to 2018 edition (related issue: #143)
- Replace `libtest` with `criterion`