### PR TITLE
Find PendingIterator in Transaction Pool

### DIFF
--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -615,7 +615,7 @@ impl<'a, T, R, S, L> Iterator for PendingIterator<'a, T, R, S, L> where
 			// Add the next best sender's transaction when applicable
 			match tx_state {
 				Readiness::Ready | Readiness::Stale => {
-					// retrieve next one from that sender.
+					// retrieve next one from the same sender.
 					let next = self.pool.transactions
 						.get(best.transaction.sender())
 						.and_then(|s| s.find_next(&best.transaction, &self.pool.scoring));
@@ -625,12 +625,12 @@ impl<'a, T, R, S, L> Iterator for PendingIterator<'a, T, R, S, L> where
 				},
 				_ => (),
 			}
-			match tx_state {
-				Readiness::Ready => {
-					return Some(best.transaction.transaction)
-				},
-				_ => trace!("[{:?}] Ignoring {:?} transaction.", best.transaction.hash(), tx_state),
+
+			if tx_state == Readiness::Ready {
+				return Some(best.transaction.transaction)
 			}
+
+			trace!("[{:?}] Ignoring {:?} transaction.", best.transaction.hash(), tx_state);
 		}
 
 		None

--- a/transaction-pool/src/tests/mod.rs
+++ b/transaction-pool/src/tests/mod.rs
@@ -268,6 +268,23 @@ fn should_construct_pending() {
 }
 
 #[test]
+fn should_skip_staled_pending_transactions() {
+	let b = TransactionBuilder::default();
+	let mut txq = TestPool::default();
+
+	let tx0 = import(&mut txq, b.tx().nonce(0).gas_price(5).new()).unwrap();
+	let tx2 = import(&mut txq, b.tx().nonce(2).gas_price(5).new()).unwrap();
+	let tx1 = import(&mut txq, b.tx().nonce(1).gas_price(5).new()).unwrap();
+
+	// tx0 and tx1 are Stale, tx2 is Ready
+	let mut pending = txq.pending(NonceReady::new(2));
+
+	// tx0 and tx1 should be skipped, tx2 should be the next Ready
+	assert_eq!(pending.next(), Some(tx2));
+	assert_eq!(pending.next(), None);
+}
+
+#[test]
 fn should_return_unordered_iterator() {
 	// given
 	let b = TransactionBuilder::default();


### PR DESCRIPTION
When encountering a `Stale` transaction in the `PendingIterator`, we should try to use the next best transaction for this sender.