### PR TITLE
Update parity-path to the 2018 edition

### DIFF
--- a/parity-path/Cargo.toml
+++ b/parity-path/Cargo.toml
@@ -5,5 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Path utilities"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
+dirs = "2"

--- a/parity-path/Cargo.toml
+++ b/parity-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-path"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Path utilities"

--- a/parity-path/src/lib.rs
+++ b/parity-path/src/lib.rs
@@ -15,14 +15,13 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Path utilities
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "macos")]
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push("Library");
 	home.push(name);
 	home
@@ -32,7 +31,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push("AppData");
 	home.push("Roaming");
 	home.push(name);
@@ -43,7 +42,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push(format!(".{}", name.to_lowercase()));
 	home
 }


### PR DESCRIPTION
See #143. `std::env::home_dir()` gave a deprecation warning and suggested using `dirs`.