### PR TITLE
[kvdb-web] bump futures-preview to 0.3.0-alpha.18

### DIFF
--- a/kvdb-web/Cargo.toml
+++ b/kvdb-web/Cargo.toml
@@ -13,7 +13,7 @@ wasm-bindgen = "0.2.49"
 js-sys = "0.3.26"
 kvdb = { version = "0.1", path = "../kvdb" }
 kvdb-memorydb = { version = "0.1", path = "../kvdb-memorydb" }
-futures-preview = "0.3.0-alpha.17"
+futures-preview = "0.3.0-alpha.18"
 log = "0.4.8"
 send_wrapper = "0.2.0"
 


### PR DESCRIPTION
Seems like substrate upgraded to .18 in https://github.com/paritytech/substrate/pull/3656.