### PR TITLE
Bump parking_lot version

### DIFF
--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-memorydb"
-version = "0.2.0"
+version = "0.1.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "A key-value in-memory database that implements the  `KeyValueDB` trait"

--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-memorydb"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "A key-value in-memory database that implements the  `KeyValueDB` trait"
@@ -8,5 +8,5 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-parking_lot = "0.6"
+parking_lot = "0.9"
 kvdb = { version = "0.1", path = "../kvdb" }

--- a/kvdb-web/Cargo.toml
+++ b/kvdb-web/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 wasm-bindgen = "0.2.49"
 js-sys = "0.3.26"
 kvdb = { version = "0.1", path = "../kvdb" }
-kvdb-memorydb = { version = "0.2", path = "../kvdb-memorydb" }
+kvdb-memorydb = { version = "0.1", path = "../kvdb-memorydb" }
 futures-preview = "0.3.0-alpha.18"
 log = "0.4.8"
 send_wrapper = "0.2.0"

--- a/kvdb-web/Cargo.toml
+++ b/kvdb-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-web"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "A key-value database for use in browsers"
@@ -12,7 +12,7 @@ edition = "2018"
 wasm-bindgen = "0.2.49"
 js-sys = "0.3.26"
 kvdb = { version = "0.1", path = "../kvdb" }
-kvdb-memorydb = { version = "0.1", path = "../kvdb-memorydb" }
+kvdb-memorydb = { version = "0.2", path = "../kvdb-memorydb" }
 futures-preview = "0.3.0-alpha.18"
 log = "0.4.8"
 send_wrapper = "0.2.0"

--- a/kvdb-web/Cargo.toml
+++ b/kvdb-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-web"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "A key-value database for use in browsers"


### PR DESCRIPTION
Implies 0.2 of `kvdb-memorydb` and `kvdb-web`.

[parity-ethereum PR](https://github.com/paritytech/parity-ethereum/pull/11091)