### PR TITLE
Fix old syntax in the README of crate uint

### DIFF
--- a/uint/README.md
+++ b/uint/README.md
@@ -16,7 +16,13 @@ In your `Cargo.toml` paste
 uint = "0.8"
 ```
 
-Put in the header of your main file
+Import the macro
+
+```
+use uint::construct_uint;
+```
+
+If you're using pre-edition Rust in your main file
 
 ```
 #[macro_use]

--- a/uint/README.md
+++ b/uint/README.md
@@ -16,11 +16,20 @@ In your `Cargo.toml` paste
 uint = "0.8"
 ```
 
+Put in the header of your main file
+
+```
+#[macro_use]
+extern crate uint;
+```
+
 Construct your own big unsigned integer type as follows.
 
 ```
 // U1024 with 1024 bits consisting of 16 x 64-bit words
-construct_uint!(U1024; 16);
+construct_uint! {
+	pub struct U1024(16);
+}
 ```
 
 ## Tests


### PR DESCRIPTION
The syntax actually reported is not working and is different from that present in the test and the examples folders.