### PR TITLE
export FromDecStrErr

### DIFF
--- a/ethereum-types/src/lib.rs
+++ b/ethereum-types/src/lib.rs
@@ -5,7 +5,7 @@
 mod hash;
 mod uint;
 
-pub use uint::{U64, U128, U256, U512};
+pub use uint::{U64, U128, U256, U512, FromDecStrErr};
 pub use hash::{BigEndianHash, H32, H64, H128, H160, H256, H264, H512, H520};
 pub use ethbloom::{Bloom, BloomRef, Input as BloomInput};
 

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -3,6 +3,8 @@ use impl_rlp::impl_uint_rlp;
 #[cfg(feature="serialize")]
 use impl_serde::impl_uint_serde;
 
+pub use uint_crate::FromDecStrErr;
+
 construct_uint! {
 	/// Unsigned 64-bit integer.
 	pub struct U64(1);


### PR DESCRIPTION
My project needs to be able to convert from uint's error type to my project's error type. This should make it possible to do this without needing to add uint as a direct dependency of my project.
