### PR TITLE
Upgrade zeroize version to v1.0

### DIFF
--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -30,7 +30,7 @@ pbkdf2 = "0.3.0"
 rand = "0.7.2"
 rustc-hex = "2.0"
 subtle = "2.1"
-zeroize = "0.9.1"
+zeroize = "1.0"
 
 [dev-dependencies]
 criterion = "0.2"


### PR DESCRIPTION
v1.0 final release is out. Release notes:

https://github.com/iqlusioninc/crates/pull/279