### PR TITLE
Release impl-rlp 0.2.1

### DIFF
--- a/primitive-types/impls/rlp/Cargo.toml
+++ b/primitive-types/impls/rlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-rlp"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
The newest commit of `impl-rlp` brings in `no_std` support, but it's not released.