### PR TITLE
kvdb-rocksdb: configurable memory budget per column

### DIFF
--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -109,9 +109,10 @@ impl CompactionProfile {
 		let hdd_check_file = db_path
 			.to_str()
 			.and_then(|path_str| Command::new("df").arg(path_str).output().ok())
-			.and_then(|df_res| match df_res.status.success() {
-				true => Some(df_res.stdout),
-				false => None,
+			.and_then(|df_res| if df_res.status.success() {
+				Some(df_res.stdout)
+			} else {
+				None
 			})
 			.and_then(rotational_from_df_output);
 		// Read out the file and match compaction profile.
@@ -155,7 +156,6 @@ impl CompactionProfile {
 	}
 }
 
-
 /// Database configuration
 #[derive(Clone)]
 pub struct DatabaseConfig {
@@ -178,10 +178,7 @@ impl DatabaseConfig {
 	/// Create new `DatabaseConfig` with default parameters and specified set of columns.
 	/// Note that cache sizes must be explicitly set.
 	pub fn with_columns(columns: Option<u32>) -> Self {
-		Self {
-			columns,
-			..Default::default()
-		}
+		Self { columns, ..Default::default() }
 	}
 
 	/// Returns the total memory budget in bytes.
@@ -190,11 +187,7 @@ impl DatabaseConfig {
 			return DB_DEFAULT_MEMORY_BUDGET_MB * MB;
 		}
 		(0..=self.columns.unwrap_or(0))
-			.map(|i| {
-				self.memory_budget
-					.get(&i.checked_sub(1))
-					.unwrap_or(&DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB) * MB
-			})
+			.map(|i| self.memory_budget.get(&i.checked_sub(1)).unwrap_or(&DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB) * MB)
 			.sum()
 	}
 
@@ -359,8 +352,8 @@ impl Database {
 		read_opts.set_verify_checksums(false);
 
 		let mut cfs: Vec<Column> = Vec::new();
-		let db = match config.columns.is_none() {
-			false => {
+		let db = match config.columns {
+			Some(_) => {
 				match DB::open_cf(&opts, path, &cfnames, &cf_options) {
 					Ok(db) => {
 						cfs = cfnames
@@ -386,7 +379,7 @@ impl Database {
 					}
 				}
 			}
-			true => DB::open(&opts, path),
+			None => DB::open(&opts, path),
 		};
 
 		let db = match db {
@@ -395,23 +388,22 @@ impl Database {
 				warn!("DB corrupted: {}, attempting repair", s);
 				DB::repair(&opts, path).map_err(other_io_err)?;
 
-				match cfnames.is_empty() {
-					true => DB::open(&opts, path).map_err(other_io_err)?,
-					false => {
-						let db = DB::open_cf(&opts, path, &cfnames, &cf_options).map_err(other_io_err)?;
-						cfs = cfnames
-							.iter()
-							.map(|n| db.cf_handle(n).expect("rocksdb opens a cf_handle for each cfname; qed"))
-							.collect();
-						db
-					}
+				if cfnames.is_empty() {
+					DB::open(&opts, path).map_err(other_io_err)?
+				} else {
+					let db = DB::open_cf(&opts, path, &cfnames, &cf_options).map_err(other_io_err)?;
+					cfs = cfnames
+						.iter()
+						.map(|n| db.cf_handle(n).expect("rocksdb opens a cf_handle for each cfname; qed"))
+						.collect();
+					db
 				}
 			}
 			Err(s) => return Err(other_io_err(s)),
 		};
 		let num_cols = cfs.len();
 		Ok(Database {
-			db: RwLock::new(Some(DBAndColumns { db: db, cfs: cfs })),
+			db: RwLock::new(Some(DBAndColumns { db, cfs })),
 			config: config.clone(),
 			write_opts,
 			overlay: RwLock::new((0..(num_cols + 1)).map(|_| HashMap::new()).collect()),
@@ -690,9 +682,8 @@ impl Database {
 	pub fn drop_column(&self) -> io::Result<()> {
 		match *self.db.write() {
 			Some(DBAndColumns { ref mut db, ref mut cfs }) => {
-				if let Some(col) = cfs.pop() {
+				if let Some(_col) = cfs.pop() {
 					let name = format!("col{}", cfs.len());
-					drop(col);
 					db.drop_cf(&name).map_err(other_io_err)?;
 				}
 				Ok(())

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -155,8 +155,10 @@ pub struct DatabaseConfig {
 	/// Memory budget (in MiB) used for setting block cache size,
 	/// write buffer size for each column.
 	pub memory_budget: Vec<Option<usize>>,
-	/// Compaction profile
+	/// Compaction profile.
 	pub compaction: CompactionProfile,
+	/// Specify the maximal number of info log files to be kept.
+	pub keep_log_file_num: i32,
 }
 
 impl DatabaseConfig {
@@ -192,6 +194,7 @@ impl Default for DatabaseConfig {
 			max_open_files: 512,
 			memory_budget: vec![],
 			compaction: CompactionProfile::default(),
+			keep_log_file_num: 1,
 		}
 	}
 }
@@ -290,7 +293,7 @@ impl Database {
 		opts.set_use_fsync(false);
 		opts.create_if_missing(true);
 		opts.set_max_open_files(config.max_open_files);
-		opts.set_parsed_options("keep_log_file_num=1").map_err(other_io_err)?;
+		opts.set_parsed_options(&format!("keep_log_file_num={}", config.keep_log_file_num)).map_err(other_io_err)?;
 		opts.set_parsed_options("bytes_per_sync=1048576").map_err(other_io_err)?;
 		if config.memory_budget.is_empty() {
 			let budget = config.memory_budget();

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -62,9 +62,14 @@ enum KeyState {
 }
 
 /// Compaction profile for the database settings
+/// Note, that changing these parameters may trigger
+/// the compaction process of RocksDB on startup.
+/// https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#level_compaction_dynamic_level_bytes-is-true
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CompactionProfile {
 	/// L0-L1 target file size
+	/// The mimimum size should be calculated in accordance with the
+	/// number of levels and the expected size of the database.
 	pub initial_file_size: u64,
 	/// block size
 	pub block_size: usize,

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -152,12 +152,11 @@ impl CompactionProfile {
 pub struct DatabaseConfig {
 	/// Max number of open files.
 	pub max_open_files: i32,
-	/// Memory budget (in MiB) used for setting block cache size, write buffer size.
-	pub memory_budget: Option<usize>,
+	/// Memory budget (in MiB) used for setting block cache size,
+	/// write buffer size for each column.
+	pub memory_budget: Vec<Option<usize>>,
 	/// Compaction profile
 	pub compaction: CompactionProfile,
-	/// Set number of columns
-	pub columns: Option<u32>,
 }
 
 impl DatabaseConfig {
@@ -165,16 +164,25 @@ impl DatabaseConfig {
 	/// Note that cache sizes must be explicitly set.
 	pub fn with_columns(columns: Option<u32>) -> Self {
 		let mut config = Self::default();
-		config.columns = columns;
+		config.memory_budget.resize(columns.unwrap_or(0) as usize, None);
 		config
 	}
 
 	pub fn memory_budget(&self) -> usize {
-		self.memory_budget.unwrap_or(DB_DEFAULT_MEMORY_BUDGET_MB) * MB
+		if self.memory_budget.is_empty() {
+			return DB_DEFAULT_MEMORY_BUDGET_MB * MB;
+		}
+		self.memory_budget
+			.iter()
+			.map(|b| b.unwrap_or(DB_DEFAULT_MEMORY_BUDGET_MB) * MB)
+			.sum()
 	}
 
-	pub fn memory_budget_per_col(&self) -> usize {
-		self.memory_budget() / self.columns.unwrap_or(1) as usize
+	/// # Panics
+	///
+	/// If `col` is out of bounds.
+	pub fn memory_budget_per_col(&self, col: usize) -> usize {
+		self.memory_budget[col].unwrap_or(DB_DEFAULT_MEMORY_BUDGET_MB) * MB
 	}
 }
 
@@ -182,9 +190,8 @@ impl Default for DatabaseConfig {
 	fn default() -> DatabaseConfig {
 		DatabaseConfig {
 			max_open_files: 512,
-			memory_budget: None,
+			memory_budget: vec![],
 			compaction: CompactionProfile::default(),
-			columns: None,
 		}
 	}
 }
@@ -192,7 +199,6 @@ impl Default for DatabaseConfig {
 /// Database iterator (for flushed data only)
 // The compromise of holding only a virtual borrow vs. holding a lock on the
 // inner DB (to prevent closing via restoration) may be re-evaluated in the future.
-//
 pub struct DatabaseIterator<'a> {
 	iter: InterleaveOrdered<::std::vec::IntoIter<(Box<[u8]>, Box<[u8]>)>, DBIterator>,
 	_marker: PhantomData<&'a Database>,
@@ -212,7 +218,7 @@ struct DBAndColumns {
 }
 
 // get column family configuration from database config.
-fn col_config(config: &DatabaseConfig, block_opts: &BlockBasedOptions) -> io::Result<Options> {
+fn col_config(config: &DatabaseConfig, block_opts: &BlockBasedOptions, memory_budget_per_col: usize) -> io::Result<Options> {
 	let mut opts = Options::new();
 
 	opts.set_parsed_options("level_compaction_dynamic_level_bytes=true").map_err(other_io_err)?;
@@ -225,7 +231,7 @@ fn col_config(config: &DatabaseConfig, block_opts: &BlockBasedOptions) -> io::Re
 	))
 	.map_err(other_io_err)?;
 
-	opts.optimize_level_style_compaction(config.memory_budget_per_col() as i32);
+	opts.optimize_level_style_compaction(memory_budget_per_col as i32);
 	opts.set_target_file_size_base(config.compaction.initial_file_size);
 
 	opts.set_parsed_options("compression_per_level=").map_err(other_io_err)?;
@@ -286,8 +292,16 @@ impl Database {
 		opts.set_max_open_files(config.max_open_files);
 		opts.set_parsed_options("keep_log_file_num=1").map_err(other_io_err)?;
 		opts.set_parsed_options("bytes_per_sync=1048576").map_err(other_io_err)?;
-		opts.set_db_write_buffer_size(config.memory_budget_per_col() / 2);
-		opts.increase_parallelism(cmp::max(1, ::num_cpus::get() as i32 / 2));
+		if config.memory_budget.is_empty() {
+			let budget = config.memory_budget();
+			opts.set_db_write_buffer_size(budget / 2);
+			// from https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#memtable
+			// Memtable size is controlled by the option `write_buffer_size`.
+			// If you increase your memtable size, be sure to also increase your L1 size!
+			// L1 size is controlled by the option `max_bytes_for_level_base`.
+			opts.set_parsed_options(&format!("max_bytes_for_level_base={}", budget)).map_err(other_io_err)?;
+		}
+		opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
 
 		let mut block_opts = BlockBasedOptions::new();
 
@@ -308,14 +322,14 @@ impl Database {
 			fs::remove_file(db_corrupted)?;
 		}
 
-		let columns = config.columns.unwrap_or(0) as usize;
+		let columns = config.memory_budget.len();
 
 		let mut cf_options = Vec::with_capacity(columns);
 		let cfnames: Vec<_> = (0..columns).map(|c| format!("col{}", c)).collect();
 		let cfnames: Vec<&str> = cfnames.iter().map(|n| n as &str).collect();
 
-		for _ in 0..config.columns.unwrap_or(0) {
-			cf_options.push(col_config(&config, &block_opts)?);
+		for i in 0..config.memory_budget.len() {
+			cf_options.push(col_config(&config, &block_opts, config.memory_budget_per_col(i))?);
 		}
 
 		let write_opts = WriteOptions::new();
@@ -323,8 +337,8 @@ impl Database {
 		read_opts.set_verify_checksums(false);
 
 		let mut cfs: Vec<Column> = Vec::new();
-		let db = match config.columns {
-			Some(_) => {
+		let db = match config.memory_budget.is_empty() {
+			false => {
 				match DB::open_cf(&opts, path, &cfnames, &cf_options) {
 					Ok(db) => {
 						cfs = cfnames
@@ -350,7 +364,7 @@ impl Database {
 					}
 				}
 			}
-			None => DB::open(&opts, path),
+			true => DB::open(&opts, path),
 		};
 
 		let db = match db {
@@ -377,13 +391,13 @@ impl Database {
 		Ok(Database {
 			db: RwLock::new(Some(DBAndColumns { db: db, cfs: cfs })),
 			config: config.clone(),
-			write_opts: write_opts,
+			write_opts,
 			overlay: RwLock::new((0..(num_cols + 1)).map(|_| HashMap::new()).collect()),
 			flushing: RwLock::new((0..(num_cols + 1)).map(|_| HashMap::new()).collect()),
 			flushing_lock: Mutex::new(false),
 			path: path.to_owned(),
-			read_opts: read_opts,
-			block_opts: block_opts,
+			read_opts,
+			block_opts,
 		})
 	}
 
@@ -642,21 +656,17 @@ impl Database {
 
 	/// The number of non-default column families.
 	pub fn num_columns(&self) -> u32 {
-		self.db
-			.read()
-			.as_ref()
-			.and_then(|db| if db.cfs.is_empty() { None } else { Some(db.cfs.len()) })
-			.map(|n| n as u32)
-			.unwrap_or(0)
+		self.config.memory_budget.len() as u32
 	}
 
 	/// Drop a column family.
-	pub fn drop_column(&self) -> io::Result<()> {
+	pub fn drop_column(&mut self) -> io::Result<()> {
 		match *self.db.write() {
 			Some(DBAndColumns { ref mut db, ref mut cfs }) => {
 				if let Some(col) = cfs.pop() {
 					let name = format!("col{}", cfs.len());
 					drop(col);
+					self.config.memory_budget.resize(cfs.len(), None);
 					db.drop_cf(&name).map_err(other_io_err)?;
 				}
 				Ok(())
@@ -666,12 +676,17 @@ impl Database {
 	}
 
 	/// Add a column family.
-	pub fn add_column(&self) -> io::Result<()> {
+	pub fn add_column(&mut self) -> io::Result<()> {
 		match *self.db.write() {
 			Some(DBAndColumns { ref mut db, ref mut cfs }) => {
-				let col = cfs.len() as u32;
+				let col = cfs.len();
 				let name = format!("col{}", col);
-				cfs.push(db.create_cf(&name, &col_config(&self.config, &self.block_opts)?).map_err(other_io_err)?);
+				if self.config.memory_budget.len() < col + 1 {
+					self.config.memory_budget.resize(col + 1, None);
+				}
+				let memory_budget_per_col = self.config.memory_budget_per_col(col);
+				let col_config = col_config(&self.config, &self.block_opts, memory_budget_per_col)?;
+				cfs.push(db.create_cf(&name, &col_config).map_err(other_io_err)?);
 				Ok(())
 			}
 			None => Ok(()),
@@ -820,7 +835,7 @@ mod tests {
 
 		// open empty, add 5.
 		{
-			let db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
+			let mut db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
 			assert_eq!(db.num_columns(), 0);
 
 			for i in 0..5 {
@@ -845,7 +860,7 @@ mod tests {
 
 		// open 5, remove all.
 		{
-			let db = Database::open(&config_5, tempdir.path().to_str().unwrap()).unwrap();
+			let mut db = Database::open(&config_5, tempdir.path().to_str().unwrap()).unwrap();
 			assert_eq!(db.num_columns(), 5);
 
 			for i in (0..5).rev() {

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -199,7 +199,7 @@ impl DatabaseConfig {
 	}
 
 	/// Returns the memory budget of the specified column in bytes.
-	pub fn memory_budget_per_col(&self, col: Option<u32>) -> MiB {
+	fn memory_budget_per_col(&self, col: Option<u32>) -> MiB {
 		self.memory_budget.get(&col).unwrap_or(&DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB) * MB
 	}
 }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -175,7 +175,8 @@ pub struct DatabaseConfig {
 }
 
 impl DatabaseConfig {
-	/// Create new `DatabaseConfig` with default parameters and specified columns.
+	/// Create new `DatabaseConfig` with default parameters and specified set of columns.
+	/// Note that cache sizes must be explicitly set.
 	pub fn with_columns(columns: Option<u32>) -> Self {
 		Self {
 			columns,
@@ -184,7 +185,7 @@ impl DatabaseConfig {
 	}
 
 	/// Returns the total memory budget in bytes.
-	pub fn memory_budget(&self) -> usize {
+	pub fn memory_budget(&self) -> MiB {
 		if self.memory_budget.is_empty() && self.columns.is_none() {
 			return DB_DEFAULT_MEMORY_BUDGET_MB * MB;
 		}
@@ -237,7 +238,7 @@ struct DBAndColumns {
 }
 
 // get column family configuration from database config.
-fn col_config(config: &DatabaseConfig, block_opts: &BlockBasedOptions, memory_budget_per_col: usize) -> io::Result<Options> {
+fn col_config(config: &DatabaseConfig, block_opts: &BlockBasedOptions, memory_budget_per_col: MiB) -> io::Result<Options> {
 	let mut opts = Options::new();
 
 	opts.set_parsed_options("level_compaction_dynamic_level_bytes=true").map_err(other_io_err)?;


### PR DESCRIPTION
Closes #135.
This is a breaking change (changes `DatabaseConfig`, makes `memory_budget_per_col` private, removed `write_rate_limit` option from `CompactionProfile`) .