### PR TITLE
Migrate primitive types to 2018 edition

### DIFF
--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
 description = "Primitive types shared by Ethereum and Substrate"
+edition = "2018"
 
 [dependencies]
 fixed-hash = { version = "0.5", path = "../fixed-hash", default-features = false }

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
 description = "Parity Codec serialization support for uint and fixed hash."
+edition = "2018"
 
 [dependencies]
 parity-scale-codec = { version = "1.0.6", default-features = false }

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -11,7 +11,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
-pub extern crate parity_scale_codec as codec;
+pub use parity_scale_codec as codec;
 
 /// Add Parity Codec serialization support to an integer created by `construct_uint!`.
 #[macro_export]

--- a/primitive-types/impls/rlp/Cargo.toml
+++ b/primitive-types/impls/rlp/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0/MIT"
 homepage = "https://github.com/paritytech/parity-common"
 description = "RLP serialization support for uint and fixed hash."
+edition = "2018"
 
 [dependencies]
 rlp = { version = "0.4", path = "../../../rlp", default-features = false }

--- a/primitive-types/impls/rlp/src/lib.rs
+++ b/primitive-types/impls/rlp/src/lib.rs
@@ -11,10 +11,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
-pub extern crate rlp;
+pub use rlp;
 
 #[doc(hidden)]
-pub extern crate core as core_;
+pub use core as core_;
 
 /// Add RLP serialization support to an integer created by `construct_uint!`.
 #[macro_export]

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -14,28 +14,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-extern crate core;
-
-#[macro_use]
-extern crate uint;
-
-#[macro_use]
-extern crate fixed_hash;
-
-#[cfg(feature = "impl-serde")]
-#[macro_use]
-extern crate impl_serde;
-
-#[cfg(feature = "impl-codec")]
-#[macro_use]
-extern crate impl_codec;
-
-#[cfg(feature = "impl-rlp")]
-#[macro_use]
-extern crate impl_rlp;
-
 use core::convert::TryFrom;
+use fixed_hash::{construct_fixed_hash, impl_fixed_hash_conversions};
+use uint::{construct_uint, uint_full_mul_reg};
 
 /// Error type for conversion.
 #[derive(Debug, PartialEq, Eq)]
@@ -73,6 +54,7 @@ construct_fixed_hash! {
 #[cfg(feature = "impl-serde")]
 mod serde {
 	use super::*;
+	use impl_serde::{impl_fixed_hash_serde, impl_uint_serde};
 
 	impl_uint_serde!(U128, 2);
 	impl_uint_serde!(U256, 4);
@@ -86,6 +68,7 @@ mod serde {
 #[cfg(feature = "impl-codec")]
 mod codec {
 	use super::*;
+	use impl_codec::{impl_fixed_hash_codec, impl_uint_codec};
 
 	impl_uint_codec!(U128, 2);
 	impl_uint_codec!(U256, 4);
@@ -99,6 +82,7 @@ mod codec {
 #[cfg(feature = "impl-rlp")]
 mod rlp {
 	use super::*;
+	use impl_rlp::{impl_fixed_hash_rlp, impl_uint_rlp};
 
 	impl_uint_rlp!(U128, 2);
 	impl_uint_rlp!(U256, 4);


### PR DESCRIPTION
Migrates following crates to 2018 edition:

* `primitive-types/impls/codec`
* `primitive-types/impls/rlp`
* `primitive-types`

Missing piece to close #143.