### PR TITLE
Use 2018 edition for rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       rust: stable
       before_script:
         - rustup component add rustfmt
-      after_script:
+      script:
         - cargo fmt -- --check
     - os: linux
       rust: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
       rust: stable
       before_script:
         - rustup component add rustfmt
-      script:
-        - cargo fmt -- --check
     - os: linux
       rust: beta
     - os: linux
@@ -22,6 +20,9 @@ matrix:
 install:
   - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 script:
+  - if [ "$TRAVIS_RUST_VERSION" == "stable" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    cargo fmt -- --check;
+    fi
   - cargo check --all --tests
   - cargo build --all
   - cargo test --all --exclude uint --exclude fixed-hash

--- a/ethbloom/src/lib.rs
+++ b/ethbloom/src/lib.rs
@@ -93,7 +93,7 @@ impl<'a> From<Input<'a>> for Hash<'a> {
 				keccak256.update(raw);
 				keccak256.finalize(&mut out);
 				Hash::Owned(out)
-			},
+			}
 			Input::Hash(hash) => Hash::Ref(hash),
 		}
 	}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 hard_tabs = true
 max_width = 120
 use_small_heuristics = "Max"
+edition = "2018"


### PR DESCRIPTION
Not sure about adding `cargo fmt -- --check` to `.travis.yml` (see #264), keeping it out for now.

Fixes #264 