### PR TITLE
Make fixed-hash test structs public

### DIFF
--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -1,8 +1,8 @@
-construct_fixed_hash! { struct H32(4); }
-construct_fixed_hash! { struct H64(8); }
-construct_fixed_hash! { struct H128(16); }
-construct_fixed_hash! { struct H160(20); }
-construct_fixed_hash! { struct H256(32); }
+construct_fixed_hash! { pub struct H32(4); }
+construct_fixed_hash! { pub struct H64(8); }
+construct_fixed_hash! { pub struct H128(16); }
+construct_fixed_hash! { pub struct H160(20); }
+construct_fixed_hash! { pub struct H256(32); }
 
 impl_fixed_hash_conversions!(H256, H160);
 


### PR DESCRIPTION
This change silents all dead_code warnings for #[cfg(test)].

Fixes #265 