### PR TITLE
[fixed-hash]: fix build with `default-features`

### DIFF
--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -10,7 +10,6 @@
 
 // Re-export liballoc using an alias so that the macros can work without
 // requiring `extern crate alloc` downstream.
-#[cfg(not(feature = "std"))]
 #[doc(hidden)]
 pub extern crate alloc as alloc_;
 


### PR DESCRIPTION
alloc is required by the `rustc-hex` implementation which makes the build with `default-features` to fail.
This commit re-exports `alloc` for both std and no-std to fix this problem