### PR TITLE
Introduce Rlp::at_with_offset method.

### DIFF
--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -186,6 +186,9 @@ impl<'a> Rlp<'a> {
 		}
 	}
 
+	/// Returns an Rlp item in a list at the given index.
+	///
+	/// Returns an error if this Rlp is not a list or if the index is out of range.
 	pub fn at<'view>(&'view self, index: usize) -> Result<Rlp<'a>, DecoderError>
 	where
 		'a: 'view,
@@ -194,6 +197,10 @@ impl<'a> Rlp<'a> {
 		Ok(rlp)
 	}
 
+	/// Returns an Rlp item in a list at the given index along with the byte offset into the
+	/// raw data slice.
+	///
+	/// Returns an error if this Rlp is not a list or if the index is out of range.
 	pub fn at_with_offset<'view>(&'view self, index: usize)
 		-> Result<(Rlp<'a>, usize), DecoderError>
 		where

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -54,6 +54,35 @@ fn rlp_at() {
 }
 
 #[test]
+fn rlp_at_with_offset() {
+	let data = vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g'];
+	{
+		let rlp = Rlp::new(&data);
+		assert!(rlp.is_list());
+		let animals: Vec<String> = rlp.as_list().unwrap();
+		assert_eq!(animals, vec!["cat".to_owned(), "dog".to_owned()]);
+
+		let (cat, cat_offset) = rlp.at_with_offset(0).unwrap();
+		assert!(cat.is_data());
+		assert_eq!(cat_offset, 1);
+		assert_eq!(cat.as_raw(), &[0x83, b'c', b'a', b't']);
+		assert_eq!(cat.as_val::<String>().unwrap(), "cat".to_owned());
+
+		let (dog, dog_offset) = rlp.at_with_offset(1).unwrap();
+		assert!(dog.is_data());
+		assert_eq!(dog_offset, 5);
+		assert_eq!(dog.as_raw(), &[0x83, b'd', b'o', b'g']);
+		assert_eq!(dog.as_val::<String>().unwrap(), "dog".to_owned());
+
+		let (cat_again, cat_offset) = rlp.at_with_offset(0).unwrap();
+		assert!(cat_again.is_data());
+		assert_eq!(cat_offset, 1);
+		assert_eq!(cat_again.as_raw(), &[0x83, b'c', b'a', b't']);
+		assert_eq!(cat_again.as_val::<String>().unwrap(), "cat".to_owned());
+	}
+}
+
+#[test]
 fn rlp_at_err() {
 	let data = vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o'];
 	{


### PR DESCRIPTION
This is needed to update parity-ethereum's Patricia Trie to version 0.16.0 of the `trie-db` crate.

`NodeCodec` in `trie-db` was changed in https://github.com/paritytech/trie/pull/34 so that encoded nodes can be decoded into a `NodePlan` which specifies the slice indices of data contained within the encoded node instead of just the slices themselves. This allows for a cleaner and faster trie iteration interface.

Since parity-ethereum uses an rlp-based codec for trie nodes unlike Substrate and the reference trie, a method to get a list item with its slice offset is required. I have written a prototype implementation [here](https://github.com/jimpo/parity/tree/trie-db-upgrade) (note that the grossness of having multiple rlp versions in the same crate would go away).