### PR TITLE
[kvdb-rocksdb] Use "pinned" gets to avoid allocations

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- use `get_pinned` API to save one allocation for each call to `get()`
+- rename `drop_column` to `remove_last_column`
+- rename `get_cf` to `cf`
 
 ## [0.2.0] - 2019-11-28
 - Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb) (see [PR #257](https://github.com/paritytech/parity-common/pull/257) for details)

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-- use `get_pinned` API to save one allocation for each call to `get()`
-- rename `drop_column` to `remove_last_column`
-- rename `get_cf` to `cf`
+- use `get_pinned` API to save one allocation for each call to `get()` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- rename `drop_column` to `remove_last_column` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- rename `get_cf` to `cf` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
 
 ## [0.2.0] - 2019-11-28
 - Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb) (see [PR #257](https://github.com/paritytech/parity-common/pull/257) for details)

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -113,7 +113,7 @@ impl<'a> IterationHandler for &'a DBAndColumns {
 			|| self.db.iterator(IteratorMode::Start),
 			|c| {
 				self.db
-					.iterator_cf(self.get_colf(c as usize), IteratorMode::Start)
+					.iterator_cf(self.cf(c as usize), IteratorMode::Start)
 					.expect("iterator params are valid; qed")
 			},
 		)
@@ -122,7 +122,7 @@ impl<'a> IterationHandler for &'a DBAndColumns {
 	fn iter_from_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Self::Iterator {
 		col.map_or_else(
 			|| self.db.prefix_iterator(prefix),
-			|c| self.db.prefix_iterator_cf(self.get_colf(c as usize), prefix).expect("iterator params are valid; qed"),
+			|c| self.db.prefix_iterator_cf(self.cf(c as usize), prefix).expect("iterator params are valid; qed"),
 		)
 	}
 }

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -111,11 +111,7 @@ impl<'a> IterationHandler for &'a DBAndColumns {
 	fn iter(&self, col: Option<u32>) -> Self::Iterator {
 		col.map_or_else(
 			|| self.db.iterator(IteratorMode::Start),
-			|c| {
-				self.db
-					.iterator_cf(self.cf(c as usize), IteratorMode::Start)
-					.expect("iterator params are valid; qed")
-			},
+			|c| self.db.iterator_cf(self.cf(c as usize), IteratorMode::Start).expect("iterator params are valid; qed"),
 		)
 	}
 

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -113,7 +113,7 @@ impl<'a> IterationHandler for &'a DBAndColumns {
 			|| self.db.iterator(IteratorMode::Start),
 			|c| {
 				self.db
-					.iterator_cf(self.get_cf(c as usize), IteratorMode::Start)
+					.iterator_cf(self.get_colf(c as usize), IteratorMode::Start)
 					.expect("iterator params are valid; qed")
 			},
 		)
@@ -122,7 +122,7 @@ impl<'a> IterationHandler for &'a DBAndColumns {
 	fn iter_from_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Self::Iterator {
 		col.map_or_else(
 			|| self.db.prefix_iterator(prefix),
-			|c| self.db.prefix_iterator_cf(self.get_cf(c as usize), prefix).expect("iterator params are valid; qed"),
+			|c| self.db.prefix_iterator_cf(self.get_colf(c as usize), prefix).expect("iterator params are valid; qed"),
 		)
 	}
 }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -226,7 +226,6 @@ struct DBAndColumns {
 }
 
 impl DBAndColumns {
-	#[inline] // todo[dvdplm] measure
 	fn cf(&self, i: usize) -> &ColumnFamily {
 		self.db.cf_handle(&self.column_names[i]).expect("the specified column name is correct; qed")
 	}
@@ -249,7 +248,7 @@ pub struct Database {
 	flushing_lock: Mutex<bool>,
 }
 
-#[inline] // todo[dvdplm] measure
+#[inline]
 fn check_for_corruption<T, P: AsRef<Path>>(path: P, res: result::Result<T, Error>) -> io::Result<T> {
 	if let Err(ref s) = res {
 		if is_corrupted(s) {
@@ -405,7 +404,6 @@ impl Database {
 		DBTransaction::new()
 	}
 
-	#[inline] // todo[dvdplm] measure
 	fn to_overlay_column(col: Option<u32>) -> usize {
 		col.map_or(0, |c| (c + 1) as usize)
 	}

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -850,7 +850,7 @@ mod tests {
 	}
 
 	#[test]
-	fn drop_columns() {
+	fn remove_columns() {
 		let config = DatabaseConfig::default();
 		let config_5 = DatabaseConfig::with_columns(Some(5));
 
@@ -862,7 +862,7 @@ mod tests {
 			assert_eq!(db.num_columns(), 5);
 
 			for i in (0..5).rev() {
-				db.drop_column().unwrap();
+				db.remove_last_column().unwrap();
 				assert_eq!(db.num_columns(), i);
 			}
 		}

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -529,7 +529,11 @@ impl Database {
 							Some(&KeyState::Delete) => Ok(None),
 							None => col
 								.map_or_else(
-									|| cfs.db.get_pinned_opt(key, &self.read_opts).map(|r| r.map(|v| DBValue::from_slice(&v))),
+									|| {
+										cfs.db
+											.get_pinned_opt(key, &self.read_opts)
+											.map(|r| r.map(|v| DBValue::from_slice(&v)))
+									},
 									|c| {
 										cfs.db
 											.get_pinned_cf_opt(cfs.cf(c as usize), key, &self.read_opts)


### PR DESCRIPTION
This PR uses the [`get_pinned()`](https://github.com/paritytech/parity-common/pull/274/files#diff-4382bfb7e75959b2b8884268540abfa3R532) API to save an allocation when calling `get()`. 

Using the benchmark from #275 there's no noticeable speedup, likely because the vast majority of time is spent in rocksdb so even halving the allocations on the rust side has no noticeable impact.

Also included are some minor cosmetic changes and the rename of `drop_column` to `remove_last_column` to make users aware of what the code actually does.