### PR TITLE
[kvdb-rocksdb] Add benchmark for point lookups

### DIFF
--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -7,6 +7,10 @@ description = "kvdb implementation backed by rocksDB"
 license = "GPL-3.0"
 edition = "2018"
 
+[[bench]]
+name = "bench_read_perf"
+harness = false
+
 [dependencies]
 elastic-array = "0.10.2"
 fs-swap = "0.2.4"
@@ -20,5 +24,8 @@ rocksdb = { version = "0.13", features = ["snappy"], default-features = false }
 owning_ref = "0.4.0"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+alloc_counter = "0.0.3"
+criterion = "0.3"
 ethereum-types = { version = "0.8.0", path = "../ethereum-types" }
+rand = "0.7.2"
+tempdir = "0.3.7"

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -24,7 +24,7 @@ rocksdb = { version = "0.13", features = ["snappy"], default-features = false }
 owning_ref = "0.4.0"
 
 [dev-dependencies]
-alloc_counter = "0.0.3"
+alloc_counter = "0.0.4"
 criterion = "0.3"
 ethereum-types = { version = "0.8.0", path = "../ethereum-types" }
 rand = "0.7.2"

--- a/kvdb-rocksdb/benches/.gitignore
+++ b/kvdb-rocksdb/benches/.gitignore
@@ -1,0 +1,1 @@
+_rocksdb_bench_get

--- a/kvdb-rocksdb/benches/bench_read_perf.rs
+++ b/kvdb-rocksdb/benches/bench_read_perf.rs
@@ -29,11 +29,10 @@ const NEEDLES: usize = 10_000;
 const NEEDLES_TO_HAYSTACK_RATIO: usize = 100;
 
 use std::io;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use alloc_counter::{count_alloc, AllocCounterSystem};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use elastic_array::core_::time::Duration;
 use ethereum_types::H256;
 use rand::{distributions::Uniform, seq::SliceRandom, Rng};
 

--- a/kvdb-rocksdb/benches/bench_read_perf.rs
+++ b/kvdb-rocksdb/benches/bench_read_perf.rs
@@ -58,7 +58,7 @@ fn open_db() -> Database {
 /// an `ElasticArray128` so sometimes we save on allocations.
 fn n_random_bytes(n: usize) -> Vec<u8> {
 	let mut rng = rand::thread_rng();
-	let variability: i64 = rng.gen_range(0, (n as f64 * 0.2) as i64);
+	let variability: i64 = rng.gen_range(0, (n / 5) as i64);
 	let plus_or_minus: i64 = if variability % 2 == 0 { 1 } else { -1 };
 	let range = Uniform::from(0..u8::max_value());
 	rng.sample_iter(&range).take((n as i64 + plus_or_minus * variability) as usize).collect()


### PR DESCRIPTION
This is far from perfect but might be a start of something. The tricky part of benchmarking databases is to setup the data set properly. This PR doesn't do anything particularly fancy but it's worth mentioning the basics:

- each benchmark run adds 1M keys to the DB (single tx, so if you're low on memory be patient) ;
- empty/small DBs are much faster obviously so the first few benchmark runs are not very indicative of anything; I think at least 3-8M keys are needed before the values start to actually mean something;
- interestingly though, during my testing, performance seem to plateau and after a while, and adding more data doesn't seem to slow any of the tests down by much
- the benchmarks all count the number of allocations; this is why they use `iter_custom()` rather than `iter()`.

Benchmark results:
```
get key                 time:   [2.5151 us 2.5616 us 2.6140 us]
                        change: [-4.3238% -1.1310% +2.0720%] (p = 0.50 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

[get key] total: iterations=4016151, allocations=6880994; allocations per iter=1.71

get key by prefix       time:   [15.011 us 15.252 us 15.511 us]
                        change: [-1.5796% +2.0998% +5.6256%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

[get key by prefix] total: iterations=580293, allocations=1160586; allocations per iter=2.00

iterate over 1k keys    time:   [430.52 us 433.30 us 436.16 us]
                        change: [-11.873% -3.7270% +2.5027%] (p = 0.44 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

[iterate over 1k keys] total: iterations=23341, allocations=46705341; allocations per iter=2.00

single key from iterator
                        time:   [2.8204 us 2.8454 us 2.8730 us]
                        change: [-6.8037% -4.5874% -2.2547%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

[single key from iterator] total: iterations=2785775, allocations=5571550; allocations per iter=2.00
```
