### PR TITLE
Fix deprecation warnings on std::mem::uninitialized

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -77,7 +77,7 @@ macro_rules! uint_overflowing_binop {
 		let $name(ref me) = $self_expr;
 		let $name(ref you) = $other;
 
-		let mut ret = unsafe { $crate::core_::mem::uninitialized() };
+		let mut ret = unsafe { $crate::core_::mem::MaybeUninit::uninit().assume_init() };
 		let ret_ptr = &mut ret as *mut [u64; $n_words] as *mut u64;
 		let mut carry = 0u64;
 


### PR DESCRIPTION
Fixed the deprecation warnings.

```
warning: use of deprecated item 'std::mem::uninitialized': use `mem::MaybeUninit` instead
  --> primitive-types/src/lib.rs:47:1
   |
47 | / construct_uint! {
48 | |     /// 128-bit unsigned integer.
49 | |     pub struct U128(2);
50 | | }
   | |_^
   |
   = note: `#[warn(deprecated)]` on by default
   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

```