### PR TITLE
[kvdb*] Make column type u32 instead of Option<u32>

### DIFF
--- a/kvdb-memorydb/CHANGELOG.md
+++ b/kvdb-memorydb/CHANGELOG.md
@@ -5,3 +5,9 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Fixed
+- `iter_from_prefix` behaviour synced with the `kvdb-rocksdb`
+### Changed
+- Default column support removed from the API
+  - Column argument type changed from `Option<u32>` to `u32`
+  - Migration `None` -> `0`, `Some(0)` -> `1`, `Some(1)` -> `2`, etc.

--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -112,3 +112,107 @@ impl KeyValueDB for InMemory {
 		Err(io::Error::new(io::ErrorKind::Other, "Attempted to restore in-memory database"))
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::{create, KeyValueDB};
+
+	#[test]
+	fn get_fails_with_non_existing_column() {
+		let db = create(1);
+		assert!(db.get(1, &[]).is_err());
+	}
+
+	#[test]
+	fn put_and_get() {
+		let db = create(1);
+
+		let key1 = b"key1";
+
+		let mut transaction = db.transaction();
+		transaction.put(0, key1, b"horse");
+		db.write_buffered(transaction);
+		assert_eq!(&*db.get(0, key1).unwrap().unwrap(), b"horse");
+	}
+
+	#[test]
+	fn delete_and_get() {
+		let db = create(1);
+
+		let key1 = b"key1";
+
+		let mut transaction = db.transaction();
+		transaction.put(0, key1, b"horse");
+		db.write_buffered(transaction);
+		assert_eq!(&*db.get(0, key1).unwrap().unwrap(), b"horse");
+
+		let mut transaction = db.transaction();
+		transaction.delete(0, key1);
+		db.write_buffered(transaction);
+		assert!(db.get(0, key1).unwrap().is_none());
+	}
+
+	#[test]
+	fn iter() {
+		let db = create(1);
+
+		let key1 = b"key1";
+		let key2 = b"key2";
+
+		let mut transaction = db.transaction();
+		transaction.put(0, key1, key1);
+		transaction.put(0, key2, key2);
+		db.write_buffered(transaction);
+
+		let contents: Vec<_> = db.iter(0).into_iter().collect();
+		assert_eq!(contents.len(), 2);
+		assert_eq!(&*contents[0].0, key1);
+		assert_eq!(&*contents[0].1, key1);
+		assert_eq!(&*contents[1].0, key2);
+		assert_eq!(&*contents[1].1, key2);
+	}
+
+	#[test]
+	fn iter_from_prefix() {
+		let db = create(1);
+
+		let key1 = b"0";
+		let key2 = b"a";
+		let key3 = b"ab";
+
+		let mut transaction = db.transaction();
+		transaction.put(0, key1, key1);
+		transaction.put(0, key2, key2);
+		transaction.put(0, key3, key3);
+		db.write_buffered(transaction);
+
+		let contents: Vec<_> = db.iter_from_prefix(0, b"").into_iter().collect();
+		assert_eq!(contents.len(), 3);
+		assert_eq!(&*contents[0].0, key1);
+		assert_eq!(&*contents[0].1, key1);
+		assert_eq!(&*contents[1].0, key2);
+		assert_eq!(&*contents[1].1, key2);
+		assert_eq!(&*contents[2].0, key3);
+		assert_eq!(&*contents[2].1, key3);
+
+		let contents: Vec<_> = db.iter_from_prefix(0, b"0").into_iter().collect();
+		assert_eq!(contents.len(), 1);
+		assert_eq!(&*contents[0].0, key1);
+		assert_eq!(&*contents[0].1, key1);
+
+		let contents: Vec<_> = db.iter_from_prefix(0, b"a").into_iter().collect();
+		assert_eq!(contents.len(), 2);
+		assert_eq!(&*contents[0].0, key2);
+		assert_eq!(&*contents[0].1, key2);
+		assert_eq!(&*contents[1].0, key3);
+		assert_eq!(&*contents[1].1, key3);
+
+		let contents: Vec<_> = db.iter_from_prefix(0, b"ab").into_iter().collect();
+		assert_eq!(contents.len(), 1);
+		assert_eq!(&*contents[0].0, key3);
+		assert_eq!(&*contents[0].1, key3);
+
+		let contents: Vec<_> = db.iter_from_prefix(0, b"abc").into_iter().collect();
+		assert_eq!(contents.len(), 0);
+	}
+}

--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -102,7 +102,7 @@ impl KeyValueDB for InMemory {
 			Some(map) => Box::new(
 				map.clone()
 					.into_iter()
-					.skip_while(move |&(ref k, _)| !k.starts_with(prefix))
+					.filter(move |&(ref k, _)| k.starts_with(prefix))
 					.map(|(k, v)| (k.into_boxed_slice(), v.into_vec().into_boxed_slice())),
 			),
 			None => Box::new(None.into_iter()),

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-- use `get_pinned` API to save one allocation for each call to `get()` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
-- rename `drop_column` to `remove_last_column` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
-- rename `get_cf` to `cf` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Use `get_pinned` API to save one allocation for each call to `get()` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Rename `drop_column` to `remove_last_column` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Rename `get_cf` to `cf` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Default column support removed from the API (See [PR #278](https://github.com/paritytech/parity-common/pull/278) for details)
+  - Column argument type changed from `Option<u32>` to `u32`
+  - Migration `None` -> `0`, `Some(0)` -> `1`, `Some(1)` -> `2`, etc.
+  - `DatabaseConfig::default()` defaults to 1 column
+  - `Database::with_columns` still accepts `u32`, but panics if `0` is provided 
 
 ## [0.2.0] - 2019-11-28
 - Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb) (see [PR #257](https://github.com/paritytech/parity-common/pull/257) for details)

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog].
   - Column argument type changed from `Option<u32>` to `u32`
   - Migration
     - Column index `None` -> `0`, `Some(0)` -> `1`, `Some(1)` -> `2`, etc.
-    - Database should be opened with +1 number of columns for migration
+    - Database must be opened with at least one column and existing DBs has to be opened with a number of columns increased by 1 to avoid having to migrate the data, e.g. before: `Some(9)`, after: `10`.
   - `DatabaseConfig::default()` defaults to 1 column
   - `Database::with_columns` still accepts `u32`, but panics if `0` is provided 
 

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -10,7 +10,9 @@ The format is based on [Keep a Changelog].
 - Rename `get_cf` to `cf` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
 - Default column support removed from the API (See [PR #278](https://github.com/paritytech/parity-common/pull/278) for details)
   - Column argument type changed from `Option<u32>` to `u32`
-  - Migration `None` -> `0`, `Some(0)` -> `1`, `Some(1)` -> `2`, etc.
+  - Migration
+    - Column index `None` -> `0`, `Some(0)` -> `1`, `Some(1)` -> `2`, etc.
+    - Database should be opened with +1 number of columns for migration
   - `DatabaseConfig::default()` defaults to 1 column
   - `Database::with_columns` still accepts `u32`, but panics if `0` is provided 
 

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog].
     - Database must be opened with at least one column and existing DBs has to be opened with a number of columns increased by 1 to avoid having to migrate the data, e.g. before: `Some(9)`, after: `10`.
   - `DatabaseConfig::default()` defaults to 1 column
   - `Database::with_columns` still accepts `u32`, but panics if `0` is provided 
+  - `Database::open` panics if configuration with 0 columns is provided
 
 ## [0.2.0] - 2019-11-28
 - Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb) (see [PR #257](https://github.com/paritytech/parity-common/pull/257) for details)

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -270,16 +270,6 @@ fn is_corrupted(err: &Error) -> bool {
 fn generate_options(config: &DatabaseConfig) -> Options {
 	let mut opts = Options::default();
 
-	if config.columns.get() == 1 {
-		let budget = config.memory_budget() / 2;
-		opts.set_db_write_buffer_size(budget);
-		// from https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#memtable
-		// Memtable size is controlled by the option `write_buffer_size`.
-		// If you increase your memtable size, be sure to also increase your L1 size!
-		// L1 size is controlled by the option `max_bytes_for_level_base`.
-		opts.set_max_bytes_for_level_base(budget as u64);
-	}
-
 	opts.set_use_fsync(false);
 	opts.create_if_missing(true);
 	opts.set_max_open_files(config.max_open_files);

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -215,7 +215,7 @@ impl Default for DatabaseConfig {
 			max_open_files: 512,
 			memory_budget: HashMap::new(),
 			compaction: CompactionProfile::default(),
-			columns: unsafe { NonZeroU32::new_unchecked(1) },
+			columns: NonZeroU32::new(1).expect("1 is not a zero; qed"),
 			keep_log_file_num: 1,
 		}
 	}

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -16,7 +16,7 @@
 
 mod iter;
 
-use std::{cmp, collections::HashMap, convert::identity, error, fs, io, mem, path::Path, result};
+use std::{cmp, collections::HashMap, convert::identity, error, fs, io, mem, num::NonZeroU32, path::Path, result};
 
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use rocksdb::{
@@ -49,8 +49,8 @@ where
 // Used for memory budget.
 type MiB = usize;
 
-const KB: usize = 1024;
-const MB: usize = 1024 * KB;
+const KB: usize = 1_024;
+const MB: usize = 1_024 * KB;
 
 /// The default column memory budget in MiB.
 pub const DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB: MiB = 128;
@@ -162,11 +162,11 @@ pub struct DatabaseConfig {
 	/// write buffer size for each column including the default one.
 	/// If the memory budget of a column is not specified,
 	/// `DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB` is used for that column.
-	pub memory_budget: HashMap<Option<u32>, MiB>,
+	pub memory_budget: HashMap<u32, MiB>,
 	/// Compaction profile.
 	pub compaction: CompactionProfile,
 	/// Set number of columns.
-	pub columns: Option<u32>,
+	pub columns: NonZeroU32,
 	/// Specify the maximum number of info/debug log files to be kept.
 	pub keep_log_file_num: i32,
 }
@@ -174,23 +174,24 @@ pub struct DatabaseConfig {
 impl DatabaseConfig {
 	/// Create new `DatabaseConfig` with default parameters and specified set of columns.
 	/// Note that cache sizes must be explicitly set.
-	pub fn with_columns(columns: Option<u32>) -> Self {
+	///
+	/// At least 1 column must be used otherwise this function panics.
+	pub fn with_columns(columns: u32) -> Self {
+		let columns = NonZeroU32::new(columns).expect("At least one column have to be specified");
+
 		Self { columns, ..Default::default() }
 	}
 
 	/// Returns the total memory budget in bytes.
 	pub fn memory_budget(&self) -> MiB {
-		match self.columns {
-			None => self.memory_budget.get(&None).unwrap_or(&DB_DEFAULT_MEMORY_BUDGET_MB) * MB,
-			Some(columns) => (0..columns)
-				.map(|i| self.memory_budget.get(&Some(i)).unwrap_or(&DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB) * MB)
-				.sum(),
-		}
+		(0..self.columns.get())
+			.map(|i| self.memory_budget.get(&i).unwrap_or(&DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB) * MB)
+			.sum()
 	}
 
 	/// Returns the memory budget of the specified column in bytes.
 	fn memory_budget_for_col(&self, col: u32) -> MiB {
-		self.memory_budget.get(&Some(col)).unwrap_or(&DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB) * MB
+		self.memory_budget.get(&col).unwrap_or(&DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB) * MB
 	}
 
 	// Get column family configuration with the given block based options.
@@ -214,7 +215,7 @@ impl Default for DatabaseConfig {
 			max_open_files: 512,
 			memory_budget: HashMap::new(),
 			compaction: CompactionProfile::default(),
-			columns: None,
+			columns: unsafe { NonZeroU32::new_unchecked(1) },
 			keep_log_file_num: 1,
 		}
 	}
@@ -268,9 +269,8 @@ fn is_corrupted(err: &Error) -> bool {
 /// Generate the options for RocksDB, based on the given `DatabaseConfig`.
 fn generate_options(config: &DatabaseConfig) -> Options {
 	let mut opts = Options::default();
-	let columns = config.columns.unwrap_or(0);
 
-	if columns == 0 {
+	if config.columns.get() == 1 {
 		let budget = config.memory_budget() / 2;
 		opts.set_db_write_buffer_size(budget);
 		// from https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#memtable
@@ -311,20 +311,10 @@ fn generate_block_based_options(config: &DatabaseConfig) -> BlockBasedOptions {
 impl Database {
 	const CORRUPTION_FILE_NAME: &'static str = "CORRUPTED";
 
-	/// Open database with default settings.
-	pub fn open_default(path: &str) -> io::Result<Database> {
-		Database::open(&DatabaseConfig::default(), path)
-	}
-
 	/// Open database file. Creates if it does not exist.
 	pub fn open(config: &DatabaseConfig, path: &str) -> io::Result<Database> {
 		let opts = generate_options(config);
 		let block_opts = generate_block_based_options(config);
-		let columns = config.columns.unwrap_or(0);
-
-		if config.columns.is_some() && config.memory_budget.contains_key(&None) {
-			warn!("Memory budget for the default column (None) is ignored if columns.is_some()");
-		}
 
 		// attempt database repair if it has been previously marked as corrupted
 		let db_corrupted = Path::new(path).join(Database::CORRUPTION_FILE_NAME);
@@ -334,36 +324,34 @@ impl Database {
 			fs::remove_file(db_corrupted)?;
 		}
 
+		let columns = config.columns.get();
+
 		let column_names: Vec<_> = (0..columns).map(|c| format!("col{}", c)).collect();
 
 		let write_opts = WriteOptions::default();
 		let mut read_opts = ReadOptions::default();
 		read_opts.set_verify_checksums(false);
 
-		let db = if config.columns.is_some() {
-			let cf_descriptors: Vec<_> = (0..columns)
-				.map(|i| ColumnFamilyDescriptor::new(&column_names[i as usize], config.column_config(&block_opts, i)))
-				.collect();
+		let cf_descriptors: Vec<_> = (0..columns)
+			.map(|i| ColumnFamilyDescriptor::new(&column_names[i as usize], config.column_config(&block_opts, i)))
+			.collect();
 
-			match DB::open_cf_descriptors(&opts, path, cf_descriptors) {
-				Err(_) => {
-					// retry and create CFs
-					match DB::open_cf(&opts, path, &[] as &[&str]) {
-						Ok(mut db) => {
-							for (i, name) in column_names.iter().enumerate() {
-								let _ = db
-									.create_cf(name, &config.column_config(&block_opts, i as u32))
-									.map_err(other_io_err)?;
-							}
-							Ok(db)
+		let db = match DB::open_cf_descriptors(&opts, path, cf_descriptors) {
+			Err(_) => {
+				// retry and create CFs
+				match DB::open_cf(&opts, path, &[] as &[&str]) {
+					Ok(mut db) => {
+						for (i, name) in column_names.iter().enumerate() {
+							let _ = db
+								.create_cf(name, &config.column_config(&block_opts, i as u32))
+								.map_err(other_io_err)?;
 						}
-						err => err,
+						Ok(db)
 					}
+					err => err,
 				}
-				ok => ok,
 			}
-		} else {
-			DB::open(&opts, path)
+			ok => ok,
 		};
 
 		let db = match db {
@@ -372,25 +360,21 @@ impl Database {
 				warn!("DB corrupted: {}, attempting repair", s);
 				DB::repair(&opts, path).map_err(other_io_err)?;
 
-				if config.columns.is_some() {
-					let cf_descriptors: Vec<_> = (0..columns)
-						.map(|i| {
-							ColumnFamilyDescriptor::new(&column_names[i as usize], config.column_config(&block_opts, i))
-						})
-						.collect();
+				let cf_descriptors: Vec<_> = (0..columns)
+					.map(|i| {
+						ColumnFamilyDescriptor::new(&column_names[i as usize], config.column_config(&block_opts, i))
+					})
+					.collect();
 
-					DB::open_cf_descriptors(&opts, path, cf_descriptors).map_err(other_io_err)?
-				} else {
-					DB::open(&opts, path).map_err(other_io_err)?
-				}
+				DB::open_cf_descriptors(&opts, path, cf_descriptors).map_err(other_io_err)?
 			}
 			Err(s) => return Err(other_io_err(s)),
 		};
 		Ok(Database {
 			db: RwLock::new(Some(DBAndColumns { db, column_names })),
 			config: config.clone(),
-			overlay: RwLock::new((0..=columns).map(|_| HashMap::new()).collect()),
-			flushing: RwLock::new((0..=columns).map(|_| HashMap::new()).collect()),
+			overlay: RwLock::new((0..columns).map(|_| HashMap::new()).collect()),
+			flushing: RwLock::new((0..columns).map(|_| HashMap::new()).collect()),
 			flushing_lock: Mutex::new(false),
 			path: path.to_owned(),
 			read_opts,
@@ -404,25 +388,15 @@ impl Database {
 		DBTransaction::new()
 	}
 
-	fn to_overlay_column(col: Option<u32>) -> usize {
-		col.map_or(0, |c| (c + 1) as usize)
-	}
-
 	/// Commit transaction to database.
 	pub fn write_buffered(&self, tr: DBTransaction) {
 		let mut overlay = self.overlay.write();
 		let ops = tr.ops;
 		for op in ops {
 			match op {
-				DBOp::Insert { col, key, value } => {
-					let c = Self::to_overlay_column(col);
-					overlay[c].insert(key, KeyState::Insert(value));
-				}
-				DBOp::Delete { col, key } => {
-					let c = Self::to_overlay_column(col);
-					overlay[c].insert(key, KeyState::Delete);
-				}
-			}
+				DBOp::Insert { col, key, value } => overlay[col as usize].insert(key, KeyState::Insert(value)),
+				DBOp::Delete { col, key } => overlay[col as usize].insert(key, KeyState::Delete),
+			};
 		}
 	}
 
@@ -435,24 +409,11 @@ impl Database {
 				{
 					for (c, column) in self.flushing.read().iter().enumerate() {
 						for (key, state) in column.iter() {
+							let cf = cfs.cf(c);
 							match *state {
-								KeyState::Delete => {
-									if c > 0 {
-										let cf = cfs.cf(c - 1);
-										batch.delete_cf(cf, key).map_err(other_io_err)?;
-									} else {
-										batch.delete(key).map_err(other_io_err)?;
-									}
-								}
-								KeyState::Insert(ref value) => {
-									if c > 0 {
-										let cf = cfs.cf(c - 1);
-										batch.put_cf(cf, key, value).map_err(other_io_err)?;
-									} else {
-										batch.put(key, value).map_err(other_io_err)?;
-									}
-								}
-							}
+								KeyState::Delete => batch.delete_cf(cf, key).map_err(other_io_err)?,
+								KeyState::Insert(ref value) => batch.put_cf(cf, key, value).map_err(other_io_err)?,
+							};
 						}
 					}
 				}
@@ -492,18 +453,14 @@ impl Database {
 				let ops = tr.ops;
 				for op in ops {
 					// remove any buffered operation for this key
-					self.overlay.write()[Self::to_overlay_column(op.col())].remove(op.key());
+					self.overlay.write()[op.col() as usize].remove(op.key());
+
+					let cf = cfs.cf(op.col() as usize);
 
 					match op {
-						DBOp::Insert { col, key, value } => match col {
-							None => batch.put(&key, &value).map_err(other_io_err)?,
-							Some(c) => batch.put_cf(cfs.cf(c as usize), &key, &value).map_err(other_io_err)?,
-						},
-						DBOp::Delete { col, key } => match col {
-							None => batch.delete(&key).map_err(other_io_err)?,
-							Some(c) => batch.delete_cf(cfs.cf(c as usize), &key).map_err(other_io_err)?,
-						},
-					}
+						DBOp::Insert { col: _, key, value } => batch.put_cf(cf, &key, &value).map_err(other_io_err)?,
+						DBOp::Delete { col: _, key } => batch.delete_cf(cf, &key).map_err(other_io_err)?,
+					};
 				}
 
 				check_for_corruption(&self.path, cfs.db.write_opt(batch, &self.write_opts))
@@ -513,31 +470,22 @@ impl Database {
 	}
 
 	/// Get value by key.
-	pub fn get(&self, col: Option<u32>, key: &[u8]) -> io::Result<Option<DBValue>> {
+	pub fn get(&self, col: u32, key: &[u8]) -> io::Result<Option<DBValue>> {
 		match *self.db.read() {
 			Some(ref cfs) => {
-				let overlay = &self.overlay.read()[Self::to_overlay_column(col)];
+				let overlay = &self.overlay.read()[col as usize];
 				match overlay.get(key) {
 					Some(&KeyState::Insert(ref value)) => Ok(Some(value.clone())),
 					Some(&KeyState::Delete) => Ok(None),
 					None => {
-						let flushing = &self.flushing.read()[Self::to_overlay_column(col)];
+						let flushing = &self.flushing.read()[col as usize];
 						match flushing.get(key) {
 							Some(&KeyState::Insert(ref value)) => Ok(Some(value.clone())),
 							Some(&KeyState::Delete) => Ok(None),
-							None => col
-								.map_or_else(
-									|| {
-										cfs.db
-											.get_pinned_opt(key, &self.read_opts)
-											.map(|r| r.map(|v| DBValue::from_slice(&v)))
-									},
-									|c| {
-										cfs.db
-											.get_pinned_cf_opt(cfs.cf(c as usize), key, &self.read_opts)
-											.map(|r| r.map(|v| DBValue::from_slice(&v)))
-									},
-								)
+							None => cfs
+								.db
+								.get_pinned_cf_opt(cfs.cf(col as usize), key, &self.read_opts)
+								.map(|r| r.map(|v| DBValue::from_slice(&v)))
 								.map_err(other_io_err),
 						}
 					}
@@ -549,19 +497,18 @@ impl Database {
 
 	/// Get value by partial key. Prefix size should match configured prefix size. Only searches flushed values.
 	// TODO: support prefix seek for unflushed data
-	pub fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>> {
+	pub fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>> {
 		self.iter_from_prefix(col, prefix).next().map(|(_, v)| v)
 	}
 
 	/// Get database iterator for flushed data.
 	/// Will hold a lock until the iterator is dropped
 	/// preventing the database from being closed.
-	pub fn iter<'a>(&'a self, col: Option<u32>) -> impl Iterator<Item = KeyValuePair> + 'a {
+	pub fn iter<'a>(&'a self, col: u32) -> impl Iterator<Item = KeyValuePair> + 'a {
 		let read_lock = self.db.read();
 		let optional = if read_lock.is_some() {
-			let c = Self::to_overlay_column(col);
 			let overlay_data = {
-				let overlay = &self.overlay.read()[c];
+				let overlay = &self.overlay.read()[col as usize];
 				let mut overlay_data = overlay
 					.iter()
 					.filter_map(|(k, v)| match *v {
@@ -582,14 +529,11 @@ impl Database {
 		};
 		optional.into_iter().flat_map(identity)
 	}
+
 	/// Get database iterator from prefix for flushed data.
 	/// Will hold a lock until the iterator is dropped
 	/// preventing the database from being closed.
-	fn iter_from_prefix<'a>(
-		&'a self,
-		col: Option<u32>,
-		prefix: &'a [u8],
-	) -> impl Iterator<Item = iter::KeyValuePair> + 'a {
+	fn iter_from_prefix<'a>(&'a self, col: u32, prefix: &'a [u8]) -> impl Iterator<Item = iter::KeyValuePair> + 'a {
 		let read_lock = self.db.read();
 		let optional = if read_lock.is_some() {
 			let guarded = iter::ReadGuardedIterator::new_from_prefix(read_lock, col, prefix);
@@ -686,11 +630,11 @@ impl Database {
 // duplicate declaration of methods here to avoid trait import in certain existing cases
 // at time of addition.
 impl KeyValueDB for Database {
-	fn get(&self, col: Option<u32>, key: &[u8]) -> io::Result<Option<DBValue>> {
+	fn get(&self, col: u32, key: &[u8]) -> io::Result<Option<DBValue>> {
 		Database::get(self, col, key)
 	}
 
-	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>> {
+	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>> {
 		Database::get_by_prefix(self, col, prefix)
 	}
 
@@ -706,16 +650,12 @@ impl KeyValueDB for Database {
 		Database::flush(self)
 	}
 
-	fn iter<'a>(&'a self, col: Option<u32>) -> Box<dyn Iterator<Item = KeyValuePair> + 'a> {
+	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = KeyValuePair> + 'a> {
 		let unboxed = Database::iter(self, col);
 		Box::new(unboxed.into_iter())
 	}
 
-	fn iter_from_prefix<'a>(
-		&'a self,
-		col: Option<u32>,
-		prefix: &'a [u8],
-	) -> Box<dyn Iterator<Item = KeyValuePair> + 'a> {
+	fn iter_from_prefix<'a>(&'a self, col: u32, prefix: &'a [u8]) -> Box<dyn Iterator<Item = KeyValuePair> + 'a> {
 		let unboxed = Database::iter_from_prefix(self, col, prefix);
 		Box::new(unboxed.into_iter())
 	}
@@ -743,6 +683,7 @@ mod tests {
 	fn test_db(config: &DatabaseConfig) {
 		let tempdir = TempDir::new("").unwrap();
 		let db = Database::open(config, tempdir.path().to_str().unwrap()).unwrap();
+
 		let key1 = H256::from_str("02c69be41d0b7e40352fc85be1cd65eb03d40ef8427a0ca4596b1ead9a00e9fc").unwrap();
 		let key2 = H256::from_str("03c69be41d0b7e40352fc85be1cd65eb03d40ef8427a0ca4596b1ead9a00e9fc").unwrap();
 		let key3 = H256::from_str("04c00000000b7e40352fc85be1cd65eb03d40ef8427a0ca4596b1ead9a00e9fc").unwrap();
@@ -750,64 +691,65 @@ mod tests {
 		let key5 = H256::from_str("04c02222220b7e40352fc85be1cd65eb03d40ef8427a0ca4596b1ead9a00e9fc").unwrap();
 
 		let mut batch = db.transaction();
-		batch.put(None, key1.as_bytes(), b"cat");
-		batch.put(None, key2.as_bytes(), b"dog");
-		batch.put(None, key3.as_bytes(), b"caterpillar");
-		batch.put(None, key4.as_bytes(), b"beef");
-		batch.put(None, key5.as_bytes(), b"fish");
+		batch.put(0, key1.as_bytes(), b"cat");
+		batch.put(0, key2.as_bytes(), b"dog");
+		batch.put(0, key3.as_bytes(), b"caterpillar");
+		batch.put(0, key4.as_bytes(), b"beef");
+		batch.put(0, key5.as_bytes(), b"fish");
 		db.write(batch).unwrap();
 
-		assert_eq!(&*db.get(None, key1.as_bytes()).unwrap().unwrap(), b"cat");
+		assert_eq!(&*db.get(0, key1.as_bytes()).unwrap().unwrap(), b"cat");
 
-		let contents: Vec<_> = db.iter(None).into_iter().collect();
+		let contents: Vec<_> = db.iter(0).into_iter().collect();
 		assert_eq!(contents.len(), 5);
 		assert_eq!(&*contents[0].0, key1.as_bytes());
 		assert_eq!(&*contents[0].1, b"cat");
 		assert_eq!(&*contents[1].0, key2.as_bytes());
 		assert_eq!(&*contents[1].1, b"dog");
 
-		let mut prefix_iter = db.iter_from_prefix(None, &[0x04, 0xc0]);
+		let mut prefix_iter = db.iter_from_prefix(0, &[0x04, 0xc0]);
 		assert_eq!(*prefix_iter.next().unwrap().1, b"caterpillar"[..]);
 		assert_eq!(*prefix_iter.next().unwrap().1, b"beef"[..]);
 		assert_eq!(*prefix_iter.next().unwrap().1, b"fish"[..]);
 
 		let mut batch = db.transaction();
-		batch.delete(None, key1.as_bytes());
+		batch.delete(0, key1.as_bytes());
 		db.write(batch).unwrap();
 
-		assert!(db.get(None, key1.as_bytes()).unwrap().is_none());
+		assert!(db.get(0, key1.as_bytes()).unwrap().is_none());
 
 		let mut batch = db.transaction();
-		batch.put(None, key1.as_bytes(), b"cat");
+		batch.put(0, key1.as_bytes(), b"cat");
 		db.write(batch).unwrap();
 
 		let mut transaction = db.transaction();
-		transaction.put(None, key3.as_bytes(), b"elephant");
-		transaction.delete(None, key1.as_bytes());
+		transaction.put(0, key3.as_bytes(), b"elephant");
+		transaction.delete(0, key1.as_bytes());
 		db.write(transaction).unwrap();
-		assert!(db.get(None, key1.as_bytes()).unwrap().is_none());
-		assert_eq!(&*db.get(None, key3.as_bytes()).unwrap().unwrap(), b"elephant");
+		assert!(db.get(0, key1.as_bytes()).unwrap().is_none());
+		assert_eq!(&*db.get(0, key3.as_bytes()).unwrap().unwrap(), b"elephant");
 
-		assert_eq!(&*db.get_by_prefix(None, key3.as_bytes()).unwrap(), b"elephant");
-		assert_eq!(&*db.get_by_prefix(None, key2.as_bytes()).unwrap(), b"dog");
+		assert_eq!(&*db.get_by_prefix(0, key3.as_bytes()).unwrap(), b"elephant");
+		assert_eq!(&*db.get_by_prefix(0, key2.as_bytes()).unwrap(), b"dog");
 
 		let mut transaction = db.transaction();
-		transaction.put(None, key1.as_bytes(), b"horse");
-		transaction.delete(None, key3.as_bytes());
+		transaction.put(0, key1.as_bytes(), b"horse");
+		transaction.delete(0, key3.as_bytes());
 		db.write_buffered(transaction);
-		assert!(db.get(None, key3.as_bytes()).unwrap().is_none());
-		assert_eq!(&*db.get(None, key1.as_bytes()).unwrap().unwrap(), b"horse");
+		assert!(db.get(0, key3.as_bytes()).unwrap().is_none());
+		assert_eq!(&*db.get(0, key1.as_bytes()).unwrap().unwrap(), b"horse");
 
 		db.flush().unwrap();
-		assert!(db.get(None, key3.as_bytes()).unwrap().is_none());
-		assert_eq!(&*db.get(None, key1.as_bytes()).unwrap().unwrap(), b"horse");
+		assert!(db.get(0, key3.as_bytes()).unwrap().is_none());
+		assert_eq!(&*db.get(0, key1.as_bytes()).unwrap().unwrap(), b"horse");
 	}
 
 	#[test]
 	fn kvdb() {
 		let tempdir = TempDir::new("").unwrap();
-		let _ = Database::open_default(tempdir.path().to_str().unwrap()).unwrap();
-		test_db(&DatabaseConfig::default());
+		let config = DatabaseConfig::default();
+		let _ = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
+		test_db(&config);
 	}
 
 	#[test]
@@ -828,17 +770,17 @@ mod tests {
 
 	#[test]
 	fn add_columns() {
-		let config = DatabaseConfig::default();
-		let config_5 = DatabaseConfig::with_columns(Some(5));
+		let config_1 = DatabaseConfig::default();
+		let config_5 = DatabaseConfig::with_columns(5);
 
 		let tempdir = TempDir::new("").unwrap();
 
-		// open empty, add 5.
+		// open 1, add 4.
 		{
-			let db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
-			assert_eq!(db.num_columns(), 0);
+			let db = Database::open(&config_1, tempdir.path().to_str().unwrap()).unwrap();
+			assert_eq!(db.num_columns(), 1);
 
-			for i in 1..=5 {
+			for i in 2..=5 {
 				db.add_column().unwrap();
 				assert_eq!(db.num_columns(), i);
 			}
@@ -853,33 +795,33 @@ mod tests {
 
 	#[test]
 	fn remove_columns() {
-		let config = DatabaseConfig::default();
-		let config_5 = DatabaseConfig::with_columns(Some(5));
+		let config_1 = DatabaseConfig::default();
+		let config_5 = DatabaseConfig::with_columns(5);
 
 		let tempdir = TempDir::new("drop_columns").unwrap();
 
-		// open 5, remove all.
+		// open 5, remove 4.
 		{
 			let db = Database::open(&config_5, tempdir.path().to_str().unwrap()).expect("open with 5 columns");
 			assert_eq!(db.num_columns(), 5);
 
-			for i in (0..5).rev() {
+			for i in (1..5).rev() {
 				db.remove_last_column().unwrap();
 				assert_eq!(db.num_columns(), i);
 			}
 		}
 
-		// reopen as 0.
+		// reopen as 1.
 		{
-			let db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
-			assert_eq!(db.num_columns(), 0);
+			let db = Database::open(&config_1, tempdir.path().to_str().unwrap()).unwrap();
+			assert_eq!(db.num_columns(), 1);
 		}
 	}
 
 	#[test]
 	fn test_iter_by_prefix() {
 		let tempdir = TempDir::new("").unwrap();
-		let config = DatabaseConfig::default();
+		let config = DatabaseConfig::with_columns(1);
 		let db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
 
 		let key1 = b"0";
@@ -888,14 +830,14 @@ mod tests {
 		let key4 = b"abcd";
 
 		let mut batch = db.transaction();
-		batch.put(None, key1, key1);
-		batch.put(None, key2, key2);
-		batch.put(None, key3, key3);
-		batch.put(None, key4, key4);
+		batch.put(0, key1, key1);
+		batch.put(0, key2, key2);
+		batch.put(0, key3, key3);
+		batch.put(0, key4, key4);
 		db.write(batch).unwrap();
 
 		// empty prefix
-		let contents: Vec<_> = db.iter_from_prefix(None, b"").into_iter().collect();
+		let contents: Vec<_> = db.iter_from_prefix(0, b"").into_iter().collect();
 		assert_eq!(contents.len(), 4);
 		assert_eq!(&*contents[0].0, key1);
 		assert_eq!(&*contents[1].0, key2);
@@ -903,24 +845,24 @@ mod tests {
 		assert_eq!(&*contents[3].0, key4);
 
 		// prefix a
-		let contents: Vec<_> = db.iter_from_prefix(None, b"a").into_iter().collect();
+		let contents: Vec<_> = db.iter_from_prefix(0, b"a").into_iter().collect();
 		assert_eq!(contents.len(), 3);
 		assert_eq!(&*contents[0].0, key2);
 		assert_eq!(&*contents[1].0, key3);
 		assert_eq!(&*contents[2].0, key4);
 
 		// prefix abc
-		let contents: Vec<_> = db.iter_from_prefix(None, b"abc").into_iter().collect();
+		let contents: Vec<_> = db.iter_from_prefix(0, b"abc").into_iter().collect();
 		assert_eq!(contents.len(), 2);
 		assert_eq!(&*contents[0].0, key3);
 		assert_eq!(&*contents[1].0, key4);
 
 		// prefix abcde
-		let contents: Vec<_> = db.iter_from_prefix(None, b"abcde").into_iter().collect();
+		let contents: Vec<_> = db.iter_from_prefix(0, b"abcde").into_iter().collect();
 		assert_eq!(contents.len(), 0);
 
 		// prefix 0
-		let contents: Vec<_> = db.iter_from_prefix(None, b"0").into_iter().collect();
+		let contents: Vec<_> = db.iter_from_prefix(0, b"0").into_iter().collect();
 		assert_eq!(contents.len(), 1);
 		assert_eq!(&*contents[0].0, key1);
 	}
@@ -928,25 +870,25 @@ mod tests {
 	#[test]
 	fn write_clears_buffered_ops() {
 		let tempdir = TempDir::new("").unwrap();
-		let config = DatabaseConfig::default();
+		let config = DatabaseConfig::with_columns(1);
 		let db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
 
 		let mut batch = db.transaction();
-		batch.put(None, b"foo", b"bar");
+		batch.put(0, b"foo", b"bar");
 		db.write_buffered(batch);
 
 		let mut batch = db.transaction();
-		batch.put(None, b"foo", b"baz");
+		batch.put(0, b"foo", b"baz");
 		db.write(batch).unwrap();
 
-		assert_eq!(db.get(None, b"foo").unwrap().unwrap().as_ref(), b"baz");
+		assert_eq!(db.get(0, b"foo").unwrap().unwrap().as_ref(), b"baz");
 	}
 
 	#[test]
 	fn default_memory_budget() {
 		let c = DatabaseConfig::default();
-		assert_eq!(c.columns, None);
-		assert_eq!(c.memory_budget(), DB_DEFAULT_MEMORY_BUDGET_MB * MB, "total memory budget is default");
+		assert_eq!(c.columns.get(), 1);
+		assert_eq!(c.memory_budget(), DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB * MB, "total memory budget is default");
 		assert_eq!(
 			c.memory_budget_for_col(0),
 			DB_DEFAULT_COLUMN_MEMORY_BUDGET_MB * MB,
@@ -961,19 +903,19 @@ mod tests {
 
 	#[test]
 	fn memory_budget() {
-		let mut c = DatabaseConfig::with_columns(Some(3));
-		c.memory_budget = [(0, 10), (1, 15), (2, 20)].iter().cloned().map(|(c, b)| (Some(c), b)).collect();
+		let mut c = DatabaseConfig::with_columns(3);
+		c.memory_budget = [(0, 10), (1, 15), (2, 20)].iter().cloned().collect();
 		assert_eq!(c.memory_budget(), 45 * MB, "total budget is the sum of the column budget");
 	}
 
 	#[test]
 	fn rocksdb_settings() {
 		const NUM_COLS: usize = 2;
-		let mut cfg = DatabaseConfig::with_columns(Some(NUM_COLS as u32));
+		let mut cfg = DatabaseConfig::with_columns(NUM_COLS as u32);
 		cfg.max_open_files = 123; // is capped by the OS fd limit (typically 1024)
 		cfg.compaction.block_size = 323232;
 		cfg.compaction.initial_file_size = 102030;
-		cfg.memory_budget = [(0, 30), (1, 300)].iter().cloned().map(|(c, b)| (Some(c), b)).collect();
+		cfg.memory_budget = [(0, 30), (1, 300)].iter().cloned().collect();
 
 		let db_path = TempDir::new("config_test").expect("the OS can create tmp dirs");
 		let _db = Database::open(&cfg, db_path.path().to_str().unwrap()).expect("can open a db");

--- a/kvdb-web/CHANGELOG.md
+++ b/kvdb-web/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Changed
+- Default column support removed from the API
+  - Column argument type changed from `Option<u32>` to `u32`
+  - Migration `None` -> `0`, `Some(0)` -> `1`, `Some(1)` -> `2`, etc.
 
 ## [0.1.1] - 2019-10-24
 ### Dependencies

--- a/kvdb-web/src/indexed_db.rs
+++ b/kvdb-web/src/indexed_db.rs
@@ -28,7 +28,7 @@ use kvdb::{DBOp, DBTransaction};
 use log::{debug, warn};
 use std::ops::Deref;
 
-use crate::{error::Error, Column};
+use crate::error::Error;
 
 pub struct IndexedDB {
 	pub version: u32,
@@ -85,13 +85,9 @@ fn store_name(num: u32) -> String {
 	format!("col{}", num)
 }
 
-fn column_to_number(column: Column) -> u32 {
-	column.map(|c| c + 1).unwrap_or_default()
-}
-
 // Returns js objects representing store names for each column
 fn store_names_js(columns: u32) -> Array {
-	let column_names = (0..=columns).map(store_name);
+	let column_names = (0..columns).map(store_name);
 
 	let js_array = Array::new();
 	for name in column_names {
@@ -136,7 +132,7 @@ pub fn idb_commit_transaction(idb: &IdbDatabase, txn: &DBTransaction, columns: u
 		.expect("The provided mode and store names are valid; qed");
 
 	// Open object stores (columns)
-	let object_stores = (0..=columns)
+	let object_stores = (0..columns)
 		.map(|n| {
 			idb_txn
 				.object_store(store_name(n).as_str())
@@ -147,8 +143,7 @@ pub fn idb_commit_transaction(idb: &IdbDatabase, txn: &DBTransaction, columns: u
 	for op in &txn.ops {
 		match op {
 			DBOp::Insert { col, key, value } => {
-				let column = column_to_number(*col) as usize;
-
+				let column = *col as usize;
 				// Convert rust bytes to js arrays
 				let key_js = Uint8Array::from(key.as_ref());
 				let val_js = Uint8Array::from(value.as_ref());
@@ -160,8 +155,7 @@ pub fn idb_commit_transaction(idb: &IdbDatabase, txn: &DBTransaction, columns: u
 				}
 			}
 			DBOp::Delete { col, key } => {
-				let column = column_to_number(*col) as usize;
-
+				let column = *col as usize;
 				// Convert rust bytes to js arrays
 				let key_js = Uint8Array::from(key.as_ref());
 

--- a/kvdb-web/tests/indexed_db.rs
+++ b/kvdb-web/tests/indexed_db.rs
@@ -36,10 +36,10 @@ async fn reopen_the_database_with_more_columns() {
 
 	// Write a value into the database
 	let mut batch = db.transaction();
-	batch.put(None, b"hello", b"world");
+	batch.put(0, b"hello", b"world");
 	db.write_buffered(batch);
 
-	assert_eq!(db.get(None, b"hello").unwrap().unwrap().as_ref(), b"world");
+	assert_eq!(db.get(0, b"hello").unwrap().unwrap().as_ref(), b"world");
 
 	// Check the database version
 	assert_eq!(db.version(), 1);
@@ -51,8 +51,8 @@ async fn reopen_the_database_with_more_columns() {
 	let db = open_db(3).await;
 
 	// The value should still be present
-	assert_eq!(db.get(None, b"hello").unwrap().unwrap().as_ref(), b"world");
-	assert!(db.get(None, b"trash").unwrap().is_none());
+	assert_eq!(db.get(0, b"hello").unwrap().unwrap().as_ref(), b"world");
+	assert!(db.get(0, b"trash").unwrap().is_none());
 
 	// The version should be bumped
 	assert_eq!(db.version(), 2);

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Changed
+- Default column support removed from the API
+  - Column argument type changed from `Option<u32>` to `u32`
+  - Migration `None` -> `0`, `Some(0)` -> `1`, `Some(1)` -> `2`, etc.
 
 ## [0.1.1] - 2019-10-24
 ### Dependencies

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -38,8 +38,8 @@ pub struct DBTransaction {
 /// Database operation.
 #[derive(Clone, PartialEq)]
 pub enum DBOp {
-	Insert { col: Option<u32>, key: ElasticArray32<u8>, value: DBValue },
-	Delete { col: Option<u32>, key: ElasticArray32<u8> },
+	Insert { col: u32, key: ElasticArray32<u8>, value: DBValue },
+	Delete { col: u32, key: ElasticArray32<u8> },
 }
 
 impl DBOp {
@@ -52,7 +52,7 @@ impl DBOp {
 	}
 
 	/// Returns the column associated with this operation.
-	pub fn col(&self) -> Option<u32> {
+	pub fn col(&self) -> u32 {
 		match *self {
 			DBOp::Insert { col, .. } => col,
 			DBOp::Delete { col, .. } => col,
@@ -72,24 +72,24 @@ impl DBTransaction {
 	}
 
 	/// Insert a key-value pair in the transaction. Any existing value will be overwritten upon write.
-	pub fn put(&mut self, col: Option<u32>, key: &[u8], value: &[u8]) {
+	pub fn put(&mut self, col: u32, key: &[u8], value: &[u8]) {
 		let mut ekey = ElasticArray32::new();
 		ekey.append_slice(key);
-		self.ops.push(DBOp::Insert { col: col, key: ekey, value: DBValue::from_slice(value) });
+		self.ops.push(DBOp::Insert { col, key: ekey, value: DBValue::from_slice(value) });
 	}
 
 	/// Insert a key-value pair in the transaction. Any existing value will be overwritten upon write.
-	pub fn put_vec(&mut self, col: Option<u32>, key: &[u8], value: Bytes) {
+	pub fn put_vec(&mut self, col: u32, key: &[u8], value: Bytes) {
 		let mut ekey = ElasticArray32::new();
 		ekey.append_slice(key);
-		self.ops.push(DBOp::Insert { col: col, key: ekey, value: DBValue::from_vec(value) });
+		self.ops.push(DBOp::Insert { col, key: ekey, value: DBValue::from_vec(value) });
 	}
 
 	/// Delete value by key.
-	pub fn delete(&mut self, col: Option<u32>, key: &[u8]) {
+	pub fn delete(&mut self, col: u32, key: &[u8]) {
 		let mut ekey = ElasticArray32::new();
 		ekey.append_slice(key);
-		self.ops.push(DBOp::Delete { col: col, key: ekey });
+		self.ops.push(DBOp::Delete { col, key: ekey });
 	}
 }
 
@@ -118,10 +118,10 @@ pub trait KeyValueDB: Sync + Send {
 	}
 
 	/// Get a value by key.
-	fn get(&self, col: Option<u32>, key: &[u8]) -> io::Result<Option<DBValue>>;
+	fn get(&self, col: u32, key: &[u8]) -> io::Result<Option<DBValue>>;
 
 	/// Get a value by partial key. Only works for flushed data.
-	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>>;
+	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>>;
 
 	/// Write a transaction of changes to the buffer.
 	fn write_buffered(&self, transaction: DBTransaction);
@@ -136,12 +136,12 @@ pub trait KeyValueDB: Sync + Send {
 	fn flush(&self) -> io::Result<()>;
 
 	/// Iterate over flushed data for a given column.
-	fn iter<'a>(&'a self, col: Option<u32>) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
+	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
 
 	/// Iterate over flushed data for a given column, starting from a given prefix.
 	fn iter_from_prefix<'a>(
 		&'a self,
-		col: Option<u32>,
+		col: u32,
 		prefix: &'a [u8],
 	) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
 


### PR DESCRIPTION
## Changes

* `kvdb`
  * Require column index - `Option<u32>` -> `u32`
* `kvdb-rocksdb`
  * Require column index - `Option<u32>` -> `u32`
  * Remove overlay column logic (`Some(0)` -> `1`)
  * Require at least one column via `NonZeroU32`
  * `DatabaseConfig::default()` defaults to 1 column
  * `DatabaseConfig::with_columns()` requires `columns > 0` otherwise panics
* `kvdb-memorydb`
  * Fixed a bug/synchronized behaviour of `iter_from_prefix` with the `kvdb-rocksdb`
    * `-memorydb` was using `skip_while` and `-rocksdb` `filter`
    * Different results were yielded for the same data
  * Require column index - `Option<u32>` -> `u32`
  * Added some basic tests to catch mistakes like mentioned `iter_from_prefix`
* `kvdb-web`
  * Require column index - `Option<u32>` -> `u32`

## Breaking

This is a breaking change from the API point of view (modified signatures), but also column indexes in downstream crates should be updated:

* `None` -> `0`
* `Some(0)` -> `1`
* `Some(1)` -> `2`
* etc.

Fixes #272