### PR TITLE
Compile triehash for no_std

### DIFF
--- a/triehash/CHANGELOG.md
+++ b/triehash/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-
+- Added no-std support (https://github.com/paritytech/parity-common/pull/280)
 ## [0.8.1] - 2019-10-24
 - Migrated to 2018 edition (https://github.com/paritytech/parity-common/pull/214)
 ### Dependencies

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -8,8 +8,8 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-hash-db = { version = "0.15.2", default_features = false }
-rlp = { version = "0.4", path = "../rlp", default_features = false }
+hash-db = { version = "0.15.2", default-features = false }
+rlp = { version = "0.4", path = "../rlp", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -20,7 +20,6 @@ trie-standardmap = "0.15.2"
 hex-literal = "0.2.1"
 
 [features]
-ethereum = ["rlp/ethereum"]
 std = [
 	"hash-db/std",
 	"rlp/std",

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triehash"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -8,8 +8,8 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-hash-db = "0.15.2"
-rlp = { version = "0.4", path = "../rlp" }
+hash-db = { version = "0.15.2", default_features = false }
+rlp = { version = "0.4", path = "../rlp", default_features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"
@@ -18,6 +18,13 @@ ethereum-types = { version = "0.8.0", path = "../ethereum-types" }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 trie-standardmap = "0.15.2"
 hex-literal = "0.2.1"
+
+[features]
+ethereum = ["rlp/ethereum"]
+std = [
+	"hash-db/std",
+	"rlp/std",
+]
 
 [[bench]]
 name = "triehash"

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -20,6 +20,7 @@ trie-standardmap = "0.15.2"
 hex-literal = "0.2.1"
 
 [features]
+default = ["std"]
 std = [
 	"hash-db/std",
 	"rlp/std",

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -30,14 +30,13 @@ mod rstd {
 
 #[cfg(not(feature = "std"))]
 mod rstd {
-	pub use alloc::vec::Vec;
 	pub use alloc::collections::BTreeMap;
+	pub use alloc::vec::Vec;
 }
 
 use core::cmp;
 use core::iter::once;
 use rstd::*;
-
 
 use hash_db::Hasher;
 use rlp::RlpStream;

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -18,9 +18,26 @@
 //!
 //! This module should be used to generate trie root hash.
 
-use std::cmp;
-use std::collections::BTreeMap;
-use std::iter::once;
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+mod rstd {
+	pub use std::collections::BTreeMap;
+}
+
+#[cfg(not(feature = "std"))]
+mod rstd {
+	pub use alloc::vec::Vec;
+	pub use alloc::collections::BTreeMap;
+}
+
+use core::cmp;
+use core::iter::once;
+use rstd::*;
+
 
 use hash_db::Hasher;
 use rlp::RlpStream;


### PR DESCRIPTION
The idea is to use this crate to compute `trie_root(transactions_receipts)` in [EthPoA -> Substrate bridge runtime module](https://github.com/svyatonik/substrate/blob/bridge_runtime/frame/bridge-eth-poa/src/validators.rs#L99). The native version of `keccak_256()` is already available in Substrate => I hope most of time `trie_root()` will spend in native code.

Another option is to provide native ext `fn keccak_256_trie_root()`, but since trie codec in Ethereum != trie codec in Substrate, it'll be called `fn ethereum_trie_root()` && I do not think that it is a good idea to have fn like that in Substrate. I'm open to suggestions, though.