### PR TITLE
Update elastic-array to 0.11.0

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-- use `get_pinned` API to save one allocation for each call to `get()` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
-- rename `drop_column` to `remove_last_column` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
-- rename `get_cf` to `cf` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Use `get_pinned` API to save one allocation for each call to `get()` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Rename `drop_column` to `remove_last_column` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Rename `get_cf` to `cf` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
+- Updated dependencies (See [PR #281](https://github.com/paritytech/parity-common/pull/281) for details)
 
 ## [0.2.0] - 2019-11-28
 - Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb) (see [PR #257](https://github.com/paritytech/parity-common/pull/257) for details)

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.2.1"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by rocksDB"

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by rocksDB"
@@ -12,7 +12,7 @@ name = "bench_read_perf"
 harness = false
 
 [dependencies]
-elastic-array = "0.10.2"
+elastic-array = "0.11.0"
 fs-swap = "0.2.4"
 interleaved-ordered = "0.1.1"
 kvdb = { path = "../kvdb", version = "0.1" }

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.1.2] - 2019-12-11
+### Dependencies
+- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+### Changed
+- Migrated to 2018 edition (https://github.com/paritytech/parity-common/pull/205)
 ## [0.1.1] - 2019-10-24
 ### Dependencies
 - Updated dependencies (https://github.com/paritytech/parity-common/pull/239)

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -5,12 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Updated dependencies (See [PR #281](https://github.com/paritytech/parity-common/pull/281) for details)
 
-## [0.1.2] - 2019-12-11
-### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
-### Changed
-- Migrated to 2018 edition (https://github.com/paritytech/parity-common/pull/205)
 ## [0.1.1] - 2019-10-24
 ### Dependencies
 - Updated dependencies (https://github.com/paritytech/parity-common/pull/239)

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb"
-version = "0.1.2"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Generic key-value trait"

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Generic key-value trait"
@@ -8,5 +8,5 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-elastic-array = "0.10.2"
+elastic-array = "0.11.0"
 bytes = { package = "parity-bytes", version = "0.1", path = "../parity-bytes" }

--- a/parity-util-mem/CHANGELOG.md
+++ b/parity-util-mem/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Updated dependencies (See [PR #281](https://github.com/paritytech/parity-common/pull/281) for details)
 
 ## [0.2.1] - 2019-10-24
 ### Dependencies

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-util-mem"
-version = "0.2.2"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Collection of memory related utilities"

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-util-mem"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Collection of memory related utilities"
@@ -20,7 +20,7 @@ wee_alloc = { version = "0.4.5", optional = true }
 mimallocator = { version = "0.1.3", features = ["secure"], optional = true }
 mimalloc-sys = { version = "0.1.6", optional = true }
 
-elastic-array = { version = "0.10.2", optional = true }
+elastic-array = { version = "0.11.0", optional = true }
 ethereum-types = { version = "0.8.0", optional = true, path = "../ethereum-types" }
 parking_lot = { version = "0.9.0", optional = true }
 


### PR DESCRIPTION
Updates crates to use the latest `elastic-array` which fixes use of `mem::uninitialized`.