### PR TITLE
[kvdb-rocksdb] adds `num_keys()`

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog].
   - `DatabaseConfig::default()` defaults to 1 column
   - `Database::with_columns` still accepts `u32`, but panics if `0` is provided 
   - `Database::open` panics if configuration with 0 columns is provided
-
+- Add `num_keys(col)` to get an estimate of the number of keys in a column (See [PR #285](https://github.com/paritytech/parity-common/pull/285)). 
 ## [0.2.0] - 2019-11-28
 - Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb) (see [PR #257](https://github.com/paritytech/parity-common/pull/257) for details)
 - Revamped configuration handling, allowing per-column memory budgeting (see [PR #256](https://github.com/paritytech/parity-common/pull/256) for details)

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -82,15 +82,14 @@ impl<'a, I: Iterator, T> Iterator for ReadGuardedIterator<'a, I, T> {
 pub trait IterationHandler {
 	type Iterator: Iterator<Item = KeyValuePair>;
 
-	/// Create an `Iterator` over the default DB column or over a `ColumnFamily` if a column number
-	/// is passed.
-	/// In addition to a read lock and a column index, it takes a ref to the same `ReadOptions` we
-	/// pass to the `get` method.
+	/// Create an `Iterator` over a `ColumnFamily` corresponding to the passed index. Takes a
+	/// reference to a `ReadOptions` to allow configuration of the new iterator (see
+	/// https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L1169).
 	fn iter(&self, col: u32, read_opts: &ReadOptions) -> Self::Iterator;
-	/// Create an `Iterator` over the default DB column or over a `ColumnFamily` if a column number
-	/// is passed. The iterator starts from the first key having the provided `prefix`.
-	/// In addition to a read lock and a column index, it takes a ref to the same `ReadOptions` we
-	/// pass to the `get` method.
+	/// Create an `Iterator` over a `ColumnFamily` corresponding to the passed index. Takes a
+	/// reference to a `ReadOptions` to allow configuration of the new iterator (see
+	/// https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L1169).
+	/// The iterator starts from the first key having the provided `prefix`.
 	fn iter_from_prefix(&self, col: u32, prefix: &[u8], read_opts: &ReadOptions) -> Self::Iterator;
 }
 

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -608,7 +608,7 @@ impl Database {
 					Err(err_string) => Err(other_io_err(err_string))
 				}
 			}
-			None => Err(other_io_err("Failed to take read lock on the db"))
+			None => Ok(0)
 		}
 	}
 

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -586,7 +586,7 @@ impl Database {
 		Ok(())
 	}
 
-	/// The number of non-default column families.
+	/// The number of column families in the db.
 	pub fn num_columns(&self) -> u32 {
 		self.db
 			.read()
@@ -594,6 +594,22 @@ impl Database {
 			.and_then(|db| if db.column_names.is_empty() { None } else { Some(db.column_names.len()) })
 			.map(|n| n as u32)
 			.unwrap_or(0)
+	}
+
+	/// The number of keys in a column (estimated).
+	/// Does not take into account the data in the overlay.
+	pub fn num_keys(&self, col: u32) -> io::Result<u64> {
+		const ESTIMATE_NUM_KEYS: &str = "rocksdb.estimate-num-keys";
+		match *self.db.read() {
+			Some(ref cfs) => {
+				let cf = cfs.cf(col as usize);
+				match cfs.db.property_int_value_cf(cf, ESTIMATE_NUM_KEYS) {
+					Ok(estimate) => { Ok(estimate.unwrap_or_default())},
+					Err(err_string) => Err(other_io_err(err_string))
+				}
+			}
+			None => Err(other_io_err("Failed to take read lock on the db"))
+		}
 	}
 
 	/// Remove the last column family in the database. The deletion is definitive.
@@ -827,6 +843,20 @@ mod tests {
 			let db = Database::open(&config_1, tempdir.path().to_str().unwrap()).unwrap();
 			assert_eq!(db.num_columns(), 1);
 		}
+	}
+
+	#[test]
+	fn test_num_keys() {
+		let tempdir = TempDir::new("").unwrap();
+		let config = DatabaseConfig::with_columns(1);
+		let db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();
+
+		assert_eq!(db.num_keys(0).unwrap(), 0, "database is empty after creation");
+		let key1 = b"beef";
+		let mut batch = db.transaction();
+		batch.put(0, key1, key1);
+		db.write(batch).unwrap();
+		assert_eq!(db.num_keys(0).unwrap(), 1, "adding a key increases the count");
 	}
 
 	#[test]

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -598,7 +598,7 @@ impl Database {
 	}
 
 	/// The number of keys in a column (estimated).
-	/// Does not take into account unflushed the data.
+	/// Does not take into account the unflushed data.
 	pub fn num_keys(&self, col: u32) -> io::Result<u64> {
 		const ESTIMATE_NUM_KEYS: &str = "rocksdb.estimate-num-keys";
 		match *self.db.read() {

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -604,11 +604,11 @@ impl Database {
 			Some(ref cfs) => {
 				let cf = cfs.cf(col as usize);
 				match cfs.db.property_int_value_cf(cf, ESTIMATE_NUM_KEYS) {
-					Ok(estimate) => { Ok(estimate.unwrap_or_default())},
-					Err(err_string) => Err(other_io_err(err_string))
+					Ok(estimate) => Ok(estimate.unwrap_or_default()),
+					Err(err_string) => Err(other_io_err(err_string)),
 				}
 			}
-			None => Ok(0)
+			None => Ok(0),
 		}
 	}
 


### PR DESCRIPTION
Uses `"rocksdb.estimate-num-keys"` to get an estimate of the number of keys in a database (see https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ#failure-recovery).