### PR TITLE
Move and extend impls for locking primitives

### DIFF
--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -43,6 +43,6 @@ jemalloc-global = ["jemallocator"]
 # use mimalloc as global allocator
 mimalloc-global = ["mimallocator", "mimalloc-sys"]
 # implement additional types
-ethereum-impls = ["ethereum-types", "parking_lot", "smallvec"]
+ethereum-impls = ["ethereum-types", "smallvec"]
 # Full estimate: no call to allocator
 estimate-heapsize = []

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -33,7 +33,7 @@ optional = true
 
 [features]
 default = ["std", "ethereum-impls"]
-std = []
+std = ["parking_lot"]
 # use dlmalloc as global allocator
 dlmalloc-global = ["dlmalloc", "estimate-heapsize"]
 # use wee_alloc as global allocator

--- a/parity-util-mem/src/impls.rs
+++ b/parity-util-mem/src/impls.rs
@@ -17,12 +17,10 @@
 //! Implementation of `MallocSize` for common types :
 //! - ethereum types uint and fixed hash.
 //! - smallvec arrays of sizes 32, 36
-//! - parking_lot mutex structures
 
 use super::{MallocSizeOf, MallocSizeOfOps};
 
 use ethereum_types::{Bloom, H128, H160, H256, H264, H32, H512, H520, H64, U128, U256, U512, U64};
-use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
 
 #[cfg(not(feature = "std"))]
@@ -53,18 +51,6 @@ macro_rules! impl_smallvec {
 
 impl_smallvec!(32); // kvdb uses this
 impl_smallvec!(36); // trie-db uses this
-
-impl<T: MallocSizeOf> MallocSizeOf for Mutex<T> {
-	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-		(*self.lock()).size_of(ops)
-	}
-}
-
-impl<T: MallocSizeOf> MallocSizeOf for RwLock<T> {
-	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-		self.read().size_of(ops)
-	}
-}
 
 #[cfg(test)]
 mod tests {

--- a/parity-util-mem/src/malloc_size.rs
+++ b/parity-util-mem/src/malloc_size.rs
@@ -539,10 +539,33 @@ impl<T: MallocSizeOf> MallocConditionalSizeOf for Arc<T> {
 /// If a mutex is stored inside of an Arc value as a member of a data type that is being measured,
 /// the Arc will not be automatically measured so there is no risk of overcounting the mutex's
 /// contents.
+///
+/// The same reasoning applies to RwLock.
 #[cfg(feature = "std")]
 impl<T: MallocSizeOf> MallocSizeOf for std::sync::Mutex<T> {
 	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-		(*self.lock().unwrap()).size_of(ops)
+		self.lock().unwrap().size_of(ops)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<T: MallocSizeOf> MallocSizeOf for parking_lot::Mutex<T> {
+	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+		self.lock().size_of(ops)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<T: MallocSizeOf> MallocSizeOf for std::sync::RwLock<T> {
+	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+		self.read().unwrap().size_of(ops)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<T: MallocSizeOf> MallocSizeOf for parking_lot::RwLock<T> {
+	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+		self.read().size_of(ops)
 	}
 }
 

--- a/parity-util-mem/src/malloc_size.rs
+++ b/parity-util-mem/src/malloc_size.rs
@@ -43,7 +43,8 @@
 //!   measured as well as the thing it points to. E.g.
 //!   `<Box<_> as MallocSizeOf>::size_of(field, ops)`.
 
-// This file is patched at commit 5bdea7dc1c80790a852a3fb03edfb2b8fbd403dc DO NOT EDIT.
+//! This is an extended (for own internal needs) version of the Servo internal malloc_size crate.
+//! We should occasionally track the upstream changes/fixes and reintroduce them here, be they applicable.
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;


### PR DESCRIPTION
- they probably should be under "std" feature flag, not "ethereum"
- `std::sync::RwLock` impl was missing 