### PR TITLE
I/O statistic for key-value databases

### DIFF
--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -1069,6 +1069,19 @@ mod tests {
 		// Since we choosed not to keep previous statistic period,
 		// this is expected to be totally empty.
 		assert_eq!(new_io_stats.transactions, 0);
+
+		let mut batch = db.transaction();
+		batch.delete(0, key1);
+		batch.delete(1, key1);
+		batch.delete(2, key1);
+
+		// transaction is not commited yet
+		assert_eq!(db.io_stats(false).writes, 0);
+
+		db.write(batch).unwrap();
+		// now it is, and delete is counted as write
+		assert_eq!(db.io_stats(false).writes, 3);
+
 	}
 
 	#[test]

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -444,7 +444,7 @@ impl Database {
 								KeyState::Delete => {
 									bytes += key.len();
 									batch.delete_cf(cf, key).map_err(other_io_err)?
-								},
+								}
 								KeyState::Insert(ref value) => {
 									bytes += key.len() + value.len();
 									batch.put_cf(cf, key, value).map_err(other_io_err)?

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -567,12 +567,10 @@ impl Database {
 
 					let cf = cfs.cf(op.col() as usize);
 
-					self.stats.add_write_bytes(
-						match op {
-							DBOp::Insert { col: _, ref key, ref value } => key.len() + value.len(),
-							DBOp::Delete { col: _, ref key } => key.len(),
-						} as u64
-					);
+					self.stats.add_write_bytes(match op {
+						DBOp::Insert { col: _, ref key, ref value } => key.len() + value.len(),
+						DBOp::Delete { col: _, ref key } => key.len(),
+					} as u64);
 
 					match op {
 						DBOp::Insert { col: _, key, value } => batch.put_cf(cf, &key, &value).map_err(other_io_err)?,
@@ -1049,7 +1047,9 @@ mod tests {
 		batch.put(1, key1, key1);
 		batch.put(2, key1, key1);
 
-		for _ in 0..10 { db.get(0, key1).unwrap(); }
+		for _ in 0..10 {
+			db.get(0, key1).unwrap();
+		}
 
 		db.write(batch).unwrap();
 

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -573,7 +573,7 @@ impl Database {
 						DBOp::Insert { col: _, key, value } => {
 							stats_total_bytes += key.len() + value.len();
 							batch.put_cf(cf, &key, &value).map_err(other_io_err)?
-						},
+						}
 						DBOp::Delete { col: _, key } => {
 							// We count deletes as writes.
 							stats_total_bytes += key.len();

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -260,6 +260,8 @@ impl DBAndColumns {
 struct DbStats {
 	reads: AtomicU64,
 	writes: AtomicU64,
+	write_bytes: AtomicU64,
+	read_bytes: AtomicU64,
 	transactions: AtomicU64,
 	started: Mutex<std::time::Instant>,
 }
@@ -267,21 +269,38 @@ struct DbStats {
 struct TakenDbStats {
 	reads: u64,
 	writes: u64,
+	write_bytes: u64,
+	read_bytes: u64,
 	transactions: u64,
 	start: std::time::Instant,
 }
 
 impl DbStats {
 	fn new() -> Self {
-		Self { reads: 0.into(), writes: 0.into(), transactions: 0.into(), started: std::time::Instant::now().into(), }
+		Self {
+			reads: 0.into(),
+			read_bytes: 0.into(),
+			writes: 0.into(),
+			write_bytes: 0.into(),
+			transactions: 0.into(),
+			started: std::time::Instant::now().into(),
+		}
 	}
 
 	fn add_reads(&self, val: u64) {
 		self.reads.fetch_add(val, AtomicOrdering::Relaxed);
 	}
 
+	fn add_read_bytes(&self, val: u64) {
+		self.read_bytes.fetch_add(val, AtomicOrdering::Relaxed);
+	}
+
 	fn add_writes(&self, val: u64) {
 		self.writes.fetch_add(val, AtomicOrdering::Relaxed);
+	}
+
+	fn add_write_bytes(&self, val: u64) {
+		self.write_bytes.fetch_add(val, AtomicOrdering::Relaxed);
 	}
 
 	fn add_transactions(&self, val: u64) {
@@ -293,6 +312,8 @@ impl DbStats {
 		let stats = TakenDbStats {
 			reads: self.reads.swap(0, AtomicOrdering::Relaxed),
 			writes: self.writes.swap(0, AtomicOrdering::Relaxed),
+			write_bytes: self.write_bytes.swap(0, AtomicOrdering::Relaxed),
+			read_bytes: self.read_bytes.swap(0, AtomicOrdering::Relaxed),
 			transactions: self.transactions.swap(0, AtomicOrdering::Relaxed),
 			start: *started_lock,
 		};
@@ -300,6 +321,19 @@ impl DbStats {
 		*started_lock = std::time::Instant::now();
 
 		stats
+	}
+
+	fn peek(&self) -> TakenDbStats {
+		let started_lock = self.started.lock();
+
+		TakenDbStats {
+			reads: self.reads.load(AtomicOrdering::Relaxed),
+			writes: self.writes.load(AtomicOrdering::Relaxed),
+			write_bytes: self.write_bytes.load(AtomicOrdering::Relaxed),
+			read_bytes: self.read_bytes.load(AtomicOrdering::Relaxed),
+			transactions: self.transactions.load(AtomicOrdering::Relaxed),
+			start: *started_lock,
+		}
 	}
 }
 
@@ -533,6 +567,13 @@ impl Database {
 
 					let cf = cfs.cf(op.col() as usize);
 
+					self.stats.add_write_bytes(
+						match op {
+							DBOp::Insert { col: _, ref key, ref value } => key.len() + value.len(),
+							DBOp::Delete { col: _, ref key } => key.len(),
+						} as u64
+					);
+
 					match op {
 						DBOp::Insert { col: _, key, value } => batch.put_cf(cf, &key, &value).map_err(other_io_err)?,
 						DBOp::Delete { col: _, key } => batch.delete_cf(cf, &key).map_err(other_io_err)?,
@@ -559,11 +600,21 @@ impl Database {
 						match flushing.get(key) {
 							Some(&KeyState::Insert(ref value)) => Ok(Some(value.clone())),
 							Some(&KeyState::Delete) => Ok(None),
-							None => cfs
-								.db
-								.get_pinned_cf_opt(cfs.cf(col as usize), key, &self.read_opts)
-								.map(|r| r.map(|v| v.to_vec()))
-								.map_err(other_io_err),
+							None => {
+								let aquired_val = cfs
+									.db
+									.get_pinned_cf_opt(cfs.cf(col as usize), key, &self.read_opts)
+									.map(|r| r.map(|v| v.to_vec()))
+									.map_err(other_io_err);
+
+								match aquired_val {
+									Ok(Some(ref v)) => self.stats.add_read_bytes((key.len() + v.len()) as u64),
+									Ok(None) => self.stats.add_read_bytes(key.len() as u64),
+									_ => {}
+								};
+
+								aquired_val
+							}
 						}
 					}
 				}
@@ -759,8 +810,8 @@ impl KeyValueDB for Database {
 		Database::restore(self, new_db)
 	}
 
-	fn io_stats(&self) -> kvdb::IoStats {
-		let taken_stats = self.stats.take();
+	fn io_stats(&self, keep: bool) -> kvdb::IoStats {
+		let taken_stats = if keep { self.stats.peek() } else { self.stats.take() };
 
 		let mut stats = kvdb::IoStats::empty();
 
@@ -769,6 +820,8 @@ impl KeyValueDB for Database {
 		stats.transactions = taken_stats.transactions;
 		stats.start = taken_stats.start;
 		stats.span = taken_stats.start.elapsed();
+		stats.write_bytes = taken_stats.write_bytes;
+		stats.read_bytes = taken_stats.read_bytes;
 
 		stats
 	}
@@ -1000,12 +1053,16 @@ mod tests {
 
 		db.write(batch).unwrap();
 
-		let io_stats = db.io_stats();
+		let io_stats = db.io_stats(false);
 		assert_eq!(io_stats.transactions, 1);
 		assert_eq!(io_stats.writes, 3);
+		assert_eq!(io_stats.write_bytes, 18);
 		assert_eq!(io_stats.reads, 10);
+		assert_eq!(io_stats.read_bytes, 30);
 
-		let new_io_stats = db.io_stats();
+		let new_io_stats = db.io_stats(true);
+		// Since we choosed not to keep previous statistic period,
+		// this is expected to be totally empty.
 		assert_eq!(new_io_stats.transactions, 0);
 	}
 

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -591,9 +591,9 @@ impl Database {
 
 	/// Get value by key.
 	pub fn get(&self, col: u32, key: &[u8]) -> io::Result<Option<DBValue>> {
-		self.stats.tally_reads(1);
 		match *self.db.read() {
 			Some(ref cfs) => {
+				self.stats.tally_reads(1);
 				let overlay = &self.overlay.read()[col as usize];
 				match overlay.get(key) {
 					Some(&KeyState::Insert(ref value)) => Ok(Some(value.clone())),

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -1081,7 +1081,6 @@ mod tests {
 		db.write(batch).unwrap();
 		// now it is, and delete is counted as write
 		assert_eq!(db.io_stats(false).writes, 3);
-
 	}
 
 	#[test]

--- a/kvdb-rocksdb/src/stats.rs
+++ b/kvdb-rocksdb/src/stats.rs
@@ -1,0 +1,144 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use parking_lot::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::time::Instant;
+
+pub struct RawDbStats {
+	pub reads: u64,
+	pub writes: u64,
+	pub bytes_written: u64,
+	pub bytes_read: u64,
+	pub transactions: u64,
+}
+
+impl RawDbStats {
+	fn combine(&self, other: &RawDbStats) -> Self {
+		RawDbStats {
+			reads: self.reads + other.reads,
+			writes: self.writes + other.writes,
+			bytes_written: self.bytes_written + other.bytes_written,
+			bytes_read: self.bytes_read + other.bytes_written,
+			transactions: self.transactions + other.transactions,
+		}
+	}
+}
+
+struct OverallDbStats {
+	stats: RawDbStats,
+	last_taken: Instant,
+	started: Instant,
+}
+
+impl OverallDbStats {
+	fn new() -> Self {
+		OverallDbStats {
+			stats: RawDbStats { reads: 0, writes: 0, bytes_written: 0, bytes_read: 0, transactions: 0 },
+			last_taken: Instant::now(),
+			started: Instant::now(),
+		}
+	}
+}
+
+pub struct RunningDbStats {
+	reads: AtomicU64,
+	writes: AtomicU64,
+	bytes_written: AtomicU64,
+	bytes_read: AtomicU64,
+	transactions: AtomicU64,
+	overall: RwLock<OverallDbStats>,
+}
+
+pub struct TakenDbStats {
+	pub raw: RawDbStats,
+	pub started: std::time::Instant,
+}
+
+impl RunningDbStats {
+	pub fn new() -> Self {
+		Self {
+			reads: 0.into(),
+			bytes_read: 0.into(),
+			writes: 0.into(),
+			bytes_written: 0.into(),
+			transactions: 0.into(),
+			overall: OverallDbStats::new().into(),
+		}
+	}
+
+	pub fn tally_reads(&self, val: u64) {
+		self.reads.fetch_add(val, AtomicOrdering::Relaxed);
+	}
+
+	pub fn tally_bytes_read(&self, val: u64) {
+		self.bytes_read.fetch_add(val, AtomicOrdering::Relaxed);
+	}
+
+	pub fn tally_writes(&self, val: u64) {
+		self.writes.fetch_add(val, AtomicOrdering::Relaxed);
+	}
+
+	pub fn tally_bytes_written(&self, val: u64) {
+		self.bytes_written.fetch_add(val, AtomicOrdering::Relaxed);
+	}
+
+	pub fn tally_transactions(&self, val: u64) {
+		self.transactions.fetch_add(val, AtomicOrdering::Relaxed);
+	}
+
+	fn take_current(&self) -> RawDbStats {
+		RawDbStats {
+			reads: self.reads.swap(0, AtomicOrdering::Relaxed),
+			writes: self.writes.swap(0, AtomicOrdering::Relaxed),
+			bytes_written: self.bytes_written.swap(0, AtomicOrdering::Relaxed),
+			bytes_read: self.bytes_read.swap(0, AtomicOrdering::Relaxed),
+			transactions: self.transactions.swap(0, AtomicOrdering::Relaxed),
+		}
+	}
+
+	fn peek_current(&self) -> RawDbStats {
+		RawDbStats {
+			reads: self.reads.load(AtomicOrdering::Relaxed),
+			writes: self.writes.load(AtomicOrdering::Relaxed),
+			bytes_written: self.bytes_written.load(AtomicOrdering::Relaxed),
+			bytes_read: self.bytes_read.load(AtomicOrdering::Relaxed),
+			transactions: self.transactions.load(AtomicOrdering::Relaxed),
+		}
+	}
+
+	pub fn since_previous(&self) -> TakenDbStats {
+		let mut overall_lock = self.overall.write();
+
+		let current = self.take_current();
+
+		overall_lock.stats = overall_lock.stats.combine(&current);
+
+		let stats = TakenDbStats { raw: current, started: overall_lock.last_taken };
+
+		overall_lock.last_taken = std::time::Instant::now();
+
+		stats
+	}
+
+	pub fn overall(&self) -> TakenDbStats {
+		let overall_lock = self.overall.read();
+
+		let current = self.peek_current();
+
+		TakenDbStats { raw: overall_lock.stats.combine(&current), started: overall_lock.started }
+	}
+}

--- a/kvdb-rocksdb/src/stats.rs
+++ b/kvdb-rocksdb/src/stats.rs
@@ -65,7 +65,7 @@ pub struct RunningDbStats {
 
 pub struct TakenDbStats {
 	pub raw: RawDbStats,
-	pub started: std::time::Instant,
+	pub started: Instant,
 }
 
 impl RunningDbStats {

--- a/kvdb-rocksdb/src/stats.rs
+++ b/kvdb-rocksdb/src/stats.rs
@@ -129,7 +129,7 @@ impl RunningDbStats {
 
 		let stats = TakenDbStats { raw: current, started: overall_lock.last_taken };
 
-		overall_lock.last_taken = std::time::Instant::now();
+		overall_lock.last_taken = Instant::now();
 
 		stats
 	}

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -26,6 +26,12 @@ pub struct IoStats {
 	pub cache_reads: u64,
 	/// Number of write operations.
 	pub writes: u64,
+	/// Number of bytes read
+	pub read_bytes: u64,
+	/// Number of bytes read from cache
+	pub cache_read_bytes: u64,
+	/// Number of bytes write
+	pub write_bytes: u64,
 	/// Start of the statistic period.
 	pub start: std::time::Instant,
 	/// Total duration of the statistic period.
@@ -40,6 +46,9 @@ impl IoStats {
 			reads: 0,
 			cache_reads: 0,
 			writes: 0,
+			read_bytes: 0,
+			cache_read_bytes: 0,
+			write_bytes: 0,
 			start: std::time::Instant::now(),
 			span: std::time::Duration::default(),
 		}

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -56,41 +56,53 @@ impl IoStats {
 
 	/// Average batch (transaction) size (writes per transaction)
 	pub fn avg_batch_size(&self) -> f64 {
-		if self.writes == 0 { return 0.0 }
+		if self.writes == 0 {
+			return 0.0;
+		}
 		self.transactions as f64 / self.writes as f64
 	}
 
 	/// Read operations per second.
 	pub fn reads_per_sec(&self) -> f64 {
-		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+		if self.span.as_secs_f64() == 0.0 {
+			return 0.0;
+		}
 
 		self.reads as f64 / self.span.as_secs_f64()
 	}
 
 	/// Write operations per second.
 	pub fn writes_per_sec(&self) -> f64 {
-		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+		if self.span.as_secs_f64() == 0.0 {
+			return 0.0;
+		}
 
 		self.writes as f64 / self.span.as_secs_f64()
 	}
 
 	/// Total number of operations per second.
 	pub fn ops_per_sec(&self) -> f64 {
-		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+		if self.span.as_secs_f64() == 0.0 {
+			return 0.0;
+		}
 
 		(self.writes as f64 + self.reads as f64) / self.span.as_secs_f64()
 	}
 
 	/// Transactions per second.
 	pub fn transactions_per_sec(&self) -> f64 {
-		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+		if self.span.as_secs_f64() == 0.0 {
+			return 0.0;
+		}
 
 		(self.transactions as f64) / self.span.as_secs_f64()
 	}
 
 	pub fn cache_hit_ration(&self) -> f64 {
-		if self.reads == 0 { return 0.0 }
+		if self.reads == 0 {
+			return 0.0;
+		}
 
 		self.cache_reads as f64 / self.reads as f64
 	}
- }
+}

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -16,6 +16,14 @@
 
 //! Generic statistics for key-value databases
 
+/// Statistic kind to query.
+pub enum Kind {
+	/// Overall statistics since start.
+	Overall,
+	/// Statistics since previous query.
+	SincePrevious,
+}
+
 /// Statistic for the `span` period
 pub struct IoStats {
 	/// Number of transaction.

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -25,6 +25,7 @@ pub enum Kind {
 }
 
 /// Statistic for the `span` period
+#[derive(Debug, Clone)]
 pub struct IoStats {
 	/// Number of transaction.
 	pub transactions: u64,
@@ -79,6 +80,14 @@ impl IoStats {
 		self.reads as f64 / self.span.as_secs_f64()
 	}
 
+	pub fn byte_reads_per_sec(&self) -> f64 {
+		if self.span.as_secs_f64() == 0.0 {
+			return 0.0
+		}
+
+		self.bytes_read as f64 / self.span.as_secs_f64()
+	}
+
 	/// Write operations per second.
 	pub fn writes_per_sec(&self) -> f64 {
 		if self.span.as_secs_f64() == 0.0 {
@@ -87,6 +96,15 @@ impl IoStats {
 
 		self.writes as f64 / self.span.as_secs_f64()
 	}
+
+	pub fn byte_writes_per_sec(&self) -> f64 {
+		if self.span.as_secs_f64() == 0.0 {
+			return 0.0
+		}
+
+		self.bytes_written as f64 / self.span.as_secs_f64()
+	}
+
 
 	/// Total number of operations per second.
 	pub fn ops_per_sec(&self) -> f64 {

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -104,7 +104,6 @@ impl IoStats {
 		}
 
 		self.bytes_written as f64 / self.transactions as f64
-
 	}
 
 	pub fn cache_hit_ratio(&self) -> f64 {

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -27,13 +27,13 @@ pub struct IoStats {
 	/// Number of write operations.
 	pub writes: u64,
 	/// Number of bytes read
-	pub read_bytes: u64,
+	pub bytes_read: u64,
 	/// Number of bytes read from cache
 	pub cache_read_bytes: u64,
 	/// Number of bytes write
-	pub write_bytes: u64,
+	pub bytes_written: u64,
 	/// Start of the statistic period.
-	pub start: std::time::Instant,
+	pub started: std::time::Instant,
 	/// Total duration of the statistic period.
 	pub span: std::time::Duration,
 }
@@ -46,10 +46,10 @@ impl IoStats {
 			reads: 0,
 			cache_reads: 0,
 			writes: 0,
-			read_bytes: 0,
+			bytes_read: 0,
 			cache_read_bytes: 0,
-			write_bytes: 0,
-			start: std::time::Instant::now(),
+			bytes_written: 0,
+			started: std::time::Instant::now(),
 			span: std::time::Duration::default(),
 		}
 	}
@@ -98,7 +98,16 @@ impl IoStats {
 		(self.transactions as f64) / self.span.as_secs_f64()
 	}
 
-	pub fn cache_hit_ration(&self) -> f64 {
+	pub fn avg_transaction_size(&self) -> f64 {
+		if self.transactions == 0 {
+			return 0.0;
+		}
+
+		self.bytes_written as f64 / self.transactions as f64
+
+	}
+
+	pub fn cache_hit_ratio(&self) -> f64 {
 		if self.reads == 0 {
 			return 0.0;
 		}

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -1,0 +1,87 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Generic statistics for key-value databases
+
+/// Statistic for the `span` period
+pub struct IoStats {
+	/// Number of transaction.
+	pub transactions: u64,
+	/// Number of read operations.
+	pub reads: u64,
+	/// Number of reads resulted in a read from cache.
+	pub cache_reads: u64,
+	/// Number of write operations.
+	pub writes: u64,
+	/// Start of the statistic period.
+	pub start: std::time::Instant,
+	/// Total duration of the statistic period.
+	pub span: std::time::Duration,
+}
+
+impl IoStats {
+	/// Empty statistic report.
+	pub fn empty() -> Self {
+		Self {
+			transactions: 0,
+			reads: 0,
+			cache_reads: 0,
+			writes: 0,
+			start: std::time::Instant::now(),
+			span: std::time::Duration::default(),
+		}
+	}
+
+	/// Average batch (transaction) size (writes per transaction)
+	pub fn avg_batch_size(&self) -> f64 {
+		if self.writes == 0 { return 0.0 }
+		self.transactions as f64 / self.writes as f64
+	}
+
+	/// Read operations per second.
+	pub fn reads_per_sec(&self) -> f64 {
+		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+
+		self.reads as f64 / self.span.as_secs_f64()
+	}
+
+	/// Write operations per second.
+	pub fn writes_per_sec(&self) -> f64 {
+		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+
+		self.writes as f64 / self.span.as_secs_f64()
+	}
+
+	/// Total number of operations per second.
+	pub fn ops_per_sec(&self) -> f64 {
+		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+
+		(self.writes as f64 + self.reads as f64) / self.span.as_secs_f64()
+	}
+
+	/// Transactions per second.
+	pub fn transactions_per_sec(&self) -> f64 {
+		if self.span.as_secs_f64() == 0.0 { return 0.0 }
+
+		(self.transactions as f64) / self.span.as_secs_f64()
+	}
+
+	pub fn cache_hit_ration(&self) -> f64 {
+		if self.reads == 0 { return 0.0 }
+
+		self.cache_reads as f64 / self.reads as f64
+	}
+ }

--- a/kvdb/src/io_stats.rs
+++ b/kvdb/src/io_stats.rs
@@ -82,7 +82,7 @@ impl IoStats {
 
 	pub fn byte_reads_per_sec(&self) -> f64 {
 		if self.span.as_secs_f64() == 0.0 {
-			return 0.0
+			return 0.0;
 		}
 
 		self.bytes_read as f64 / self.span.as_secs_f64()
@@ -99,12 +99,11 @@ impl IoStats {
 
 	pub fn byte_writes_per_sec(&self) -> f64 {
 		if self.span.as_secs_f64() == 0.0 {
-			return 0.0
+			return 0.0;
 		}
 
 		self.bytes_written as f64 / self.span.as_secs_f64()
 	}
-
 
 	/// Total number of operations per second.
 	pub fn ops_per_sec(&self) -> f64 {

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -154,9 +154,6 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	/// default, empty statistics is returned. Also, not all kvdb implementation
 	/// can return every statistic or configured to do so (some statistics gathering
 	/// may impede the performance and might be off by default).
-	///
-	/// `keep` argument indicates if database should erase current accumulated statistics
-	/// and start new gathering period at current time.
 	fn io_stats(&self, _kind: IoStatsKind) -> IoStats {
 		IoStats::empty()
 	}

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -154,7 +154,10 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	/// default, empty statistics is returned. Also, not all kvdb implementation
 	/// can return every statistic or configured to do so (some statistics gathering
 	/// may impede the performance and might be off by default).
-	fn io_stats(&self) -> IoStats {
+	///
+	/// `keep` argument indicates if database should erase current accumulated statistics
+	/// and start new gathering period at current time.
+	fn io_stats(&self, _keep: bool) -> IoStats {
 		IoStats::empty()
 	}
 }

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -32,7 +32,7 @@ pub type DBValue = Vec<u8>;
 /// Database keys.
 pub type DBKey = SmallVec<[u8; 32]>;
 
-pub use io_stats::IoStats;
+pub use io_stats::{IoStats, Kind as IoStatsKind};
 
 /// Write transaction. Batches a sequence of put/delete operations for efficiency.
 #[derive(Default, Clone, PartialEq)]
@@ -157,7 +157,7 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	///
 	/// `keep` argument indicates if database should erase current accumulated statistics
 	/// and start new gathering period at current time.
-	fn io_stats(&self, _keep: bool) -> IoStats {
+	fn io_stats(&self, _kind: IoStatsKind) -> IoStats {
 		IoStats::empty()
 	}
 }


### PR DESCRIPTION
This provides basic i/o stats api for key-value databases.

User can:
1. Query overall stats. They persist during all database instance lifetime.
2. Query intermediate stats since the last querying. 