### PR TITLE
Add a top level function to parity-util-mem

### DIFF
--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -73,10 +73,17 @@ pub use malloc_size::{MallocSizeOf, MallocSizeOfOps};
 
 pub use parity_util_mem_derive::*;
 
+/// Heap size of structure.
+///
+/// Structure can be anything that implements MallocSizeOf.
+pub fn malloc_size<T: MallocSizeOf + ?Sized>(t: &T) -> usize {
+	MallocSizeOf::size_of(t, &mut allocators::new_malloc_size_ops())
+}
+
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-	use super::MallocSizeOfExt;
+	use super::{MallocSizeOfExt, MallocSizeOf, malloc_size};
 	use std::sync::Arc;
 
 	#[test]
@@ -84,5 +91,13 @@ mod test {
 		let val = Arc::new("test".to_string());
 		let s = val.malloc_size_of();
 		assert!(s > 0);
+	}
+
+	#[test]
+	fn test_dyn() {
+		trait Augmented : MallocSizeOf { }
+		impl Augmented for Vec<u8> { }
+		let val: Arc<dyn Augmented> = Arc::new(vec![0u8; 1024]);
+		assert!(malloc_size(&*val) > 1000);
 	}
 }

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -96,7 +96,7 @@ mod test {
 	#[test]
 	fn test_dyn() {
 		trait Augmented : MallocSizeOf { }
-		impl Augmented for Vec<u8> { }
+		impl Augmented for Vec<u8> {}
 		let val: Arc<dyn Augmented> = Arc::new(vec![0u8; 1024]);
 		assert!(malloc_size(&*val) > 1000);
 	}

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -95,7 +95,7 @@ mod test {
 
 	#[test]
 	fn test_dyn() {
-		trait Augmented : MallocSizeOf { }
+		trait Augmented: MallocSizeOf {}
 		impl Augmented for Vec<u8> {}
 		let val: Arc<dyn Augmented> = Arc::new(vec![0u8; 1024]);
 		assert!(malloc_size(&*val) > 1000);

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -83,7 +83,7 @@ pub fn malloc_size<T: MallocSizeOf + ?Sized>(t: &T) -> usize {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
-	use super::{MallocSizeOfExt, MallocSizeOf, malloc_size};
+	use super::{malloc_size, MallocSizeOf, MallocSizeOfExt};
 	use std::sync::Arc;
 
 	#[test]


### PR DESCRIPTION
- to avoid importing traits in the namespace
- also this seems the only way to query heap size of `Arc<dyn SomeTrait: MallocSizeOf>`, if user needs to 