### PR TITLE
uint: make zero const fn

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -642,8 +642,8 @@ macro_rules! construct_uint {
 
 			/// Zero (additive identity) of this type.
 			#[inline]
-			pub fn zero() -> Self {
-				From::from(0u64)
+			pub const fn zero() -> Self {
+				Self([0; $n_words])
 			}
 
 			/// One (multiplicative identity) of this type.


### PR DESCRIPTION
Since `zero` is special in that it is the usual initialization default, I figured I could unblock `const fn new` for structs that use uint types.