### PR TITLE
prepare rlp-derive release

### DIFF
--- a/ethbloom/CHANGELOG.md
+++ b/ethbloom/CHANGELOG.md
@@ -10,4 +10,4 @@ The format is based on [Keep a Changelog].
 
 ## [0.8.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/ethereum-types/CHANGELOG.md
+++ b/ethereum-types/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog].
 - License changed from MIT to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ### Added
-- uint error type is re-exported (https://github.com/paritytech/parity-common/pull/244)
+- Uint error type is re-exported. [#244](https://github.com/paritytech/parity-common/pull/244)

--- a/fixed-hash/CHANGELOG.md
+++ b/fixed-hash/CHANGELOG.md
@@ -10,8 +10,8 @@ The format is based on [Keep a Changelog].
 
 ## [0.5.2] - 2019-12-19
 ### Fixed
-- re-export `alloc` for both std and no-std to fix compilation (See [PR #268](https://github.com/paritytech/parity-common/pull/268))
+- Re-export `alloc` for both std and no-std to fix compilation. [#268](https://github.com/paritytech/parity-common/pull/268)
 
 ## [0.5.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/keccak-hash/CHANGELOG.md
+++ b/keccak-hash/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -9,4 +9,4 @@ The format is based on [Keep a Changelog].
 
 ## [0.4.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/kvdb-memorydb/CHANGELOG.md
+++ b/kvdb-memorydb/CHANGELOG.md
@@ -19,7 +19,6 @@ The format is based on [Keep a Changelog].
 ## [0.2.0] - 2019-12-19
 ### Fixed
 - `iter_from_prefix` behaviour synced with the `kvdb-rocksdb`
-
 ### Changed
 - Default column support removed from the API
   - Column argument type changed from `Option<u32>` to `u32`

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog].
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ## [0.5.0] - 2019-02-05
-- Bump parking_lot to 0.10. [#332](https://github.com/paritytech/parity-common/pull/332
+- Bump parking_lot to 0.10. [#332](https://github.com/paritytech/parity-common/pull/332)
 
 ## [0.4.2] - 2019-02-04
 ### Fixes
@@ -22,10 +22,10 @@ The format is based on [Keep a Changelog].
 - Support querying memory footprint via `MallocSizeOf` trait. [#292](https://github.com/paritytech/parity-common/pull/292)
 
 ## [0.3.0] - 2019-12-19
-- Use `get_pinned` API to save one allocation for each call to `get()` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
-- Rename `drop_column` to `remove_last_column` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
-- Rename `get_cf` to `cf` (See [PR #274](https://github.com/paritytech/parity-common/pull/274) for details)
-- Default column support removed from the API (See [PR #278](https://github.com/paritytech/parity-common/pull/278) for details)
+- Use `get_pinned` API to save one allocation for each call to `get()`. [#274](https://github.com/paritytech/parity-common/pull/274)
+- Rename `drop_column` to `remove_last_column`. [#274](https://github.com/paritytech/parity-common/pull/274)
+- Rename `get_cf` to `cf`. [#274](https://github.com/paritytech/parity-common/pull/274)
+- Default column support removed from the API. [#278](https://github.com/paritytech/parity-common/pull/278)
   - Column argument type changed from `Option<u32>` to `u32`
   - Migration
     - Column index `None` -> unsupported, `Some(0)` -> `0`, `Some(1)` -> `1`, etc.
@@ -33,16 +33,16 @@ The format is based on [Keep a Changelog].
   - `DatabaseConfig::default()` defaults to 1 column
   - `Database::with_columns` still accepts `u32`, but panics if `0` is provided
   - `Database::open` panics if configuration with 0 columns is provided
-- Add `num_keys(col)` to get an estimate of the number of keys in a column (See [PR #285](https://github.com/paritytech/parity-common/pull/285)).
-- Remove `ElasticArray` and use the new `DBValue` (alias for `Vec<u8>`) and `DBKey` types from `kvdb`. (See [PR #282](https://github.com/paritytech/parity-common/pull/282/files))
+- Add `num_keys(col)` to get an estimate of the number of keys in a column. [#285](https://github.com/paritytech/parity-common/pull/285)
+- Remove `ElasticArray` and use the new `DBValue` (alias for `Vec<u8>`) and `DBKey` types from `kvdb`. [#282](https://github.com/paritytech/parity-common/pull/282)
 
 ## [0.2.0] - 2019-11-28
-- Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb) (see [PR #257](https://github.com/paritytech/parity-common/pull/257) for details)
-- Revamped configuration handling, allowing per-column memory budgeting (see [PR #256](https://github.com/paritytech/parity-common/pull/256) for details)
+- Switched away from using [parity-rocksdb](https://crates.io/crates/parity-rocksdb) in favour of upstream [rust-rocksdb](https://crates.io/crates/rocksdb). [#257](https://github.com/paritytech/parity-common/pull/257)
+- Revamped configuration handling, allowing per-column memory budgeting. [#256](https://github.com/paritytech/parity-common/pull/256)
 ### Dependencies
 - rust-rocksdb v0.13
 
 ## [0.1.6] - 2019-10-24
-- Updated to 2018 edition idioms (https://github.com/paritytech/parity-common/pull/237)
+- Updated to 2018 edition idioms. [#237](https://github.com/paritytech/parity-common/pull/237)
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/kvdb-shared-tests/CHANGELOG.md
+++ b/kvdb-shared-tests/CHANGELOG.md
@@ -5,6 +5,3 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-
-## [0.1.0] - 2020-02-13
-- Extracted from parity-ethereum repo. [#343](https://github.com/paritytech/parity-common/pull/343)

--- a/kvdb-web/CHANGELOG.md
+++ b/kvdb-web/CHANGELOG.md
@@ -24,4 +24,4 @@ The format is based on [Keep a Changelog].
 
 ## [0.1.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -22,10 +22,10 @@ The format is based on [Keep a Changelog].
 - Default column support removed from the API
   - Column argument type changed from `Option<u32>` to `u32`
   - Migration `None` -> unsupported, `Some(0)` -> `0`, `Some(1)` -> `1`, etc.
-- Remove `ElasticArray` and change `DBValue` to be a type alias for `Vec<u8>` and add a `DBKey` backed by a `SmallVec`.  (See [PR #282](https://github.com/paritytech/parity-common/pull/282/files))
+- Remove `ElasticArray` and change `DBValue` to be a type alias for `Vec<u8>` and add a `DBKey` backed by a `SmallVec`.  [#282](https://github.com/paritytech/parity-common/pull/282)
 
 ## [0.1.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)
 ### Changed
-- Migrated to 2018 edition (https://github.com/paritytech/parity-common/pull/205)
+- Migrated to 2018 edition. [#205](https://github.com/paritytech/parity-common/pull/205)

--- a/parity-bytes/CHANGELOG.md
+++ b/parity-bytes/CHANGELOG.md
@@ -9,6 +9,6 @@ The format is based on [Keep a Changelog].
 
 ## [0.1.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
-### Added 
-- Added no-std support (https://github.com/paritytech/parity-common/pull/154)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)
+### Added
+- Added no-std support. [#154](https://github.com/paritytech/parity-common/pull/154)

--- a/parity-crypto/CHANGELOG.md
+++ b/parity-crypto/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,10 +8,10 @@ The format is based on [Keep a Changelog].
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ## [0.5.0] - 2020-02-08
-- Remove `inv()` from `SecretKey` (breaking) (https://github.com/paritytech/parity-common/pull/258)
-- `Generate::generate()` does not return error (https://github.com/paritytech/parity-common/pull/258)
-- `Secp256k1` is no longer exported (https://github.com/paritytech/parity-common/pull/258)
-- Remove `public_is_valid()` as it is now impossible to create invalid public keys (https://github.com/paritytech/parity-common/pull/258)
-- 0-valued `Secp::Message`s are disallowed (signatures on them are forgeable for all keys) (https://github.com/paritytech/parity-common/pull/258) 
-- Switch to upstream `rust-secp256k1` at v0.17.2 (https://github.com/paritytech/parity-common/pull/258)
-- make `rustc_hex` dependency optional (https://github.com/paritytech/parity-common/pull/337)
+- Remove `inv()` from `SecretKey` (breaking). [#258](https://github.com/paritytech/parity-common/pull/258)
+- `Generate::generate()` does not return error. [#258](https://github.com/paritytech/parity-common/pull/258)
+- `Secp256k1` is no longer exported. [#258](https://github.com/paritytech/parity-common/pull/258)
+- Remove `public_is_valid()` as it is now impossible to create invalid public keys. [#258](https://github.com/paritytech/parity-common/pull/258)
+- 0-valued `Secp::Message`s are disallowed (signatures on them are forgeable for all keys). [#258](https://github.com/paritytech/parity-common/pull/258)
+- Switch to upstream `rust-secp256k1` at v0.17.2. [#258](https://github.com/paritytech/parity-common/pull/258)
+- make `rustc_hex` dependency optional. [#337](https://github.com/paritytech/parity-common/pull/337)

--- a/parity-util-mem/CHANGELOG.md
+++ b/parity-util-mem/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog].
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ## [0.5.1] - 2019-02-05
-- Add different mode for malloc_size_of_is_0 macro dealing with generics #334. [#332](https://github.com/paritytech/parity-common/pull/334)
+- Add different mode for malloc_size_of_is_0 macro dealing with generics. [#334](https://github.com/paritytech/parity-common/pull/334)
 
 ## [0.5.0] - 2019-02-05
 - Bump parking_lot to 0.10. [#332](https://github.com/paritytech/parity-common/pull/332)
@@ -27,8 +27,8 @@ The format is based on [Keep a Changelog].
 - Added default implementation of `MallocSizeOf` for tuples up to 12. [#300](https://github.com/paritytech/parity-common/pull/300)
 
 ## [0.3.0] - 2019-12-19
-- Remove `MallocSizeOf` impls for `ElasticArray` and implement it for `SmallVec` (32 and 36). (See [PR #282](https://github.com/paritytech/parity-common/pull/282/files))
+- Remove `MallocSizeOf` impls for `ElasticArray` and implement it for `SmallVec` (32 and 36). [#282](https://github.com/paritytech/parity-common/pull/282)
 
 ## [0.2.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/parity-util-mem/derive/CHANGELOG.md
+++ b/parity-util-mem/derive/CHANGELOG.md
@@ -5,6 +5,3 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-
-## [0.1.0] - 2020-02-13
-- Extracted from parity-ethereum repo. [#343](https://github.com/paritytech/parity-common/pull/343)

--- a/plain_hasher/CHANGELOG.md
+++ b/plain_hasher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,6 +8,6 @@ The format is based on [Keep a Changelog].
 - License changed from MIT to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ## [0.2.2] - 2019-10-24
-- Migrated to 2018 edition (https://github.com/paritytech/parity-common/pull/213)
+- Migrated to 2018 edition. [#213](https://github.com/paritytech/parity-common/pull/213)
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -12,4 +12,4 @@ The format is based on [Keep a Changelog].
 
 ## [0.6.1] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/primitive-types/impls/serde/CHANGELOG.md
+++ b/primitive-types/impls/serde/CHANGELOG.md
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog].
 
 ## [0.2.3] - 2019-10-29
 ### Fixed
-- Fixed a bug in empty slice serialization (https://github.com/paritytech/parity-common/pull/253)
+- Fixed a bug in empty slice serialization. [#253](https://github.com/paritytech/parity-common/pull/253)

--- a/rlp-derive/Cargo.toml
+++ b/rlp-derive/Cargo.toml
@@ -16,4 +16,4 @@ quote = "1.0.2"
 proc-macro2 = "1.0.8"
 
 [dev-dependencies]
-rlp = "0.4.0"
+rlp = "0.4.4"

--- a/rlp-derive/src/de.rs
+++ b/rlp-derive/src/de.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/rlp-derive/src/en.rs
+++ b/rlp-derive/src/en.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/rlp-derive/src/lib.rs
+++ b/rlp-derive/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/rlp-derive/tests/rlp.rs
+++ b/rlp-derive/tests/rlp.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/rlp/CHANGELOG.md
+++ b/rlp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,12 +8,12 @@ The format is based on [Keep a Changelog].
 
 ## [0.4.4] - 2019-11-20
 ### Added
-- Method `Rlp::at_with_offset` (https://github.com/paritytech/parity-common/pull/269)
+- Method `Rlp::at_with_offset`. [#269](https://github.com/paritytech/parity-common/pull/269)
 
 ## [0.4.3] - 2019-10-24
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)
 ### Fixed
-- Fixed nested unbounded lists (https://github.com/paritytech/parity-common/pull/203)
+- Fixed nested unbounded lists. [#203](https://github.com/paritytech/parity-common/pull/203)
 ### Added
-- Added no-std support (https://github.com/paritytech/parity-common/pull/206)
+- Added no-std support. [#206](https://github.com/paritytech/parity-common/pull/206)

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -6,6 +6,6 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.1.1] - 2019-11-25
+## [0.1.1] - 2020-02-11
 ### Changed
 - Moved to parity common repo, prepared for publishing. [#271](https://github.com/paritytech/parity-common/pull/271)

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog].
 
 ## [0.1.1] - 2019-11-25
 ### Changed
-- Moved to parity common repo, prepared for publishing (https://github.com/paritytech/parity-common/pull/271)
+- Moved to parity common repo, prepared for publishing. [#271](https://github.com/paritytech/parity-common/pull/271)

--- a/trace-time/CHANGELOG.md
+++ b/trace-time/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,6 +8,6 @@ The format is based on [Keep a Changelog].
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ## [0.1.2] - 2019-10-24
-- Migrated to 2018 edition (https://github.com/paritytech/parity-common/pull/232)
+- Migrated to 2018 edition. [#232](https://github.com/paritytech/parity-common/pull/232)
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/transaction-pool/CHANGELOG.md
+++ b/transaction-pool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,6 +8,6 @@ The format is based on [Keep a Changelog].
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ## [2.0.2] - 2019-10-24
-- Updated to 2018 edition idioms (https://github.com/paritytech/parity-common/pull/237) 
+- Updated to 2018 edition idioms. [#237](https://github.com/paritytech/parity-common/pull/237)
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/triehash/CHANGELOG.md
+++ b/triehash/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog].
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 
 ## [0.8.2] - 2019-12-15
-- Added no-std support (https://github.com/paritytech/parity-common/pull/280)
+- Added no-std support. [#280](https://github.com/paritytech/parity-common/pull/280)
 ## [0.8.1] - 2019-10-24
-- Migrated to 2018 edition (https://github.com/paritytech/parity-common/pull/214)
+- Migrated to 2018 edition. [#214](https://github.com/paritytech/parity-common/pull/214)
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog].
 
 ## [0.8.2] - 2019-10-24
 ### Fixed
-- Fixed 2018 edition imports (https://github.com/paritytech/parity-common/pull/237)
-- Removed `uninitialized` usage (https://github.com/paritytech/parity-common/pull/238)
+- Fixed 2018 edition imports. [#237](https://github.com/paritytech/parity-common/pull/237)
+- Removed `uninitialized` usage. [#238](https://github.com/paritytech/parity-common/pull/238)
 ### Dependencies
-- Updated dependencies (https://github.com/paritytech/parity-common/pull/239)
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)
 ### Changed
-- Modified AsRef impl (https://github.com/paritytech/parity-common/pull/196)
+- Modified AsRef impl. [#196](https://github.com/paritytech/parity-common/pull/196)


### PR DESCRIPTION
also unifies the changelog format