### PR TITLE
kvdb-rocksdb: expose RocksDB stats

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
+- Added `get_statistics` method and `enable_statistics` config parameter. [#347](https://github.com/paritytech/parity-common/pull/347)
 
 ## [0.5.0] - 2019-02-05
 - Bump parking_lot to 0.10. [#332](https://github.com/paritytech/parity-common/pull/332)

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -167,7 +167,7 @@ pub struct DatabaseConfig {
 	pub columns: u32,
 	/// Specify the maximum number of info/debug log files to be kept.
 	pub keep_log_file_num: i32,
-	/// Enable RocksDB statistics.
+	/// Enable native RocksDB statistics.
 	/// Disabled by default.
 	///
 	/// It can have a negative performance impact up to 10% according to

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -722,8 +722,12 @@ impl Database {
 	}
 
 	/// Get RocksDB statistics.
-	pub fn get_statistics(&self) -> Option<String> {
-		self.opts.get_statistics()
+	pub fn get_statistics(&self) -> HashMap<String, stats::RocksDbStatsValue> {
+		if let Some(stats) = self.opts.get_statistics() {
+			stats::parse_rocksdb_stats(stats)
+		} else {
+			HashMap::new()
+		}
 	}
 }
 
@@ -1009,9 +1013,7 @@ mod tests {
 			.expect("rocksdb creates a LOG file");
 		let mut settings = String::new();
 		let statistics = db.get_statistics();
-		assert!(statistics.is_some(), "statistics are enabled");
-		let statistics = statistics.unwrap();
-		assert!(statistics.contains("block.cache.hit"));
+		assert!(statistics.contains_key("block.cache.hit"));
 
 		rocksdb_log.read_to_string(&mut settings).unwrap();
 		// Check column count

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -770,9 +770,7 @@ impl KeyValueDB for Database {
 
 	fn io_stats(&self, kind: kvdb::IoStatsKind) -> kvdb::IoStats {
 		let rocksdb_stats = self.get_statistics();
-		let cache_hit_count = rocksdb_stats.get("block.cache.hit")
-			.map(|s| s.count)
-			.unwrap_or(0u64);
+		let cache_hit_count = rocksdb_stats.get("block.cache.hit").map(|s| s.count).unwrap_or(0u64);
 		let overall_stats = self.stats.overall();
 		let old_cache_hit_count = overall_stats.raw.cache_hit_count;
 

--- a/kvdb-rocksdb/src/stats.rs
+++ b/kvdb-rocksdb/src/stats.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::time::Instant;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct RawDbStats {
 	pub reads: u64,
 	pub writes: u64,
@@ -22,7 +22,7 @@ pub struct RawDbStats {
 	pub cache_hit_count: u64,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct RocksDbStatsTimeValue {
 	/// 50% percentile
 	pub p50: f64,
@@ -35,13 +35,13 @@ pub struct RocksDbStatsTimeValue {
 	pub sum: u64,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct RocksDbStatsValue {
 	pub count: u64,
 	pub times: Option<RocksDbStatsTimeValue>,
 }
 
-pub fn parse_rocksdb_stats(stats: String) -> HashMap<String, RocksDbStatsValue> {
+pub fn parse_rocksdb_stats(stats: &str) -> HashMap<String, RocksDbStatsValue> {
 	stats.lines().map(|line| parse_rocksdb_stats_row(line.splitn(2, ' '))).collect()
 }
 

--- a/kvdb-rocksdb/src/stats.rs
+++ b/kvdb-rocksdb/src/stats.rs
@@ -7,10 +7,10 @@
 // except according to those terms.
 
 use parking_lot::RwLock;
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-use std::time::Instant;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::time::Instant;
 
 #[derive(Default)]
 pub struct RawDbStats {
@@ -42,9 +42,7 @@ pub struct RocksDbStatsValue {
 }
 
 pub fn parse_rocksdb_stats(stats: String) -> HashMap<String, RocksDbStatsValue> {
-	stats.lines()
-		.map(|line| parse_rocksdb_stats_row(line.splitn(2, ' ')))
-		.collect()
+	stats.lines().map(|line| parse_rocksdb_stats_row(line.splitn(2, ' '))).collect()
 }
 
 fn parse_rocksdb_stats_row<'a>(mut iter: impl Iterator<Item = &'a str>) -> (String, RocksDbStatsValue) {
@@ -68,11 +66,8 @@ fn parse_rocksdb_stats_row<'a>(mut iter: impl Iterator<Item = &'a str>) -> (Stri
 			p100: f64::from_str(values.get(7).expect(PROOF)).expect(PROOF),
 			sum: u64::from_str(values.get(11).expect(PROOF)).expect(PROOF),
 		};
-		RocksDbStatsValue {
-			count: u64::from_str(values.get(9).expect(PROOF)).expect(PROOF),
-			times: Some(times),
-		}
-	 };
+		RocksDbStatsValue { count: u64::from_str(values.get(9).expect(PROOF)).expect(PROOF), times: Some(times) }
+	};
 	(key, value)
 }
 
@@ -97,11 +92,7 @@ struct OverallDbStats {
 
 impl OverallDbStats {
 	fn new() -> Self {
-		OverallDbStats {
-			stats: RawDbStats::default(),
-			last_taken: Instant::now(),
-			started: Instant::now(),
-		}
+		OverallDbStats { stats: RawDbStats::default(), last_taken: Instant::now(), started: Instant::now() }
 	}
 }
 


### PR DESCRIPTION
For some reason in tests `block.cache.hit/miss` is always 0, not sure why.