### PR TITLE
kvdb: remove parity-bytes dependency

### DIFF
--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
-- Remove dependency on parity-bytes.  [#351](https://github.com/paritytech/parity-common/pull/351)
+- Remove dependency on parity-bytes. [#351](https://github.com/paritytech/parity-common/pull/351)
 
 ## [0.4.0] - 2019-01-06
 - Bump parking_lot to 0.10. [#332](https://github.com/paritytech/parity-common/pull/332)

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
+- Remove dependency on parity-bytes.  [#351](https://github.com/paritytech/parity-common/pull/351)
 
 ## [0.4.0] - 2019-01-06
 - Bump parking_lot to 0.10. [#332](https://github.com/paritytech/parity-common/pull/332)

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -9,5 +9,4 @@ edition = "2018"
 
 [dependencies]
 smallvec = "1.0.0"
-bytes = { package = "parity-bytes", version = "0.1", path = "../parity-bytes" }
 parity-util-mem = { path = "../parity-util-mem", version = "0.5", default-features = false }

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -8,7 +8,6 @@
 
 //! Key-Value store abstraction.
 
-use bytes::Bytes;
 use smallvec::SmallVec;
 use std::io;
 
@@ -73,7 +72,7 @@ impl DBTransaction {
 	}
 
 	/// Insert a key-value pair in the transaction. Any existing value will be overwritten upon write.
-	pub fn put_vec(&mut self, col: u32, key: &[u8], value: Bytes) {
+	pub fn put_vec(&mut self, col: u32, key: &[u8], value: Vec<u8>) {
 		self.ops.push(DBOp::Insert { col, key: DBKey::from_slice(key), value });
 	}
 


### PR DESCRIPTION
`bytes::Bytes` is just an alias to a `Vec`, so that's not even a breaking change.