### PR TITLE
parity-util-mem: update mimalloc feature

### DIFF
--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -13,7 +13,7 @@ dlmalloc = { version = "0.1.3", features = ["global"], optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 lru = { version = "0.4", optional = true }
 hashbrown = { version = "0.6", optional = true }
-mimalloc = { version = "0.1.18", default-features = false, optional = true }
+mimalloc = { version = "0.1.18", optional = true }
 libmimalloc-sys = { version = "0.1.14", optional = true }
 parity-util-mem-derive = { path = "derive", version = "0.1" }
 impl-trait-for-tuples = "0.1.3"

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -13,13 +13,8 @@ dlmalloc = { version = "0.1.3", features = ["global"], optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 lru = { version = "0.4", optional = true }
 hashbrown = { version = "0.6", optional = true }
-# from https://github.com/microsoft/mimalloc:
-# mimalloc can be built in secure mode,
-# adding guard pages, randomized allocation, encrypted free lists, etc.
-# to protect against various heap vulnerabilities.
-# The performance penalty is only around 3% on average over our benchmarks.
-mimallocator = { version = "0.1.3", features = ["secure"], optional = true }
-mimalloc-sys = { version = "0.1.6", optional = true }
+mimalloc = { version = "0.1.18", default-features = false, optional = true }
+libmimalloc-sys = { version = "0.1.14", optional = true }
 parity-util-mem-derive = { path = "derive", version = "0.1" }
 impl-trait-for-tuples = "0.1.3"
 
@@ -45,7 +40,7 @@ weealloc-global = ["wee_alloc", "estimate-heapsize"]
 # use jemalloc as global allocator
 jemalloc-global = ["jemallocator"]
 # use mimalloc as global allocator
-mimalloc-global = ["mimallocator", "mimalloc-sys"]
+mimalloc-global = ["mimalloc", "libmimalloc-sys"]
 # implement additional types
 ethereum-impls = ["ethereum-types", "primitive-types"]
 # Full estimate: no call to allocator

--- a/parity-util-mem/src/allocators.rs
+++ b/parity-util-mem/src/allocators.rs
@@ -93,7 +93,7 @@ mod usable_size {
 			pub unsafe extern "C" fn malloc_usable_size(ptr: *const c_void) -> usize {
 				// mimalloc doesn't actually mutate the value ptr points to,
 				// but requires a mut pointer in the API
-				mimalloc_sys::mi_usable_size(ptr as *mut _)
+				libmimalloc_sys::mi_usable_size(ptr as *mut _)
 			}
 
 		} else if #[cfg(target_os = "linux")] {

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -21,24 +21,24 @@ cfg_if::cfg_if! {
 		not(target_os = "windows"),
 		not(target_arch = "wasm32")
 	))] {
-		#[global_allocator]
 		/// Global allocator
+		#[global_allocator]
 		pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 	} else if #[cfg(feature = "dlmalloc-global")] {
-		#[global_allocator]
 		/// Global allocator
+		#[global_allocator]
 		pub static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
 	} else if #[cfg(feature = "weealloc-global")] {
-		#[global_allocator]
 		/// Global allocator
+		#[global_allocator]
 		pub static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 	} else if #[cfg(all(
 			feature = "mimalloc-global",
 			not(target_arch = "wasm32")
 		))] {
-		#[global_allocator]
 		/// Global allocator
-		pub static ALLOC: mimallocator::Mimalloc = mimallocator::Mimalloc;
+		#[global_allocator]
+		pub static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 	} else {
 		// default allocator used
 	}


### PR DESCRIPTION
This PR makes use of https://github.com/purpleprotocol/mimalloc_rust instead of https://github.com/gnzlbg/mimallocator as the latter seems to be outdated and not properly maintained at the moment.