### PR TITLE
parity-util-mem: use malloc for usable_size on android

### DIFF
--- a/parity-util-mem/src/allocators.rs
+++ b/parity-util-mem/src/allocators.rs
@@ -96,7 +96,7 @@ mod usable_size {
 				mimalloc_sys::mi_usable_size(ptr as *mut _)
 			}
 
-		} else if #[cfg(target_os = "linux")] {
+		} else if #[cfg(any(target_os = "linux", target_os = "android"))] {
 
 			/// Linux call system allocator (currently malloc).
 			extern "C" {


### PR DESCRIPTION
Fixes #354.