### PR TITLE
Fix limit prefix delete case

### DIFF
--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -74,8 +74,11 @@ impl KeyValueDB for InMemory {
 							col.clear();
 						} else {
 							let start_range = Bound::Included(prefix.to_vec());
-							let end_range = Bound::Excluded(kvdb::end_prefix(&prefix[..]));
-							let keys: Vec<_> = col.range((start_range, end_range)).map(|(k, _)| k.clone()).collect();
+							let keys: Vec<_> = if let Some(end_range) = kvdb::end_prefix(&prefix[..]) {
+								col.range((start_range, Bound::Excluded(end_range))).map(|(k, _)| k.clone()).collect()
+							} else {
+								col.range((start_range, Bound::Unbounded)).map(|(k, _)| k.clone()).collect()
+							};
 							for key in keys.into_iter() {
 								col.remove(&key[..]);
 							}

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -107,12 +107,12 @@ where
 		read_lock: RwLockReadGuard<'a, Option<T>>,
 		col: u32,
 		prefix: &[u8],
-		upper_bound: Box<[u8]>,
+		upper_bound: Option<Box<[u8]>>,
 		read_opts: &ReadOptions,
 	) -> Self {
 		Self {
 			inner: Self::new_inner(read_lock, |db| db.iter_with_prefix(col, prefix, read_opts)),
-			upper_bound_prefix: Some(upper_bound),
+			upper_bound_prefix: upper_bound,
 		}
 	}
 

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -454,18 +454,6 @@ impl Database {
 									batch.delete_cf(cf, &key[..]).map_err(other_io_err)?;
 								}
 							}
-							if !prefix.is_empty() {
-								if let Some(end_range) = kvdb::end_prefix(&prefix[..]) {
-									batch.delete_range_cf(cf, &prefix[..], &end_range[..]).map_err(other_io_err)?;
-								} else {
-									iter_prefix_delete(&prefix[..], &mut batch)?;
-								}
-							} else {
-								// Deletes all values in the column.
-								let end_range = [u8::max_value(); 16];
-								batch.delete_range_cf(cf, &prefix[..], &end_range[..]).map_err(other_io_err)?;
-								iter_prefix_delete(&end_range[..], &mut batch)?;
-							}
 						}
 					};
 				}

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -454,7 +454,7 @@ impl Database {
 								}
 							} else {
 								// Deletes all values in the column.
-								let end_range = &[u8::max_value()];
+								let end_range = [u8::max_value(); 16];
 								batch.delete_range_cf(cf, &prefix[..], &end_range[..]).map_err(other_io_err)?;
 								for (key, _) in self.iter_with_prefix(col, &end_range[..]) {
 									batch.delete_cf(cf, &key[..]).map_err(other_io_err)?;

--- a/kvdb-shared-tests/src/lib.rs
+++ b/kvdb-shared-tests/src/lib.rs
@@ -175,7 +175,7 @@ pub fn test_io_stats(db: &dyn KeyValueDB) -> io::Result<()> {
 }
 
 /// The number of columns required to run `test_delete_prefix`.
-pub const DELETE_PREFIX_NUM_COLUMNS: u32 = 5;
+pub const DELETE_PREFIX_NUM_COLUMNS: u32 = 7;
 
 /// A test for `KeyValueDB::delete_prefix`.
 pub fn test_delete_prefix(db: &dyn KeyValueDB) -> io::Result<()> {
@@ -190,6 +190,7 @@ pub fn test_delete_prefix(db: &dyn KeyValueDB) -> io::Result<()> {
 		&[2][..],
 		&[2, 0][..],
 		&[2, 255][..],
+		&[255, 255][..],
 	];
 	let init_db = |ix: u32| -> io::Result<()> {
 		let mut batch = db.transaction();
@@ -199,8 +200,8 @@ pub fn test_delete_prefix(db: &dyn KeyValueDB) -> io::Result<()> {
 		db.write(batch)?;
 		Ok(())
 	};
-	let check_db = |ix: u32, content: [bool; 10]| -> io::Result<()> {
-		let mut state = [true; 10];
+	let check_db = |ix: u32, content: [bool; 11]| -> io::Result<()> {
+		let mut state = [true; 11];
 		for (c, key) in keys.iter().enumerate() {
 			state[c] = db.get(ix, key)?.is_some();
 		}
@@ -209,15 +210,19 @@ pub fn test_delete_prefix(db: &dyn KeyValueDB) -> io::Result<()> {
 	};
 	let tests: [_; DELETE_PREFIX_NUM_COLUMNS as usize] = [
 		// standard
-		(&[1u8][..], [true, true, true, false, false, false, false, true, true, true]),
+		(&[1u8][..], [true, true, true, false, false, false, false, true, true, true, true]),
 		// edge
-		(&[1u8, 255, 255][..], [true, true, true, true, true, true, false, true, true, true]),
+		(&[1u8, 255, 255][..], [true, true, true, true, true, true, false, true, true, true, true]),
 		// none 1
-		(&[1, 2][..], [true, true, true, true, true, true, true, true, true, true]),
+		(&[1, 2][..], [true, true, true, true, true, true, true, true, true, true, true]),
 		// none 2
-		(&[8][..], [true, true, true, true, true, true, true, true, true, true]),
+		(&[8][..], [true, true, true, true, true, true, true, true, true, true, true]),
+		// last value
+		(&[255, 255][..], [true, true, true, true, true, true, true, true, true, true, false]),
+		// last value, limit prefix
+		(&[255][..], [true, true, true, true, true, true, true, true, true, true, false]),
 		// all
-		(&[][..], [false, false, false, false, false, false, false, false, false, false]),
+		(&[][..], [false, false, false, false, false, false, false, false, false, false, false]),
 	];
 	for (ix, test) in tests.iter().enumerate() {
 		let ix = ix as u32;

--- a/kvdb-shared-tests/src/lib.rs
+++ b/kvdb-shared-tests/src/lib.rs
@@ -190,7 +190,7 @@ pub fn test_delete_prefix(db: &dyn KeyValueDB) -> io::Result<()> {
 		&[2][..],
 		&[2, 0][..],
 		&[2, 255][..],
-		&[255, 255][..],
+		&[255; 16][..],
 	];
 	let init_db = |ix: u32| -> io::Result<()> {
 		let mut batch = db.transaction();

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -142,15 +142,17 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 
 /// For a given start prefix (inclusive), returns the correct end prefix (non-inclusive).
 /// This assumes the key bytes are ordered in lexicographical order.
-pub fn end_prefix(prefix: &[u8]) -> Vec<u8> {
+pub fn end_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
 	let mut end_range = prefix.to_vec();
 	while let Some(0xff) = end_range.last() {
 		end_range.pop();
 	}
 	if let Some(byte) = end_range.last_mut() {
 		*byte += 1;
+		Some(end_range)
+	} else {
+		None
 	}
-	end_range
 }
 
 #[cfg(test)]
@@ -159,17 +161,17 @@ mod test {
 
 	#[test]
 	fn end_prefix_test() {
-		assert_eq!(end_prefix(&[5, 6, 7]), vec![5, 6, 8]);
-		assert_eq!(end_prefix(&[5, 6, 255]), vec![5, 7]);
+		assert_eq!(end_prefix(&[5, 6, 7]), Some(vec![5, 6, 8]));
+		assert_eq!(end_prefix(&[5, 6, 255]), Some(vec![5, 7]));
 		// This is not equal as the result is before start.
-		assert_ne!(end_prefix(&[5, 255, 255]), vec![5, 255]);
+		assert_ne!(end_prefix(&[5, 255, 255]), Some(vec![5, 255]));
 		// This is equal ([5, 255] will not be deleted because
 		// it is before start).
-		assert_eq!(end_prefix(&[5, 255, 255]), vec![6]);
-		assert_eq!(end_prefix(&[255, 255, 255]), vec![]);
+		assert_eq!(end_prefix(&[5, 255, 255]), Some(vec![6]));
+		assert_eq!(end_prefix(&[255, 255, 255]), None);
 
-		assert_eq!(end_prefix(&[0x00, 0xff]), vec![0x01]);
-		assert_eq!(end_prefix(&[0xff]), vec![]);
-		assert_eq!(end_prefix(&[]), vec![]);
+		assert_eq!(end_prefix(&[0x00, 0xff]), Some(vec![0x01]));
+		assert_eq!(end_prefix(&[0xff]), None);
+		assert_eq!(end_prefix(&[]), None);
 	}
 }

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -142,6 +142,8 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 
 /// For a given start prefix (inclusive), returns the correct end prefix (non-inclusive).
 /// This assumes the key bytes are ordered in lexicographical order.
+/// Since key length is not limited, for some case we return `None` because there is
+/// no bounded limit (every keys in the serie `[]`, `[255]`, `[255, 255]` ...).
 pub fn end_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
 	let mut end_range = prefix.to_vec();
 	while let Some(0xff) = end_range.last() {


### PR DESCRIPTION
My previous PR to delete by prefix contains an ordering error, this PR fixes that.

The test change in this PR shows the problematic case.

The pr make use of the existing iter by prefix iterator for the corner case in rocksdb, and change end_prefix api to be safest, so it breaks #365.
One of the corner case that may be tricky to implement in #365 is this one, basically iterating by prefix [255] with existing key [255, 255], [255, 255, 255] ... in the db.
Ok, I am wrong this should work without change (since #365 only change read opt to set upper bound).
So this only require changing the call to end_prefix in #365