### PR TITLE
Allow pubkey recovery for all-zero messages

### DIFF
--- a/parity-crypto/src/publickey/ecdsa_signature.rs
+++ b/parity-crypto/src/publickey/ecdsa_signature.rs
@@ -246,13 +246,31 @@ pub fn verify_address(address: &Address, signature: &Signature, message: &Messag
 
 /// Recovers the public key from the signature for the message
 pub fn recover(signature: &Signature, message: &Message) -> Result<Public, Error> {
-	let context = &SECP256K1;
-	let message = ZeroesAllowedMessage(*message);
-	let rsig = RecoverableSignature::from_compact(&signature[0..64], RecoveryId::from_i32(signature[64] as i32)?)?;
-	let pubkey = context.recover(&message.into(), &rsig)?;
+	let rsig = RecoverableSignature::from_compact(
+		&signature[0..64],
+		RecoveryId::from_i32(signature[64] as i32)?
+	)?;
+	let pubkey = &SECP256K1.recover(&SecpMessage::from_slice(&message[..])?, &rsig)?;
 	let serialized = pubkey.serialize_uncompressed();
-
 	let mut public = Public::default();
+	public.as_bytes_mut().copy_from_slice(&serialized[1..65]);
+	Ok(public)
+}
+
+/// Recovers the public key from the signature for the given message.
+/// This version of `recover()` allows for all-zero messages, which is necessary
+/// for ethereum but is otherwise highly discouraged. Use with caution.
+pub fn recover_allowing_all_zero_message(
+	signature: &Signature,
+	message: ZeroesAllowedMessage
+) -> Result<Public, Error> {
+	let rsig = RecoverableSignature::from_compact(
+		&signature[0..64],
+		RecoveryId::from_i32(signature[64] as i32)?,
+	)?;
+	let pubkey = &SECP256K1.recover(&message.into(), &rsig)?;
+	let serialized = pubkey.serialize_uncompressed();
+	let mut public = Public::zero();
 	public.as_bytes_mut().copy_from_slice(&serialized[1..65]);
 	Ok(public)
 }
@@ -260,9 +278,29 @@ pub fn recover(signature: &Signature, message: &Message) -> Result<Public, Error
 #[cfg(test)]
 mod tests {
 	use super::super::{Generator, Message, Random, SECP256K1};
-	use super::{recover, sign, verify_address, verify_public, Signature, ZeroesAllowedMessage};
+	use super::{
+		recover, recover_allowing_all_zero_message, sign, verify_address, verify_public,
+		Secret, Signature, ZeroesAllowedMessage
+	};
 	use secp256k1::SecretKey;
 	use std::str::FromStr;
+
+	// Copy of `sign()` that allows signing all-zero Messages.
+	// Note: this is for *tests* only. DO NOT USE UNLESS YOU NEED IT.
+	fn sign_zero_message(secret: &Secret) -> Signature {
+		let context = &SECP256K1;
+		let sec = SecretKey::from_slice(secret.as_ref()).unwrap();
+		// force an all-zero message into a secp `Message` bypassing the validity check.
+		let zero_msg = ZeroesAllowedMessage(Message::zero());
+		let s = context.sign_recoverable(&zero_msg.into(), &sec);
+		let (rec_id, data) = s.serialize_compact();
+		let mut data_arr = [0; 65];
+
+		// no need to check if s is low, it always is
+		data_arr[0..64].copy_from_slice(&data[0..64]);
+		data_arr[64] = rec_id.to_i32() as u8;
+		Signature(data_arr)
+	}
 
 	#[test]
 	fn vrs_conversion() {
@@ -298,23 +336,22 @@ mod tests {
 	}
 
 	#[test]
-	fn sign_and_recover_public_works_with_zeroed_messages() {
+	fn sign_and_recover_public_fails_with_zeroed_messages() {
 		let keypair = Random.generate();
+		let signature = sign_zero_message(keypair.secret());
 		let zero_message = Message::zero();
-		let signature = {
-			let context = &SECP256K1;
-			let sec = SecretKey::from_slice(keypair.secret().as_ref()).unwrap();
-			let secp_msg = ZeroesAllowedMessage(zero_message);
-			let s = context.sign_recoverable(&secp_msg.into(), &sec);
-			let (rec_id, data) = s.serialize_compact();
-			let mut data_arr = [0; 65];
+		assert!(&recover(&signature, &zero_message).is_err());
+	}
 
-			// no need to check if s is low, it always is
-			data_arr[0..64].copy_from_slice(&data[0..64]);
-			data_arr[64] = rec_id.to_i32() as u8;
-			Signature(data_arr)
-		};
-		assert_eq!(keypair.public(), &recover(&signature, &zero_message).unwrap());
+	#[test]
+	fn recover_allowing_all_zero_message_can_recover_from_all_zero_messages() {
+		let keypair = Random.generate();
+		let signature = sign_zero_message(keypair.secret());
+		let zero_message = ZeroesAllowedMessage(Message::zero());
+		assert_eq!(
+			keypair.public(),
+			&recover_allowing_all_zero_message(&signature, zero_message).unwrap()
+		)
 	}
 
 	#[test]

--- a/parity-crypto/src/publickey/ecdsa_signature.rs
+++ b/parity-crypto/src/publickey/ecdsa_signature.rs
@@ -247,9 +247,9 @@ pub fn verify_address(address: &Address, signature: &Signature, message: &Messag
 /// Recovers the public key from the signature for the message
 pub fn recover(signature: &Signature, message: &Message) -> Result<Public, Error> {
 	let context = &SECP256K1;
-	let secp_msg = ZeroesAllowedMessage(message.clone());
+	let message = ZeroesAllowedMessage(*message);
 	let rsig = RecoverableSignature::from_compact(&signature[0..64], RecoveryId::from_i32(signature[64] as i32)?)?;
-	let pubkey = context.recover(&secp_msg.into(), &rsig)?;
+	let pubkey = context.recover(&message.into(), &rsig)?;
 	let serialized = pubkey.serialize_uncompressed();
 
 	let mut public = Public::default();

--- a/parity-crypto/src/publickey/mod.rs
+++ b/parity-crypto/src/publickey/mod.rs
@@ -34,7 +34,15 @@ pub use ethereum_types::{Address, Public};
 pub type Message = H256;
 
 use secp256k1::ThirtyTwoByteHash;
-pub struct ZeroesAllowedMessage(H256);
+
+/// In ethereum we allow public key recovery from a signature + message pair
+/// where the message is all-zeroes. This conflicts with the best practise of
+/// not allowing such values and so in order to avoid breaking consensus we need
+/// this to work around it. The `ZeroesAllowedType` wraps an `H256` that can be
+/// converted to a `[u8; 32]` which in turn can be cast to a
+/// `secp256k1::Message` by the `ThirtyTwoByteHash` and satisfy the API for
+/// `recover()`.
+struct ZeroesAllowedMessage(H256);
 impl ThirtyTwoByteHash for ZeroesAllowedMessage {
 	fn into_32(self) -> [u8; 32] {
 		self.0.to_fixed_bytes()

--- a/parity-crypto/src/publickey/mod.rs
+++ b/parity-crypto/src/publickey/mod.rs
@@ -20,7 +20,10 @@ pub mod ecdh;
 pub mod ecies;
 pub mod error;
 
-pub use self::ecdsa_signature::{recover, sign, verify_address, verify_public, Signature};
+pub use self::ecdsa_signature::{
+	recover, recover_allowing_all_zero_message, sign, verify_address, verify_public,
+	Signature
+};
 pub use self::error::Error;
 pub use self::extended_keys::{Derivation, DerivationError, ExtendedKeyPair, ExtendedPublic, ExtendedSecret};
 pub use self::keypair::{public_to_address, KeyPair};
@@ -42,7 +45,7 @@ use secp256k1::ThirtyTwoByteHash;
 /// converted to a `[u8; 32]` which in turn can be cast to a
 /// `secp256k1::Message` by the `ThirtyTwoByteHash` and satisfy the API for
 /// `recover()`.
-struct ZeroesAllowedMessage(H256);
+pub struct ZeroesAllowedMessage(H256);
 impl ThirtyTwoByteHash for ZeroesAllowedMessage {
 	fn into_32(self) -> [u8; 32] {
 		self.0.to_fixed_bytes()

--- a/parity-crypto/src/publickey/mod.rs
+++ b/parity-crypto/src/publickey/mod.rs
@@ -21,8 +21,7 @@ pub mod ecies;
 pub mod error;
 
 pub use self::ecdsa_signature::{
-	recover, recover_allowing_all_zero_message, sign, verify_address, verify_public,
-	Signature
+	recover, recover_allowing_all_zero_message, sign, verify_address, verify_public, Signature,
 };
 pub use self::error::Error;
 pub use self::extended_keys::{Derivation, DerivationError, ExtendedKeyPair, ExtendedPublic, ExtendedSecret};

--- a/parity-crypto/src/publickey/mod.rs
+++ b/parity-crypto/src/publickey/mod.rs
@@ -33,6 +33,14 @@ use lazy_static::lazy_static;
 pub use ethereum_types::{Address, Public};
 pub type Message = H256;
 
+use secp256k1::ThirtyTwoByteHash;
+pub struct ZeroesAllowedMessage(pub H256);
+impl ThirtyTwoByteHash for ZeroesAllowedMessage {
+	fn into_32(self) -> [u8; 32] {
+		self.0.to_fixed_bytes()
+	}
+}
+
 /// The number -1 encoded as a secret key
 const MINUS_ONE_KEY: &'static [u8] = &[
 	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xba, 0xae, 0xdc,

--- a/parity-crypto/src/publickey/mod.rs
+++ b/parity-crypto/src/publickey/mod.rs
@@ -34,7 +34,7 @@ pub use ethereum_types::{Address, Public};
 pub type Message = H256;
 
 use secp256k1::ThirtyTwoByteHash;
-pub struct ZeroesAllowedMessage(pub H256);
+pub struct ZeroesAllowedMessage(H256);
 impl ThirtyTwoByteHash for ZeroesAllowedMessage {
 	fn into_32(self) -> [u8; 32] {
 		self.0.to_fixed_bytes()


### PR DESCRIPTION
After https://github.com/openethereum/openethereum/pull/11406 it is no longer possible to do public key recovery from messages that are all-zero. This creates issues when using the `ecrecover` builtin because externally produced signatures may well provide a message (i.e. a preimage) that is all-zeroes.
This works around the problem at the cost of cloning the incoming message and create a `ZeroesAllowedMessage` wrapper around it. The `ZeroesAllowedMessage` implements the `ThirtyTwoByteHash` trait from `rust-secp256k1` which circumvents the zero-check.

In a follow-up PR we'll likely change the interface of `recover()` to take a `ZeroesAllowedMessage` directly, thus removing the unneeded clone.