### PR TITLE
 keccak-hash: add keccak256_range and keccak512_range functions

### DIFF
--- a/keccak-hash/CHANGELOG.md
+++ b/keccak-hash/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.4.2] - 2020-03-16
+## [0.5.1] - 2020-03-16
+- Added `keccak256_range` and `keccak512_range` functions. [#370](https://github.com/paritytech/parity-common/pull/370)
+
+## [0.5.0] - 2020-03-16
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 - Updated dependencies. [#361](https://github.com/paritytech/parity-common/pull/361)
+- Updated tiny-keccak. [#260](https://github.com/paritytech/parity-common/pull/260)
 
 ## [0.4.1] - 2019-10-24
 ### Dependencies

--- a/keccak-hash/CHANGELOG.md
+++ b/keccak-hash/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.5.1] - 2020-03-16
+## [0.5.1] - 2020-04-10
 - Added `keccak256_range` and `keccak512_range` functions. [#370](https://github.com/paritytech/parity-common/pull/370)
 
 ## [0.5.0] - 2020-03-16

--- a/keccak-hash/src/lib.rs
+++ b/keccak-hash/src/lib.rs
@@ -46,6 +46,9 @@ pub fn keccak256(data: &mut [u8]) {
 }
 
 /// Computes in-place keccak256 hash of `data[range]`.
+///
+/// The `range` argument specifies a subslice of `data` in bytes to be hashed.
+/// The resulting hash will be written back to `data`.
 /// # Panics
 ///
 /// If `range` is out of bounds.
@@ -75,6 +78,9 @@ pub fn keccak512(data: &mut [u8]) {
 }
 
 /// Computes in-place keccak512 hash of `data[range]`.
+///
+/// The `range` argument specifies a subslice of `data` in bytes to be hashed.
+/// The resulting hash will be written back to `data`.
 /// # Panics
 ///
 /// If `range` is out of bounds.

--- a/keccak-hash/src/lib.rs
+++ b/keccak-hash/src/lib.rs
@@ -45,10 +45,54 @@ pub fn keccak256(data: &mut [u8]) {
 	keccak256.finalize(data);
 }
 
+/// Computes in-place keccak256 hash of `data[range]`.
+/// # Panics
+///
+/// If `range` is out of bounds.
+///
+/// # Example
+///
+/// ```
+/// let mut data = [1u8; 32];
+/// keccak_hash::keccak256_range(&mut data, 0..8);
+/// let expected = [
+///     0x54, 0x84, 0x4f, 0x69, 0xb4, 0xda, 0x4b, 0xb4, 0xa9, 0x9f, 0x24, 0x59, 0xb5, 0x11, 0xd4, 0x42,
+///     0xcc, 0x5b, 0xd2, 0xfd, 0xf4, 0xc3, 0x54, 0xd2, 0x07, 0xbb, 0x13, 0x08, 0x94, 0x43, 0xaf, 0x68,
+/// ];
+/// assert_eq!(&data, &expected);
+/// ```
+pub fn keccak256_range(data: &mut [u8], range: core::ops::Range<usize>) {
+	let mut keccak256 = Keccak::v256();
+	keccak256.update(&data[range]);
+	keccak256.finalize(data);
+}
+
 /// Computes in-place keccak512 hash of `data`.
 pub fn keccak512(data: &mut [u8]) {
 	let mut keccak512 = Keccak::v512();
 	keccak512.update(data.as_ref());
+	keccak512.finalize(data);
+}
+
+/// Computes in-place keccak512 hash of `data[range]`.
+/// # Panics
+///
+/// If `range` is out of bounds.
+///
+/// # Example
+///
+/// ```
+/// let mut data = [1u8; 64];
+/// keccak_hash::keccak512_range(&mut data, 0..8);
+/// let expected = [
+///     0x90, 0x45, 0xc5, 0x9e, 0xd3, 0x0e, 0x1f, 0x42, 0xac, 0x35, 0xcc, 0xc9, 0x55, 0x7c, 0x77, 0x17,
+///     0xc8, 0x89, 0x3a, 0x77, 0x6c, 0xea, 0x2e, 0xf3, 0x88, 0xea, 0xe5, 0xc0, 0xea, 0x40, 0x26, 0x64,
+/// ];
+/// assert_eq!(&data[..32], &expected);
+/// ```
+pub fn keccak512_range(data: &mut [u8], range: core::ops::Range<usize>) {
+	let mut keccak512 = Keccak::v512();
+	keccak512.update(&data[range]);
 	keccak512.finalize(data);
 }
 

--- a/keccak-hash/src/lib.rs
+++ b/keccak-hash/src/lib.rs
@@ -57,6 +57,7 @@ pub fn keccak256(data: &mut [u8]) {
 ///
 /// ```
 /// let mut data = [1u8; 32];
+/// // Hash the first 8 bytes of `data` and write the result, 32 bytes, to `data`.
 /// keccak_hash::keccak256_range(&mut data, 0..8);
 /// let expected = [
 ///     0x54, 0x84, 0x4f, 0x69, 0xb4, 0xda, 0x4b, 0xb4, 0xa9, 0x9f, 0x24, 0x59, 0xb5, 0x11, 0xd4, 0x42,


### PR DESCRIPTION
This is a safe version of https://github.com/openethereum/openethereum/pull/11620/commits/f2b0869b0146059cb931fe3d24e2e9bab987e95e.