### PR TITLE
bump parity-util-mem

### DIFF
--- a/parity-util-mem/CHANGELOG.md
+++ b/parity-util-mem/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-### Breaking
+
+## [0.6.1] - 2020-04-15
+- Fix compilation on Windows for no-std. [#375](https://github.com/paritytech/parity-common/pull/375)
 - Prevent multiple versions from being linked into the same program. [#363](https://github.com/paritytech/parity-common/pull/363)
 
 ## [0.6.0] - 2020-03-13

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-util-mem"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Collection of memory related utilities"

--- a/parity-util-mem/README.md
+++ b/parity-util-mem/README.md
@@ -9,8 +9,8 @@ it must be the sole place where a global allocator is defined.
 The only exception to this rule is when used in a `no_std` context or when the `estimate-heapsize` feature is used.
 
 Because of that, it must be present in the dependency tree with a single version.
-Starting from version 0.7, having duplicate versions of `parity-util-mem` will lead
-to a compile-time error. It still will be possible to have 0.6 and 0.7 versions in the same binary though.
+Starting from version 0.6.1, having duplicate versions of `parity-util-mem` will lead
+to a compile-time error. It still will be possible to have 0.5 and 0.6.1 versions in the same binary though.
 
 Unless heeded you risk UB; see discussion in [issue 364].
 


### PR DESCRIPTION
I marked #363 previously as a breaking change to be on the safer side, but it can be technically viewed as a non-breaking one I guess.