### PR TITLE
uint: fix UB in uint::from_big_endian

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1120,13 +1120,8 @@ macro_rules! construct_uint {
 				let mut ret = [0; $n_words];
 				unsafe {
 					let ret_u8: &mut [u8; $n_words * 8] = $crate::core_::mem::transmute(&mut ret);
-					let mut ret_ptr = ret_u8.as_mut_ptr();
-					let mut slice_ptr = slice.as_ptr().offset(slice.len() as isize - 1);
-					for _ in 0..slice.len() {
-						*ret_ptr = *slice_ptr;
-						ret_ptr = ret_ptr.offset(1);
-						slice_ptr = slice_ptr.offset(-1);
-					}
+					ret_u8[0..slice.len()].copy_from_slice(slice);
+					ret_u8[0..slice.len()].reverse();
 				}
 
 				$name(ret)

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -990,6 +990,12 @@ fn from_big_endian() {
 	let number = U256::from_big_endian(&source[..]);
 
 	assert_eq!(U256::from(1), number);
+
+	let number = U256::from_big_endian(&[]);
+	assert_eq!(U256::zero(), number);
+
+	let number = U256::from_big_endian(&[1]);
+	assert_eq!(U256::from(1), number);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #380.

```
u256_from_be            time:   [23.877 ns 24.007 ns 24.160 ns]                          
                        change: [-6.5124% -5.8920% -5.3296%] (p = 0.00 < 0.05)
                        Performance has improved.
```