### PR TITLE
uint: simplify `Ord` impl

### DIFF
--- a/uint/benches/bigint.rs
+++ b/uint/benches/bigint.rs
@@ -601,7 +601,7 @@ fn u512_ord(c: &mut Criterion) {
 		36306297304129857,
 		3453,
 	]);
-	c.bench_function("u512_ord", move |b| b.iter(|| black_box(one < two)));
+	c.bench_function("u512_ord", move |b| b.iter(|| black_box(one) < black_box(two)));
 }
 
 fn u256_from_le(c: &mut Criterion) {

--- a/uint/benches/bigint.rs
+++ b/uint/benches/bigint.rs
@@ -577,7 +577,7 @@ fn u512_shr(c: &mut Criterion) {
 fn u256_ord(c: &mut Criterion) {
 	let one = U256([12767554894655550452, 16333049135534778834, 140317443000293558, 598963]);
 	let two = U256([2096410819092764509, 8483673822214032535, 36306297304129857, 3453]);
-	c.bench_function("u256_ord", move |b| b.iter(|| black_box(one < two)));
+	c.bench_function("u256_ord", move |b| b.iter(|| black_box(one) < black_box(two)));
 }
 
 fn u512_ord(c: &mut Criterion) {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1464,15 +1464,7 @@ macro_rules! construct_uint {
 
 		impl $crate::core_::cmp::Ord for $name {
 			fn cmp(&self, other: &$name) -> $crate::core_::cmp::Ordering {
-				let &$name(ref me) = self;
-				let &$name(ref you) = other;
-				let mut i = $n_words;
-				while i > 0 {
-					i -= 1;
-					if me[i] < you[i] { return $crate::core_::cmp::Ordering::Less; }
-					if me[i] > you[i] { return $crate::core_::cmp::Ordering::Greater; }
-				}
-				$crate::core_::cmp::Ordering::Equal
+                self.as_ref().iter().rev().cmp(other.as_ref().iter().rev())
 			}
 		}
 


### PR DESCRIPTION
```
u256_ord                time:   [3.5101 ns 3.5176 ns 3.5261 ns]                      
                        change: [-0.1706% +0.1258% +0.4540%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

u512_ord                time:   [6.9543 ns 6.9750 ns 6.9998 ns]                      
                        change: [-0.3145% +0.3842% +1.1102%] (p = 0.31 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe
```
Also fixes the `u256_ord` and `u512_ord` benches (`1.5204 ns` vs `6.9600 ns`).