### PR TITLE
uint: manually implement `Eq` and `Hash`

### DIFF
--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Added a manual impl of `Eq` and `Hash`. [#390](https://github.com/paritytech/parity-common/pull/390)
 
 ## [0.8.3] - 2020-04-27
 - Added `arbitrary` feature. [#378](https://github.com/paritytech/parity-common/pull/378)

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1468,8 +1468,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl $crate::core_::cmp::Eq for $name {
-		}
+		impl $crate::core_::cmp::Eq for $name {}
 
 		impl $crate::core_::hash::Hash for $name {
 			fn hash<H: $crate::core_::hash::Hasher>(&self, state: &mut H) {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -445,7 +445,7 @@ macro_rules! construct_uint {
 		/// Little-endian large integer type
 		#[repr(C)]
 		$(#[$attr])*
-		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+		#[derive(Copy, Clone)]
 		$visibility struct $name (pub [u64; $n_words]);
 
 		/// Get a reference to the underlying little-endian words.
@@ -1459,6 +1459,22 @@ macro_rules! construct_uint {
 		impl<T> $crate::core_::ops::ShrAssign<T> for $name where T: Into<$name> {
 			fn shr_assign(&mut self, shift: T) {
 				*self = *self >> shift;
+			}
+		}
+
+		impl $crate::core_::cmp::PartialEq for $name {
+			fn eq(&self, other: &$name) -> bool {
+				self.cmp(other) == $crate::core_::cmp::Ordering::Equal
+			}
+		}
+
+		impl $crate::core_::cmp::Eq for $name {
+		}
+
+		impl $crate::core_::hash::Hash for $name {
+			fn hash<H: $crate::core_::hash::Hasher>(&self, state: &mut H) {
+				// use the impl as slice &[u64]
+				<[u64] as $crate::core_::hash::Hash>::hash(&self.0[..], state);
 			}
 		}
 

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1475,7 +1475,7 @@ macro_rules! construct_uint {
 		impl $crate::core_::hash::Hash for $name {
 			fn hash<H: $crate::core_::hash::Hasher>(&self, state: &mut H) {
 				// use the impl as slice &[u64]
-				<[u64] as $crate::core_::hash::Hash>::hash(&self.0[..], state);
+				self.as_ref().hash(state);
 			}
 		}
 

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1462,6 +1462,8 @@ macro_rules! construct_uint {
 			}
 		}
 
+		// We implement `Eq` and `Hash` manually to workaround
+		// https://github.com/rust-lang/rust/issues/61415
 		impl $crate::core_::cmp::PartialEq for $name {
 			fn eq(&self, other: &$name) -> bool {
 				self.cmp(other) == $crate::core_::cmp::Ordering::Equal

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1466,7 +1466,7 @@ macro_rules! construct_uint {
 		// https://github.com/rust-lang/rust/issues/61415
 		impl $crate::core_::cmp::PartialEq for $name {
 			fn eq(&self, other: &$name) -> bool {
-				self.cmp(other) == $crate::core_::cmp::Ordering::Equal
+				self.as_ref() == other.as_ref()
 			}
 		}
 

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -25,7 +25,7 @@ construct_uint! {
 fn hash_impl_is_the_same_as_for_a_slice() {
 	use core::hash::{Hash, Hasher as _};
 	use std::collections::hash_map::DefaultHasher;
-	
+
 	let uint_hash = {
 		let mut h = DefaultHasher::new();
 		let uint = U256::from(123u64);

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -281,7 +281,6 @@ fn uint256_bits_test() {
 }
 
 #[test]
-#[cfg_attr(feature = "dev", allow(eq_op))]
 fn uint256_comp_test() {
 	let small = U256([10u64, 0, 0, 0]);
 	let big = U256([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]);
@@ -296,6 +295,10 @@ fn uint256_comp_test() {
 	assert!(bigger >= big);
 	assert!(bigger >= small);
 	assert!(small <= small);
+	assert_eq!(small, small);
+	assert_eq!(biggest, biggest);
+	assert_ne!(big, biggest);
+	assert_ne!(big, bigger);
 }
 
 #[test]

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -20,6 +20,26 @@ construct_uint! {
 	pub struct U512(8);
 }
 
+#[cfg(feature = "std")]
+#[test]
+fn hash_impl_is_the_same_as_for_a_slice() {
+	use core::hash::{Hash, Hasher as _};
+	use std::collections::hash_map::DefaultHasher;
+	
+	let uint_hash = {
+		let mut h = DefaultHasher::new();
+		let uint = U256::from(123u64);
+		Hash::hash(&uint, &mut h);
+		h.finish()
+	};
+	let slice_hash = {
+		let mut h = DefaultHasher::new();
+		Hash::hash(&[123u64, 0, 0, 0], &mut h);
+		h.finish()
+	};
+	assert_eq!(uint_hash, slice_hash);
+}
+
 #[test]
 fn u128_conversions() {
 	let mut a = U256::from(u128::max_value());
@@ -1013,10 +1033,10 @@ fn into_fixed_array() {
 fn test_u256_from_fixed_array() {
 	let ary = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 123];
 	let num: U256 = ary.into();
-	assert_eq!(num, U256::from(std::u64::MAX) + 1 + 123);
+	assert_eq!(num, U256::from(core::u64::MAX) + 1 + 123);
 
 	let a_ref: &U256 = &ary.into();
-	assert_eq!(a_ref, &(U256::from(std::u64::MAX) + 1 + 123));
+	assert_eq!(a_ref, &(U256::from(core::u64::MAX) + 1 + 123));
 }
 
 #[test]


### PR DESCRIPTION
Part of #388.
It doesn't allow `U4096` yet, currently blocked on an issue with `crunchy`.