### PR TITLE
Implement codec for ethereum types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,4 +60,5 @@ script:
   - cd rlp/ && cargo test --no-default-features && cargo check --benches && cd ..
   - cd triehash/ && cargo check --benches && cd ..
   - cd kvdb-web/ && wasm-pack test --headless --firefox && cd ..
-
+  - cd ethbloom/ && cargo test --all-features
+  - cd ethereum-types/ && cargo test --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,5 +60,5 @@ script:
   - cd rlp/ && cargo test --no-default-features && cargo check --benches && cd ..
   - cd triehash/ && cargo check --benches && cd ..
   - cd kvdb-web/ && wasm-pack test --headless --firefox && cd ..
-  - cd ethbloom/ && cargo test --all-features
-  - cd ethereum-types/ && cargo test --all-features
+  - cd ethbloom/ && cargo test --all-features && cd ..
+  - cd ethereum-types/ && cargo test --all-features && cd ..

--- a/ethbloom/CHANGELOG.md
+++ b/ethbloom/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.2] - 2020-05-18
+- Added `codec` feature. [#393](https://github.com/paritytech/parity-common/pull/393)
+
 ## [0.9.1] - 2020-04-27
 - Added `arbitrary` feature. [#378](https://github.com/paritytech/parity-common/pull/378)
 

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -15,6 +15,7 @@ crunchy = { version = "0.2.2", default-features = false, features = ["limit_256"
 fixed-hash = { path = "../fixed-hash", version = "0.6", default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
+impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
@@ -27,6 +28,7 @@ std = ["fixed-hash/std", "crunchy/std"]
 serialize = ["std", "impl-serde"]
 rustc-hex = ["fixed-hash/rustc-hex"]
 arbitrary = ["fixed-hash/arbitrary"]
+codec = ["impl-codec"]
 
 [[bench]]
 name = "bloom"

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT OR Apache-2.0"

--- a/ethbloom/src/lib.rs
+++ b/ethbloom/src/lib.rs
@@ -57,6 +57,8 @@ use fixed_hash::*;
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
+#[cfg(feature = "codec")]
+use impl_codec::impl_fixed_hash_codec;
 use tiny_keccak::{Hasher, Keccak};
 
 // 3 according to yellowpaper
@@ -68,6 +70,10 @@ construct_fixed_hash! {
 	pub struct Bloom(BLOOM_SIZE);
 }
 impl_fixed_hash_rlp!(Bloom, BLOOM_SIZE);
+#[cfg(feature = "serialize")]
+impl_fixed_hash_serde!(Bloom, BLOOM_SIZE);
+#[cfg(feature = "codec")]
+impl_fixed_hash_codec!(Bloom, BLOOM_SIZE);
 
 /// Returns log2.
 fn log2(x: usize) -> u32 {
@@ -263,9 +269,6 @@ impl<'a> From<&'a Bloom> for BloomRef<'a> {
 		BloomRef(&bloom.0)
 	}
 }
-
-#[cfg(feature = "serialize")]
-impl_fixed_hash_serde!(Bloom, BLOOM_SIZE);
 
 #[cfg(test)]
 mod tests {

--- a/ethbloom/src/lib.rs
+++ b/ethbloom/src/lib.rs
@@ -54,11 +54,11 @@ use core::{mem, ops};
 
 use crunchy::unroll;
 use fixed_hash::*;
+#[cfg(feature = "codec")]
+use impl_codec::impl_fixed_hash_codec;
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
-#[cfg(feature = "codec")]
-use impl_codec::impl_fixed_hash_codec;
 use tiny_keccak::{Hasher, Keccak};
 
 // 3 according to yellowpaper

--- a/ethereum-types/CHANGELOG.md
+++ b/ethereum-types/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.2] - 2020-05-18
+- Added `codec` feature. [#393](https://github.com/paritytech/parity-common/pull/393)
+
 ## [0.9.1] - 2020-04-27
 - Added `arbitrary` feature. [#378](https://github.com/paritytech/parity-common/pull/378)
 

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -14,6 +14,7 @@ uint-crate = { path = "../uint", package = "uint", version = "0.8", default-feat
 primitive-types = { path = "../primitive-types", version = "0.7", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3.0", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
+impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.41"
@@ -23,3 +24,4 @@ default = ["std", "serialize"]
 std = ["uint-crate/std", "fixed-hash/std", "ethbloom/std", "primitive-types/std"]
 serialize = ["std", "impl-serde", "primitive-types/serde", "ethbloom/serialize"]
 arbitrary = ["ethbloom/arbitrary", "fixed-hash/arbitrary", "uint-crate/arbitrary"]
+codec = ["impl-codec", "ethbloom/codec"]

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -11,6 +11,8 @@ use fixed_hash::*;
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
+#[cfg(feature = "codec")]
+use impl_codec::impl_fixed_hash_codec;
 
 pub trait BigEndianHash {
 	type Uint;
@@ -23,16 +25,22 @@ construct_fixed_hash! { pub struct H32(4); }
 impl_fixed_hash_rlp!(H32, 4);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H32, 4);
+#[cfg(feature = "codec")]
+impl_fixed_hash_codec!(H32, 4);
 
 construct_fixed_hash! { pub struct H64(8); }
 impl_fixed_hash_rlp!(H64, 8);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H64, 8);
+#[cfg(feature = "codec")]
+impl_fixed_hash_codec!(H64, 8);
 
 construct_fixed_hash! { pub struct H128(16); }
 impl_fixed_hash_rlp!(H128, 16);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H128, 16);
+#[cfg(feature = "codec")]
+impl_fixed_hash_codec!(H128, 16);
 
 pub use primitive_types::H160;
 pub use primitive_types::H256;
@@ -41,6 +49,8 @@ construct_fixed_hash! { pub struct H264(33); }
 impl_fixed_hash_rlp!(H264, 33);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H264, 33);
+#[cfg(feature = "codec")]
+impl_fixed_hash_codec!(H264, 33);
 
 pub use primitive_types::H512;
 
@@ -48,6 +58,8 @@ construct_fixed_hash! { pub struct H520(65); }
 impl_fixed_hash_rlp!(H520, 65);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H520, 65);
+#[cfg(feature = "codec")]
+impl_fixed_hash_codec!(H520, 65);
 
 macro_rules! impl_uint_conversions {
 	($hash: ident, $uint: ident) => {

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -8,11 +8,11 @@
 
 use crate::{U128, U256, U512, U64};
 use fixed_hash::*;
+#[cfg(feature = "codec")]
+use impl_codec::impl_fixed_hash_codec;
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
-#[cfg(feature = "codec")]
-use impl_codec::impl_fixed_hash_codec;
 
 pub trait BigEndianHash {
 	type Uint;

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "codec")]
+use impl_codec::impl_uint_codec;
 use impl_rlp::impl_uint_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_uint_serde;
-#[cfg(feature = "codec")]
-use impl_codec::impl_uint_codec;
 use uint_crate::*;
 
 pub use uint_crate::FromDecStrErr;

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -9,6 +9,8 @@
 use impl_rlp::impl_uint_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_uint_serde;
+#[cfg(feature = "codec")]
+use impl_codec::impl_uint_codec;
 use uint_crate::*;
 
 pub use uint_crate::FromDecStrErr;
@@ -20,6 +22,8 @@ construct_uint! {
 impl_uint_rlp!(U64, 1);
 #[cfg(feature = "serialize")]
 impl_uint_serde!(U64, 1);
+#[cfg(feature = "codec")]
+impl_uint_codec!(U64, 1);
 
 pub use primitive_types::{U128, U256, U512};
 


### PR DESCRIPTION
This adds codec support for `ethbloom` and `ethereum-types`, which is needed in Frontier.