### PR TITLE
uint: use wrapping_offset instead of offset

### DIFF
--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Replace `ptr::offset` with `ptr::wrapping_offset`. [#394](https://github.com/paritytech/parity-common/pull/394)
 
 ## [0.8.3] - 2020-04-27
 - Added `arbitrary` feature. [#378](https://github.com/paritytech/parity-common/pull/378)

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -118,7 +118,7 @@ macro_rules! uint_overflowing_binop {
 
 					unsafe {
 						// SAFETY: `i` is within bounds and `i * size_of::<u64>() < isize::MAX`
-						*ret_ptr.offset(i as _) = res2
+						*ret_ptr.wrapping_offset(i as _) = res2
 					}
 					carry = (overflow1 as u8 + overflow2 as u8) as u64;
 				} else {
@@ -126,7 +126,7 @@ macro_rules! uint_overflowing_binop {
 
 					unsafe {
 						// SAFETY: `i` is within bounds and `i * size_of::<u64>() < isize::MAX`
-						*ret_ptr.offset(i as _) = res
+						*ret_ptr.wrapping_offset(i as _) = res
 					}
 
 					carry = overflow as u64;


### PR DESCRIPTION
Fixes #392.

TBH I don't think it's safer in this case, because we already have a static assert (verified at compile-time) justifying the safety:
https://github.com/paritytech/parity-common/blob/a28452bc276421c9ba5af0c6c0795516b2cc6b3e/uint/src/uint.rs#L104-L106

The `SAFETY` comments still need to stay for correctness proof and dereferencing a raw pointer is unsafe anyway.

OTOH, from the (noisy) results running benches I didn't spot any regressions, so why not.