### PR TITLE
kvdb-rocksdb: set format_version to 5

### DIFF
--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -339,6 +339,8 @@ fn generate_read_options() -> ReadOptions {
 fn generate_block_based_options(config: &DatabaseConfig) -> BlockBasedOptions {
 	let mut block_opts = BlockBasedOptions::default();
 	block_opts.set_block_size(config.compaction.block_size);
+	block_opts.set_format_version(5);
+	block_opts.set_block_restart_interval(16);
 	// Set cache size as recommended by
 	// https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size
 	let cache_size = config.memory_budget() / 3;
@@ -1106,7 +1108,7 @@ rocksdb.db.get.micros P50 : 2.000000 P95 : 3.000000 P99 : 4.000000 P100 : 5.0000
 		// Don't fsync every store
 		assert!(settings.contains("Options.use_fsync: 0"));
 
-		// We're using the old format
-		assert!(settings.contains("format_version: 2"));
+		// We're using the new format
+		assert!(settings.contains("format_version: 5"));
 	}
 }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -339,6 +339,7 @@ fn generate_read_options() -> ReadOptions {
 fn generate_block_based_options(config: &DatabaseConfig) -> BlockBasedOptions {
 	let mut block_opts = BlockBasedOptions::default();
 	block_opts.set_block_size(config.compaction.block_size);
+	// See https://github.com/facebook/rocksdb/blob/a1523efcdf2f0e8133b9a9f6e170a0dad49f928f/include/rocksdb/table.h#L246-L271 for details on what the format versions are/do.
 	block_opts.set_format_version(5);
 	block_opts.set_block_restart_interval(16);
 	// Set cache size as recommended by


### PR DESCRIPTION
The `block_restart_interval` is set in accordance with https://rocksdb.org/blog/2019/03/08/format-version-4.html.

Context: https://github.com/facebook/rocksdb/blob/a1523efcdf2f0e8133b9a9f6e170a0dad49f928f/include/rocksdb/table.h#L246-L271

This change is backwards compatible with rocksdb versions >= 6.6.
> // This option only affects newly written tables. When reading existing
// tables, the information about version is read from the footer.