### PR TITLE
kvdb-rocksdb: fix deadlock caused by double read lock

### DIFF
--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -573,7 +573,7 @@ impl Database {
 	/// Will hold a lock until the iterator is dropped
 	/// preventing the database from being closed.
 	fn iter_with_prefix<'a>(&'a self, col: u32, prefix: &'a [u8]) -> impl Iterator<Item = iter::KeyValuePair> + 'a {
-		let read_lock = self.db.read();
+		let read_lock = self.db.read_recursive();
 		let optional = if read_lock.is_some() {
 			let mut read_opts = generate_read_options();
 			// rocksdb doesn't work with an empty upper bound


### PR DESCRIPTION
This PR fixes a deadlock caused by double read lock in kvdb-rocksdb/src/lib.rs.

The first read lock is in `write()`:
https://github.com/paritytech/parity-common/blob/8e121591acd63e7def9146fbf6bee0693fee3450/kvdb-rocksdb/src/lib.rs#L480-L481
Then `iter_with_prefix()` is called.
https://github.com/paritytech/parity-common/blob/8e121591acd63e7def9146fbf6bee0693fee3450/kvdb-rocksdb/src/lib.rs#L511
The second readlock is in `iter_with_prefix()`:
https://github.com/paritytech/parity-common/blob/8e121591acd63e7def9146fbf6bee0693fee3450/kvdb-rocksdb/src/lib.rs#L575-L576

According to parking_lot::RwLock:
“readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock.”
“attempts to recursively acquire a read lock within a single thread may result in a deadlock.”

Therefore, when two read locks are interleaved by a write lock (e.g. in `close()`, `restore()`) from another thread, a deadlock happens.

The fix is to use a `read_recursive()` in `iter_with_prefix()`. It concerns me that `read_recursive()` may starve the write lock. But this seems the only solution currently.
Or maybe we can create a new version `iter_with_prefix_recursive()` using `read_recursive()` and use this version in `write()`