### PR TITLE
parity-util-mem: export MallocShallowSizeOf

### DIFF
--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -64,7 +64,7 @@ pub mod ethereum_impls;
 pub mod primitives_impls;
 
 pub use allocators::MallocSizeOfExt;
-pub use malloc_size::{MallocSizeOf, MallocSizeOfOps};
+pub use malloc_size::{MallocSizeOf, MallocSizeOfOps, MallocShallowSizeOf};
 
 pub use parity_util_mem_derive::*;
 

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -64,7 +64,7 @@ pub mod ethereum_impls;
 pub mod primitives_impls;
 
 pub use allocators::MallocSizeOfExt;
-pub use malloc_size::{MallocSizeOf, MallocSizeOfOps, MallocShallowSizeOf};
+pub use malloc_size::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};
 
 pub use parity_util_mem_derive::*;
 


### PR DESCRIPTION
This is useful for computing `MallocSizeOf` incrementally for a collection.