### PR TITLE
Changelog to publish kvdb-web 0.7.0

### DIFF
--- a/kvdb-web/CHANGELOG.md
+++ b/kvdb-web/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.7.0] - 2020-06-
+- Updated `kvdb` to 0.7. [](https://github.com/paritytech/parity-common/pull/)
+
 ## [0.6.0] - 2020-05-05
 ### Breaking
 - Updated to the new `kvdb` interface. [#313](https://github.com/paritytech/parity-common/pull/313)

--- a/kvdb-web/CHANGELOG.md
+++ b/kvdb-web/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.7.0] - 2020-06-
-- Updated `kvdb` to 0.7. [](https://github.com/paritytech/parity-common/pull/)
+## [0.7.0] - 2020-06-30
+- Updated `kvdb` to 0.7.0 [](https://github.com/paritytech/parity-common/pull/404)
 
 ## [0.6.0] - 2020-05-05
 ### Breaking

--- a/kvdb-web/CHANGELOG.md
+++ b/kvdb-web/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 
 ## [0.7.0] - 2020-06-30
-- Updated `kvdb` to 0.7.0 [](https://github.com/paritytech/parity-common/pull/404)
+- Updated `kvdb` to 0.7.0 [#404](https://github.com/paritytech/parity-common/pull/404)
 
 ## [0.6.0] - 2020-05-05
 ### Breaking

--- a/kvdb-web/CHANGELOG.md
+++ b/kvdb-web/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.7.0] - 2020-06-30
+## [0.7.0] - 2020-07-06
 - Updated `kvdb` to 0.7.0 [#404](https://github.com/paritytech/parity-common/pull/404)
 
 ## [0.6.0] - 2020-05-05


### PR DESCRIPTION
Others kvdb crates where updated for kvdb 0.7.0, but I miss kvdb-web, when testing substrate with latest kvdb this is needed.