### PR TITLE
parity-runtime: bump to v0.2.0

### DIFF
--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.2.0] - 2020-07-16
+### Changed
+- Port runtime to tokio-compat. [#403](https://github.com/paritytech/parity-common/pull/403)
+
 ## [0.1.1] - 2020-02-11
 ### Changed
 - Moved to parity common repo, prepared for publishing. [#271](https://github.com/paritytech/parity-common/pull/271)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-runtime"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 


### PR DESCRIPTION
Prepare to release `parity-runtime` v0.2.0. rel #403.