### PR TITLE
Add automatic methods to KeyValueDB which test for the existence of certain objects

### DIFF
--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -139,6 +139,16 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	fn io_stats(&self, _kind: IoStatsKind) -> IoStats {
 		IoStats::empty()
 	}
+
+	/// Check for the existence of a value by key.
+	fn has_key(&self, col: u32, key: &[u8]) -> io::Result<bool> {
+		self.get(col, key).map(|opt| opt.is_some())
+	}
+
+	/// Check for the existence of a value by prefix.
+	fn has_prefix(&self, col: u32, prefix: &[u8]) -> bool {
+		self.get_by_prefix(col, prefix).is_some()
+	}
 }
 
 /// For a given start prefix (inclusive), returns the correct end prefix (non-inclusive).


### PR DESCRIPTION
Motivation: We have a use case in which we care about a large object's
existence, but don't care to load megabytes of data from disc. We have
only a `dyn KeyValueDB` handle available; whatever we use has to be
part of the trait.

By adding automatic implementations for the new methods, we avoid
breaking existing code. The automatic implementations are no worse than 
the code which is possible with the existing API.

Part 2 of this fix will be tracking down the concrete type in use
and implementing specializations of those methods, so that we actually
do save work, but that's dependent on this PR being merged.

Compatibility: this won't change the behavior of any existing code, even if
concrete instantiators already have methods which shadow the default
implementation: [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=3a22e53247ec3f0ab8341914200a94a5). 