### PR TITLE
plain_hasher: remove std feature and unsafe code

### DIFF
--- a/plain_hasher/CHANGELOG.md
+++ b/plain_hasher/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.3.0] - 2020-07-27
+- Add support for big-endian platforms. [#407](https://github.com/paritytech/parity-common/pull/407)
+- Remove unsafe code and `std` feature. [#410](https://github.com/paritytech/parity-common/pull/410)
+
 ## [0.2.3] - 2020-03-16
 - License changed from MIT to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 

--- a/plain_hasher/Cargo.toml
+++ b/plain_hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plain_hasher"
 description = "Hasher for 32-byte keys."
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 keywords = ["hash", "hasher"]
@@ -16,8 +16,6 @@ crunchy = { version = "0.2.2", default-features = false }
 criterion = "0.3.0"
 
 [features]
-default = ["std"]
-std = ["crunchy/std"]
 
 [[bench]]
 name = "bench"

--- a/plain_hasher/src/lib.rs
+++ b/plain_hasher/src/lib.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use core::hash::Hasher;
 
@@ -26,18 +26,13 @@ impl Hasher for PlainHasher {
 	}
 
 	#[inline]
-	#[allow(unused_assignments)]
 	fn write(&mut self, bytes: &[u8]) {
 		debug_assert!(bytes.len() == 32);
-		let mut bytes_ptr = bytes.as_ptr();
 		let mut prefix_bytes = self.prefix.to_le_bytes();
 
 		unroll! {
 			for i in 0..8 {
-				unsafe {
-					prefix_bytes[i] ^= (*bytes_ptr ^ *bytes_ptr.offset(8)) ^ (*bytes_ptr.offset(16) ^ *bytes_ptr.offset(24));
-					bytes_ptr = bytes_ptr.offset(1);
-				}
+                prefix_bytes[i] ^= (bytes[i] ^ bytes[i + 8]) ^ (bytes[i + 16] ^ bytes[i + 24]);
 			}
 		}
 

--- a/plain_hasher/src/lib.rs
+++ b/plain_hasher/src/lib.rs
@@ -32,7 +32,7 @@ impl Hasher for PlainHasher {
 
 		unroll! {
 			for i in 0..8 {
-                prefix_bytes[i] ^= (bytes[i] ^ bytes[i + 8]) ^ (bytes[i + 16] ^ bytes[i + 24]);
+				prefix_bytes[i] ^= (bytes[i] ^ bytes[i + 8]) ^ (bytes[i + 16] ^ bytes[i + 24]);
 			}
 		}
 

--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 - Added a manual impl of `Eq` and `Hash`. [#390](https://github.com/paritytech/parity-common/pull/390)
+- Remove some unsafe code and add big-endian support. [#407](https://github.com/paritytech/parity-common/pull/407)
 
 ## [0.8.3] - 2020-04-27
 - Added `arbitrary` feature. [#378](https://github.com/paritytech/parity-common/pull/378)


### PR DESCRIPTION
No difference in perf detected. 
The `std` feature of `crunchy` is only used for tests, I don't know why we expose it here.
Unfortunately, removing a feature is a breaking change, hence the bump in version.