### PR TITLE
parity-crypto: use mlock for Secret

### DIFF
--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -31,6 +31,7 @@ sha2 = "0.8.0"
 subtle = "2.2.1"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 zeroize = { version = "1.0.0", default-features = false }
+region = { version = "2.2.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
@@ -40,4 +41,4 @@ hex-literal = "0.2.1"
 default = []
 # public key crypto utils
 # moved from ethkey module in parity ethereum repository
-publickey = ["secp256k1", "lazy_static", "ethereum-types", "rustc-hex"]
+publickey = ["secp256k1", "lazy_static", "ethereum-types", "region", "rustc-hex"]

--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -32,6 +32,7 @@ subtle = "2.2.1"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 zeroize = { version = "1.0.0", default-features = false }
 region = { version = "2.2.0", optional = true }
+log = { version = "0.4.11", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
@@ -41,4 +42,4 @@ hex-literal = "0.2.1"
 default = []
 # public key crypto utils
 # moved from ethkey module in parity ethereum repository
-publickey = ["secp256k1", "lazy_static", "ethereum-types", "region", "rustc-hex"]
+publickey = ["ethereum-types", "lazy_static", "log", "region", "rustc-hex", "secp256k1"]

--- a/parity-crypto/src/publickey/secret_key.rs
+++ b/parity-crypto/src/publickey/secret_key.rs
@@ -23,7 +23,7 @@ use crate::publickey::Error;
 /// Represents secret key
 pub struct Secret {
 	// We're using `region::lock` to avoid swapping secret data to disk.
-	// Since don't propagate the error if a syscall fails,
+	// Since we don't propagate the error if a syscall fails,
 	// the guard returned by `region::lock` is optional.
 	mlock_guard: Option<region::LockGuard>,
 	inner: Box<H256>,
@@ -231,7 +231,6 @@ impl Clone for Secret {
 	fn clone_from(&mut self, other: &Self) {
 		self.inner.as_bytes_mut().copy_from_slice(other.inner.as_bytes());
 	}
-
 }
 
 impl PartialEq for Secret {

--- a/parity-crypto/src/publickey/secret_key.rs
+++ b/parity-crypto/src/publickey/secret_key.rs
@@ -93,8 +93,14 @@ impl Secret {
 	pub fn zero() -> Self {
 		let inner = Box::new(H256::zero());
 		let bytes = inner.as_bytes();
-		// Lock the memory page and convert the result to `Option`.
-		let mlock_guard = region::lock(bytes.as_ptr(), bytes.len()).ok();
+		// Try to lock the memory page and convert the result to `Option`.
+		let mlock_guard = match region::lock(bytes.as_ptr(), bytes.len()) {
+			Ok(guard) => Some(guard),
+			Err(e) => {
+				log::warn!("Failed to lock memory page with a Secret: {}", e);
+				None
+			}
+		};
 		Self { mlock_guard, inner }
 	}
 

--- a/parity-crypto/src/publickey/secret_key.rs
+++ b/parity-crypto/src/publickey/secret_key.rs
@@ -84,7 +84,8 @@ impl Secret {
 	pub fn copy_from_str(s: &str) -> Result<Self, Error> {
 		let mut h = H256::from_str(s).map_err(|e| Error::Custom(format!("{:?}", e)))?;
 		let mut me = Self::zero();
-		me.inner.as_bytes_mut().swap_with_slice(h.as_bytes_mut());
+		me.inner.as_bytes_mut().copy_from_slice(h.as_bytes());
+		h.0.zeroize();
 		Ok(me)
 	}
 
@@ -266,7 +267,8 @@ impl From<[u8; 32]> for Secret {
 	fn from(mut k: [u8; 32]) -> Self {
 		let mut me = Self::zero();
 		let mut secret = H256(k);
-		me.inner.as_bytes_mut().swap_with_slice(secret.as_bytes_mut());
+		me.inner.as_bytes_mut().copy_from_slice(secret.as_bytes());
+		secret.0.zeroize();
 		k.zeroize();
 		me
 	}
@@ -276,7 +278,7 @@ impl From<H256> for Secret {
 	#[inline(always)]
 	fn from(mut s: H256) -> Self {
 		let mut me = Self::zero();
-		me.inner.as_bytes_mut().swap_with_slice(s.as_bytes_mut());
+		me.inner.as_bytes_mut().copy_from_slice(s.as_bytes());
 		s.0.zeroize();
 		me
 	}


### PR DESCRIPTION
Fixes #411.

As mentioned in our internal issue tracker, it's not clear to me how it could integrated into secrecy for two reasons:
* `secrecy::SecretBox<S>` is generic over `S` and in order to call `mlock`, we would need something like a slice. This could be potentially "solved" by introducing a trait that abstracts over a slice (e.g. `AsRef<[u8]>`), but that would limit `SecretBox` only to these types.
* it's not clear how an error on `mlock` should be propagated. In this PR we simply ignore it as this security measure is optional and the syscall may fail due to multiple reasons, e.g. on windows there is a small amount of maximal pages a process can lock by default. Also it's not guaranteed that a memory page won't be written to disk, e.g. in case of hibernation or memory starvation. 

This PR suggests a simple approach to not introduce an abstraction for it (at least for now) and ignore the errors on construction.
If you have ideas how it could be improved though, please share!

This is a non-breaking change.