### PR TITLE
parity-crypto: dependency upgrades to remove block-cipher-trait

### DIFF
--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -14,9 +14,9 @@ harness = false
 required-features = ["publickey"]
 
 [dependencies]
-aes = "0.3.2"
-aes-ctr = "0.3.0"
-block-modes = "0.3.3"
+aes = "0.4.0"
+aes-ctr = "0.4.0"
+block-modes = "0.5.0"
 digest = "0.8"
 ethereum-types = { version = "0.9.0", optional = true, path = "../ethereum-types" }
 hmac = "0.7"

--- a/parity-crypto/src/aes.rs
+++ b/parity-crypto/src/aes.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use aes::block_cipher_trait::generic_array::GenericArray;
+use aes::block_cipher::generic_array::GenericArray;
 use aes::{Aes128, Aes256};
 use aes_ctr::stream_cipher::{NewStreamCipher, SyncStreamCipher};
 use block_modes::{


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2020-0018