### PR TITLE
uint: Add checked_pow

### DIFF
--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 - Added a manual impl of `Eq` and `Hash`. [#390](https://github.com/paritytech/parity-common/pull/390)
-- Remove some unsafe code and add big-endian support. [#407](https://github.com/paritytech/parity-common/pull/407)
+- Removed some unsafe code and add big-endian support. [#407](https://github.com/paritytech/parity-common/pull/407)
+- Added `checked_pow`. [#417](https://github.com/paritytech/parity-common/pull/417)
 
 ## [0.8.3] - 2020-04-27
 - Added `arbitrary` feature. [#378](https://github.com/paritytech/parity-common/pull/378)

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -899,6 +899,14 @@ macro_rules! construct_uint {
 				(res, overflow)
 			}
 
+			/// Checked exponentiation. Returns `None` if overflow occurred.
+			pub fn checked_pow(self, expon: $name) -> Option<$name> {
+				match self.overflowing_pow(expon) {
+					(_, true) => None,
+					(val, _) => Some(val),
+				}
+			}
+
 			/// Add with overflow.
 			#[inline(always)]
 			pub fn overflowing_add(self, other: $name) -> ($name, bool) {

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -62,6 +62,7 @@ fn uint256_checked_ops() {
 	assert_eq!(U256::from(10).checked_pow(U256::from(3)), Some(U256::from(1000)));
 	assert_eq!(U256::from(10).checked_pow(U256::from(20)), Some(U256::exp10(20)));
 	assert_eq!(U256::from(2).checked_pow(U256::from(0x100)), None);
+	assert_eq!(U256::max_value().checked_pow(U256::from(2)), None);
 
 	assert_eq!(a.checked_add(b), None);
 	assert_eq!(a.checked_add(a), Some(20.into()));

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -56,8 +56,12 @@ fn uint256_checked_ops() {
 	let a = U256::from(10);
 	let b = !U256::from(1);
 
-	assert_eq!(a.checked_pow(b), None);
-	assert_eq!(a.checked_pow(z), Some(1.into()));
+	assert_eq!(U256::from(10).checked_pow(U256::from(0)), Some(U256::from(1)));
+	assert_eq!(U256::from(10).checked_pow(U256::from(1)), Some(U256::from(10)));
+	assert_eq!(U256::from(10).checked_pow(U256::from(2)), Some(U256::from(100)));
+	assert_eq!(U256::from(10).checked_pow(U256::from(3)), Some(U256::from(1000)));
+	assert_eq!(U256::from(10).checked_pow(U256::from(20)), Some(U256::exp10(20)));
+	assert_eq!(U256::from(2).checked_pow(U256::from(0x100)), None);
 
 	assert_eq!(a.checked_add(b), None);
 	assert_eq!(a.checked_add(a), Some(20.into()));
@@ -1188,6 +1192,10 @@ pub mod laws {
 				quickcheck! {
 					fn pow_mul(x: $uint_ty) -> TestResult {
 						if x.overflowing_pow($uint_ty::from(2)).1 || x.overflowing_pow($uint_ty::from(3)).1 {
+							// On overflow `checked_pow` should return `None`.
+							assert_eq!(x.checked_pow($uint_ty::from(2)), None);
+							assert_eq!(x.checked_pow($uint_ty::from(3)), None);
+
 							return TestResult::discard();
 						}
 

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -56,6 +56,9 @@ fn uint256_checked_ops() {
 	let a = U256::from(10);
 	let b = !U256::from(1);
 
+	assert_eq!(a.checked_pow(b), None);
+	assert_eq!(a.checked_pow(z), Some(1.into()));
+
 	assert_eq!(a.checked_add(b), None);
 	assert_eq!(a.checked_add(a), Some(20.into()));
 


### PR DESCRIPTION
Similar to how 025a0c1ea added `checked_{add,sub,mul,div,rem,neg}` add
`checked_pow`.

---

Would prove useful for https://github.com/libp2p/rust-libp2p/pull/1680.