### PR TITLE
kvdb-rocksdb: bump rocksdb, version, update changelog

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.9.1] - 2020-08-25
+## [0.9.1] - 2020-08-26
 - Updated rocksdb to 0.15. [#424](https://github.com/paritytech/parity-common/pull/424)
 - Set `format_version` to 5. [#395](https://github.com/paritytech/parity-common/pull/395) 
 

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.1] - 2020-08-25
+- Updated rocksdb to 0.15. [#424](https://github.com/paritytech/parity-common/pull/424)
+- Set `format_version` to 5. [#395](https://github.com/paritytech/parity-common/pull/395) 
+
 ## [0.9.0] - 2020-06-24
 - Updated `kvdb` to 0.7. [#402](https://github.com/paritytech/parity-common/pull/402)
 

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by RocksDB"
@@ -19,7 +19,7 @@ log = "0.4.8"
 num_cpus = "1.10.1"
 parking_lot = "0.10.0"
 regex = "1.3.1"
-rocksdb = { version = "0.14", features = ["snappy"], default-features = false }
+rocksdb = { version = "0.15", features = ["snappy"], default-features = false }
 owning_ref = "0.4.0"
 parity-util-mem = { path = "../parity-util-mem", version = "0.7", default-features = false, features = ["std", "smallvec"] }
 


### PR DESCRIPTION
We don't expose any of rocksdb types, so I believe this change (and #395) is non-breaking.