### PR TITLE
Support for tlp decodable with removed leading zeros

### DIFF
--- a/primitive-types/impls/rlp/src/lib.rs
+++ b/primitive-types/impls/rlp/src/lib.rs
@@ -58,7 +58,11 @@ macro_rules! impl_fixed_hash_rlp {
 		impl $crate::rlp::Decodable for $name {
 			fn decode(rlp: &$crate::rlp::Rlp) -> Result<Self, $crate::rlp::DecoderError> {
 				rlp.decoder().decode_value(|bytes| match bytes.len().cmp(&$size) {
-					$crate::core_::cmp::Ordering::Less => Err($crate::rlp::DecoderError::RlpIsTooShort),
+					$crate::core_::cmp::Ordering::Less => {
+						let mut t = [0u8; $size];
+						t[$size - bytes.len()..$size].copy_from_slice(bytes);
+						Ok($name(t))
+					},
 					$crate::core_::cmp::Ordering::Greater => Err($crate::rlp::DecoderError::RlpIsTooBig),
 					$crate::core_::cmp::Ordering::Equal => {
 						let mut t = [0u8; $size];

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -9,7 +9,7 @@
 use core::{cmp, fmt};
 
 use hex_literal::hex;
-use primitive_types::{H160, U256};
+use primitive_types::{H160, U256, H256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
 #[test]
@@ -608,4 +608,11 @@ fn test_list_at() {
 	let _rlp1 = rlp.at(1).unwrap();
 	let rlp2 = rlp.at(2).unwrap();
 	assert_eq!(rlp2.val_at::<u16>(2).unwrap(), 33338);
+}
+
+#[test]
+fn test_trimmed_address() {
+	let raw = hex!("f86582033280831000009430a5e0cbe6729895f4188000b4ec61f8a659d2d6843b9aca008079a0777431d65e1f74adfe7b06598f8ec36de82328673874b4431eb0d94edc06b3aa9f92849d2cc6b3cc436b4162af737ef245ae50c7e31e5acd707947085f88d465");
+	let rlp = Rlp::new(&raw);
+	assert_eq!(rlp.val_at::<H256>(8).unwrap(), H256::from(hex!("0092849d2cc6b3cc436b4162af737ef245ae50c7e31e5acd707947085f88d465")));
 }


### PR DESCRIPTION
It adds support for RLP encoded values of expected length (like H256) trimmed of their leading zeros.