### PR TITLE
primitive-types 0.7.3

### DIFF
--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.7.3] - 2020-11-12
+- Added `scale_info` support. [#312](https://github.com/paritytech/parity-common/pull/312)
+- Added `H128` type. [#434](https://github.com/paritytech/parity-common/pull/434)
+- Added `fp-conversion` feature: `U256` <-> `f64`. [#436](https://github.com/paritytech/parity-common/pull/436)
+
 ## [0.7.2] - 2020-05-05
 - Added `serde_no_std` feature. [#385](https://github.com/paritytech/parity-common/pull/385)
 

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -13,7 +13,7 @@ uint = { version = "0.8.3", path = "../uint", default-features = false }
 impl-serde = { version = "0.3.1", path = "impls/serde", default-features = false, optional = true }
 impl-codec = { version = "0.4.1", path = "impls/codec", default-features = false, optional = true }
 impl-rlp = { version = "0.2", path = "impls/rlp", default-features = false, optional = true }
-scale-info = { version = "0.2", features = ["derive"], default-features = false, optional = true }
+scale-info = { version = "0.4", features = ["derive"], default-features = false, optional = true }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Also updated `scale-info` to 0.4.

