### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    labels: ["A2-insubstantial", "M5-dependencies"]
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
to keep our rust dependencies up-to-date.