### PR TITLE
rlp: Use BytesMut for RlpStream's backing buffer 

### DIFF
--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
+bytes = "0.6"
 rustc-hex = { version = "2.0.1", default-features = false }
 
 [dev-dependencies]

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.6"
+bytes = { version = "0.6", default-features = false }
 rustc-hex = { version = "2.0.1", default-features = false }
 
 [dev-dependencies]
@@ -18,7 +18,7 @@ primitive-types = { path = "../primitive-types", version = "0.7", features = ["i
 
 [features]
 default = ["std"]
-std = ["rustc-hex/std"]
+std = ["bytes/std", "rustc-hex/std"]
 
 [[bench]]
 name = "rlp"

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -45,12 +45,15 @@ mod traits;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use bytes::BytesMut;
 use core::borrow::Borrow;
 
-pub use self::error::DecoderError;
-pub use self::rlpin::{PayloadInfo, Prototype, Rlp, RlpIterator};
-pub use self::stream::RlpStream;
-pub use self::traits::{Decodable, Encodable};
+pub use self::{
+	error::DecoderError,
+	rlpin::{PayloadInfo, Prototype, Rlp, RlpIterator},
+	stream::RlpStream,
+	traits::{Decodable, Encodable},
+};
 
 /// The RLP encoded empty data (used to mean "null value").
 pub const NULL_RLP: [u8; 1] = [0x80; 1];
@@ -87,21 +90,21 @@ where
 /// let out = rlp::encode(&animal);
 /// assert_eq!(out, vec![0x83, b'c', b'a', b't']);
 /// ```
-pub fn encode<E>(object: &E) -> Vec<u8>
+pub fn encode<E>(object: &E) -> BytesMut
 where
 	E: Encodable,
 {
 	let mut stream = RlpStream::new();
 	stream.append(object);
-	stream.drain()
+	stream.out()
 }
 
-pub fn encode_list<E, K>(object: &[K]) -> Vec<u8>
+pub fn encode_list<E, K>(object: &[K]) -> BytesMut
 where
 	E: Encodable,
 	K: Borrow<E>,
 {
 	let mut stream = RlpStream::new();
 	stream.append_list(object);
-	stream.drain()
+	stream.out()
 }

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -8,7 +8,7 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use bytes::BufMut;
+use bytes::{BufMut, BytesMut};
 use core::borrow::Borrow;
 
 use crate::traits::Encodable;
@@ -29,7 +29,7 @@ impl ListInfo {
 /// Appendable rlp encoder.
 pub struct RlpStream {
 	unfinished_lists: Vec<ListInfo>,
-	buffer: Vec<u8>,
+	buffer: BytesMut,
 	finished_list: bool,
 }
 
@@ -42,7 +42,7 @@ impl Default for RlpStream {
 impl RlpStream {
 	/// Initializes instance of empty `Stream`.
 	pub fn new() -> Self {
-		RlpStream { unfinished_lists: Vec::with_capacity(16), buffer: Vec::with_capacity(1024), finished_list: false }
+		RlpStream { unfinished_lists: Vec::with_capacity(16), buffer: BytesMut::new(), finished_list: false }
 	}
 
 	/// Initializes the `Stream` as a list.
@@ -271,7 +271,7 @@ impl RlpStream {
 	/// Streams out encoded bytes.
 	///
 	/// panic! if stream is not finished.
-	pub fn out(self) -> Vec<u8> {
+	pub fn out(self) -> BytesMut {
 		if self.is_finished() {
 			self.buffer
 		} else {
@@ -330,7 +330,7 @@ impl RlpStream {
 }
 
 pub struct BasicEncoder<'a> {
-	buffer: &'a mut Vec<u8>,
+	buffer: &'a mut BytesMut,
 }
 
 impl<'a> BasicEncoder<'a> {

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -52,6 +52,18 @@ impl RlpStream {
 		stream
 	}
 
+	/// Initializes instance of empty `Stream`.
+	pub fn new_with_buffer(buffer: BytesMut) -> Self {
+		RlpStream { unfinished_lists: Vec::with_capacity(16), buffer, finished_list: false }
+	}
+
+	/// Initializes the `Stream` as a list.
+	pub fn new_list_with_buffer(buffer: BytesMut, len: usize) -> Self {
+		let mut stream = RlpStream::new_with_buffer(buffer);
+		stream.begin_list(len);
+		stream
+	}
+
 	/// Apends null to the end of stream, chainable.
 	///
 	/// ```

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -72,11 +72,6 @@ impl RlpStream {
 		self
 	}
 
-	/// Drain the object and return the underlying ElasticArray. Panics if it is not finished.
-	pub fn drain(self) -> Vec<u8> {
-		self.out()
-	}
-
 	/// Appends raw (pre-serialised) RLP data. Use with caution. Chainable.
 	pub fn append_raw(&mut self, bytes: &[u8], item_count: usize) -> &mut Self {
 		// push raw items

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -42,14 +42,12 @@ impl Default for RlpStream {
 impl RlpStream {
 	/// Initializes instance of empty `Stream`.
 	pub fn new() -> Self {
-		RlpStream { unfinished_lists: Vec::with_capacity(16), buffer: BytesMut::new(), finished_list: false }
+		Self::new_with_buffer(BytesMut::with_capacity(1024))
 	}
 
 	/// Initializes the `Stream` as a list.
 	pub fn new_list(len: usize) -> Self {
-		let mut stream = RlpStream::new();
-		stream.begin_list(len);
-		stream
+		Self::new_list_with_buffer(BytesMut::with_capacity(1024), len)
 	}
 
 	/// Initializes instance of empty `Stream`.

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -321,12 +321,6 @@ impl RlpStream {
 		self.note_appended(1);
 		self.finished_list = true;
 	}
-
-	/// Finalize current unbounded list. Panics if no unbounded list has been opened.
-	#[deprecated(since = "0.4.3", note = "use finalize_unbounded_list instead")]
-	pub fn complete_unbounded_list(&mut self) {
-		self.finalize_unbounded_list();
-	}
 }
 
 pub struct BasicEncoder<'a> {

--- a/rlp/src/traits.rs
+++ b/rlp/src/traits.rs
@@ -9,10 +9,9 @@
 //! Common RLP traits
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use bytes::BytesMut;
 
-use crate::error::DecoderError;
-use crate::rlpin::Rlp;
-use crate::stream::RlpStream;
+use crate::{error::DecoderError, rlpin::Rlp, stream::RlpStream};
 
 /// RLP decodable trait
 pub trait Decodable: Sized {
@@ -26,9 +25,9 @@ pub trait Encodable {
 	fn rlp_append(&self, s: &mut RlpStream);
 
 	/// Get rlp-encoded bytes for this instance
-	fn rlp_bytes(&self) -> Vec<u8> {
+	fn rlp_bytes(&self) -> BytesMut {
 		let mut s = RlpStream::new();
 		self.rlp_append(&mut s);
-		s.drain()
+		s.out()
 	}
 }

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -234,7 +234,7 @@ fn encode_into_existing_buffer() {
 	let mut buffer = BytesMut::new();
 	buffer.extend_from_slice(b"junk");
 
-	let mut s = RlpStream::new_with_buffer(buffer.split());
+	let mut s = RlpStream::new_with_buffer(buffer.split_off(buffer.len()));
 	s.append(&"cat");
 	buffer.unsplit(s.out());
 

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -8,6 +8,7 @@
 
 use core::{cmp, fmt};
 
+use bytes::BytesMut;
 use hex_literal::hex;
 use primitive_types::{H160, U256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
@@ -226,6 +227,18 @@ fn encode_str() {
 		),
 	];
 	run_encode_tests(tests);
+}
+
+#[test]
+fn encode_into_existing_buffer() {
+	let mut buffer = BytesMut::new();
+	buffer.extend_from_slice(b"junk");
+
+	let mut s = RlpStream::new_with_buffer(buffer.split());
+	s.append(&"cat");
+	buffer.unsplit(s.out());
+
+	assert_eq!(&buffer[..], &[b'j', b'u', b'n', b'k', 0x83, b'c', b'a', b't']);
 }
 
 #[test]

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -480,7 +480,7 @@ fn test_rlp_nested_empty_list_encode() {
 	let mut stream = RlpStream::new_list(2);
 	stream.append_list(&(Vec::new() as Vec<u32>));
 	stream.append(&40u32);
-	assert_eq!(stream.drain()[..], [0xc2u8, 0xc0u8, 40u8][..]);
+	assert_eq!(stream.out()[..], [0xc2u8, 0xc0u8, 40u8][..]);
 }
 
 #[test]
@@ -497,7 +497,7 @@ fn test_rlp_stream_size_limit() {
 		let item = [0u8; 1];
 		let mut stream = RlpStream::new();
 		while stream.append_raw_checked(&item, 1, limit) {}
-		assert_eq!(stream.drain().len(), limit);
+		assert_eq!(stream.out().len(), limit);
 	}
 }
 


### PR DESCRIPTION
While profiling rust-devp2p, I've noticed that a noticeable portion of allocations comes from `rlp`. I suspect that this comes from rlp allocating byte buffer for each `RlpStream` - even though it is really a mere writer.

This PR switches `RlpStream` to accept user-provided `bytes::BytesMut` as internal buffer.
* In my case (building RLPx packets) this allows for completely reusing `BytesMut` provided by `tokio`'s Framed, for potentially zero allocations for each packet.
* `bytes` is a pretty established crate at this point. It is no_std ready and is used all across Tokio ecosystem - from Tokio itself all the way to hyper.