### PR TITLE
The time crate after 0.2 is unergonomic to use; just use chrono

### DIFF
--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -33,4 +33,4 @@ tempdir = "0.3.7"
 keccak-hash = { path = "../keccak-hash" }
 sysinfo = "0.15.3"
 ctrlc = "3.1.4"
-time = "0.1"
+chrono = "0.4"

--- a/kvdb-rocksdb/examples/memtest.rs
+++ b/kvdb-rocksdb/examples/memtest.rs
@@ -136,7 +136,7 @@ fn main() {
 		keyvalues = KeyValueSeed::with_seed(seed);
 
 		if step % 10000 == 9999 {
-			let timestamp = time::strftime("%Y-%m-%d %H:%M:%S", &time::now()).expect("Error formatting log timestamp");
+			let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
 
 			println!("{}", timestamp);
 			println!("\tData written: {} keys - {} Mb", step + 1, ((step + 1) * 64 * 128) / 1024 / 1024);


### PR DESCRIPTION
The 0.2 series of `time` doesn't make it easy to "just" create a timestamp. The `chrono` crate uses `time` v0.1 and is, I believe, what users like us should be using. So let's just do that.

Supersedes  #455 