### PR TITLE
rlp: Fix buffer indexing

### DIFF
--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -234,11 +234,23 @@ fn encode_into_existing_buffer() {
 	let mut buffer = BytesMut::new();
 	buffer.extend_from_slice(b"junk");
 
-	let mut s = RlpStream::new_with_buffer(buffer.split_off(buffer.len()));
+	let mut split_buffer = buffer.split_off(buffer.len());
+	split_buffer.extend_from_slice(b"!");
+
+	let mut s = RlpStream::new_with_buffer(split_buffer);
 	s.append(&"cat");
 	buffer.unsplit(s.out());
 
-	assert_eq!(&buffer[..], &[b'j', b'u', b'n', b'k', 0x83, b'c', b'a', b't']);
+	buffer.extend_from_slice(b" and ");
+
+	let mut s = RlpStream::new_with_buffer(buffer);
+	s.append(&"dog");
+	let buffer = s.out();
+
+	assert_eq!(
+		&buffer[..],
+		&[b'j', b'u', b'n', b'k', b'!', 0x83, b'c', b'a', b't', b' ', b'a', b'n', b'd', b' ', 0x83, b'd', b'o', b'g']
+	);
 }
 
 #[test]

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -319,6 +319,19 @@ fn encode_vector_str() {
 	run_encode_tests_list(tests);
 }
 
+#[test]
+fn clear() {
+	let mut buffer = BytesMut::new();
+	buffer.extend_from_slice(b"junk");
+
+	let mut s = RlpStream::new_with_buffer(buffer);
+	s.append(&"parrot");
+	s.clear();
+	s.append(&"cat");
+
+	assert_eq!(&s.out()[..], &[b'j', b'u', b'n', b'k', 0x83, b'c', b'a', b't']);
+}
+
 struct DTestPair<T>(T, Vec<u8>)
 where
 	T: Decodable + fmt::Debug + cmp::Eq;


### PR DESCRIPTION
Users can provide their own buffer now - we must assume that buffers start with arbitrary length.