### PR TITLE
bump versions and update changelogs

### DIFF
--- a/contract-address/CHANGELOG.md
+++ b/contract-address/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Updated `ethereum-types` to 0.10. [#463](https://github.com/paritytech/parity-common/pull/463)
 
 ## [0.9.0] - 2020-03-16
 - License changed from MIT to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)

--- a/contract-address/Cargo.toml
+++ b/contract-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-address"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -11,8 +11,8 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-ethereum-types = { version = "0.9.0", path = "../ethereum-types" }
-rlp = { version = "0.4", path = "../rlp" }
+ethereum-types = { version = "0.10.0", path = "../ethereum-types" }
+rlp = { version = "0.5", path = "../rlp" }
 keccak-hash = { version = "0.5", path = "../keccak-hash", default-features = false }
 
 [features]

--- a/ethbloom/CHANGELOG.md
+++ b/ethbloom/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Updated `rlp` to 0.5. [#463](https://github.com/paritytech/parity-common/pull/463)
 
 ## [0.9.2] - 2020-05-18
 - Added `codec` feature. [#393](https://github.com/paritytech/parity-common/pull/393)

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 crunchy = { version = "0.2.2", default-features = false, features = ["limit_256"] }
 fixed-hash = { path = "../fixed-hash", version = "0.6", default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3", default-features = false, optional = true }
-impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
+impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.3", default-features = false }
 impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/ethereum-types/CHANGELOG.md
+++ b/ethereum-types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Updated `rlp` to 0.5. [#463](https://github.com/paritytech/parity-common/pull/463)
 
 ## [0.9.2] - 2020-05-18
 - Added `codec` feature. [#393](https://github.com/paritytech/parity-common/pull/393)

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -8,12 +8,12 @@ description = "Ethereum types"
 edition = "2018"
 
 [dependencies]
-ethbloom = { path = "../ethbloom", version = "0.9", default-features = false }
+ethbloom = { path = "../ethbloom", version = "0.10", default-features = false }
 fixed-hash = { path = "../fixed-hash", version = "0.6", default-features = false, features = ["byteorder", "rustc-hex"] }
 uint-crate = { path = "../uint", package = "uint", version = "0.8", default-features = false }
-primitive-types = { path = "../primitive-types", version = "0.7", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.8", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3.0", default-features = false, optional = true }
-impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
+impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.3", default-features = false }
 impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/keccak-hash/CHANGELOG.md
+++ b/keccak-hash/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Updated `primitive-types` to 0.8. [#463](https://github.com/paritytech/parity-common/pull/463)
 
 ## [0.5.1] - 2020-04-10
 - Added `keccak256_range` and `keccak512_range` functions. [#370](https://github.com/paritytech/parity-common/pull/370)

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 tiny-keccak = { version = "2.0", features = ["keccak"] }
-primitive-types = { path = "../primitive-types", version = "0.7", default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.8", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/parity-crypto/CHANGELOG.md
+++ b/parity-crypto/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-- Bump `rust-secp256k1` to v0.19, remove infrastructure for handling zero signatures (breaking). [#438](https://github.com/paritytech/parity-common/pull/438)
+### Breaking
+- Bump `rust-secp256k1` to v0.19, always allow zero signatures. [#438](https://github.com/paritytech/parity-common/pull/438)
+- Updated `rlp` to 0.5. [#463](https://github.com/paritytech/parity-common/pull/463)
 
 ## [0.6.2] - 2020-06-19
 - Put `Secret` memory on heap. [#400](https://github.com/paritytech/parity-common/pull/400)
@@ -14,7 +16,7 @@ The format is based on [Keep a Changelog].
 
 ## [0.6.1] - 2020-04-11
 - Add `recover_allowing_all_zero_message()` and `ZeroesAllowedMessage` to accomodate ethereum's `ecrecover` builtin. [#369](https://github.com/paritytech/parity-common/pull/369)
- 
+
 ## [0.6.0] - 2020-03-16
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 - Updated dependencies. [#361](https://github.com/paritytech/parity-common/pull/361)

--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-crypto"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Crypto utils used by ethstore and network."
@@ -18,7 +18,7 @@ aes = "0.4.0"
 aes-ctr = "0.4.0"
 block-modes = "0.5.0"
 digest = "0.8"
-ethereum-types = { version = "0.9.0", optional = true, path = "../ethereum-types" }
+ethereum-types = { version = "0.10.0", optional = true, path = "../ethereum-types" }
 hmac = "0.7"
 lazy_static = { version = "1.0", optional = true }
 pbkdf2 = "0.3.0"

--- a/parity-util-mem/CHANGELOG.md
+++ b/parity-util-mem/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 - Updated dlmalloc to 0.2.1. [#452](https://github.com/paritytech/parity-common/pull/452)
+### Breaking
+- Updated `ethereum-types` to 0.10. [#463](https://github.com/paritytech/parity-common/pull/463)
 
 ## [0.7.0] - 2020-06-24
 - Added `const_size` to `MallocSizeOf` to optimize it for flat collections. [#398](https://github.com/paritytech/parity-common/pull/398)

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -26,9 +26,9 @@ parity-util-mem-derive = { path = "derive", version = "0.1" }
 impl-trait-for-tuples = "0.1.3"
 
 smallvec = { version = "1.0.0", optional = true }
-ethereum-types = { version = "0.9.0", optional = true, path = "../ethereum-types" }
+ethereum-types = { version = "0.10.0", optional = true, path = "../ethereum-types" }
 parking_lot = { version = "0.10.0", optional = true }
-primitive-types = { version = "0.7", path = "../primitive-types", default-features = false, optional = true }
+primitive-types = { version = "0.8", path = "../primitive-types", default-features = false, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", features = ["heapapi"] }

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Updated `impl-rlp` to `rlp` 0.5. [#463](https://github.com/paritytech/parity-common/pull/463)
 
 ## [0.7.3] - 2020-11-12
 - Added `scale_info` support. [#312](https://github.com/paritytech/parity-common/pull/312)

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.7.3"
+version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -12,7 +12,7 @@ fixed-hash = { version = "0.6", path = "../fixed-hash", default-features = false
 uint = { version = "0.8.3", path = "../uint", default-features = false }
 impl-serde = { version = "0.3.1", path = "impls/serde", default-features = false, optional = true }
 impl-codec = { version = "0.4.1", path = "impls/codec", default-features = false, optional = true }
-impl-rlp = { version = "0.2", path = "impls/rlp", default-features = false, optional = true }
+impl-rlp = { version = "0.3", path = "impls/rlp", default-features = false, optional = true }
 scale-info = { version = "0.4", features = ["derive"], default-features = false, optional = true }
 
 [features]

--- a/primitive-types/impls/rlp/CHANGELOG.md
+++ b/primitive-types/impls/rlp/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Updated `rlp` to 0.5. [#463](https://github.com/paritytech/parity-common/pull/463)

--- a/primitive-types/impls/rlp/Cargo.toml
+++ b/primitive-types/impls/rlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-rlp"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -8,7 +8,7 @@ description = "RLP serialization support for uint and fixed hash."
 edition = "2018"
 
 [dependencies]
-rlp = { version = "0.4", path = "../../../rlp", default-features = false }
+rlp = { version = "0.5", path = "../../../rlp", default-features = false }
 
 [features]
 default = ["std"]

--- a/rlp/CHANGELOG.md
+++ b/rlp/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Use BytesMut for `RlpStream`'s backing buffer. [#453](https://github.com/paritytech/parity-common/pull/453)
 
 ## [0.4.6] - 2020-09-29
 - Implement Encodable, Decodable for boxed types. [#427](https://github.com/paritytech/parity-common/pull/427)

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlp"
-version = "0.4.6"
+version = "0.5.0"
 description = "Recursive-length prefix encoding, decoding, and compression"
 repository = "https://github.com/paritytech/parity-common"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ rustc-hex = { version = "2.0.1", default-features = false }
 [dev-dependencies]
 criterion = "0.3.0"
 hex-literal = "0.3.1"
-primitive-types = { path = "../primitive-types", version = "0.7", features = ["impl-rlp"] }
+primitive-types = { path = "../primitive-types", version = "0.8", features = ["impl-rlp"] }
 
 [features]
 default = ["std"]

--- a/transaction-pool/Cargo.toml
+++ b/transaction-pool/Cargo.toml
@@ -13,4 +13,4 @@ smallvec = "0.6.10"
 trace-time = { path = "../trace-time", version = "0.1" }
 
 [dev-dependencies]
-ethereum-types = { version = "0.9.0", path = "../ethereum-types" }
+ethereum-types = { version = "0.10.0", path = "../ethereum-types" }

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2018"
 
 [dependencies]
 hash-db = { version = "0.15.2", default-features = false }
-rlp = { version = "0.4", path = "../rlp", default-features = false }
+rlp = { version = "0.5", path = "../rlp", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"
 keccak-hasher = "0.15.2"
-ethereum-types = { version = "0.9.0", path = "../ethereum-types" }
+ethereum-types = { version = "0.10.0", path = "../ethereum-types" }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 trie-standardmap = "0.15.2"
 hex-literal = "0.3.1"


### PR DESCRIPTION
Unfortunately `rlp` version bump is very contagious and even spreads to `parity-util-mem`, which will trigger another round of version bumps (left for another PR that will also update other dependencies of it).