### PR TITLE
Make RLP optional in several crates

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -14,7 +14,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 crunchy = { version = "0.2.2", default-features = false, features = ["limit_256"] }
 fixed-hash = { path = "../fixed-hash", version = "0.6", default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3", default-features = false, optional = true }
-impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
+impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false, optional = true }
 impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -23,11 +23,12 @@ rand = "0.7.2"
 hex-literal = "0.3.1"
 
 [features]
-default = ["std", "serialize", "rustc-hex"]
+default = ["std", "rlp", "serialize", "rustc-hex"]
 std = ["fixed-hash/std", "crunchy/std"]
 serialize = ["std", "impl-serde"]
 rustc-hex = ["fixed-hash/rustc-hex"]
 arbitrary = ["fixed-hash/arbitrary"]
+rlp = ["impl-rlp"]
 codec = ["impl-codec"]
 
 [[bench]]

--- a/ethbloom/src/lib.rs
+++ b/ethbloom/src/lib.rs
@@ -56,6 +56,7 @@ use crunchy::unroll;
 use fixed_hash::*;
 #[cfg(feature = "codec")]
 use impl_codec::impl_fixed_hash_codec;
+#[cfg(feature = "rlp")]
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
@@ -69,6 +70,7 @@ construct_fixed_hash! {
 	/// Bloom hash type with 256 bytes (2048 bits) size.
 	pub struct Bloom(BLOOM_SIZE);
 }
+#[cfg(feature = "rlp")]
 impl_fixed_hash_rlp!(Bloom, BLOOM_SIZE);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(Bloom, BLOOM_SIZE);

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -11,17 +11,18 @@ edition = "2018"
 ethbloom = { path = "../ethbloom", version = "0.9", default-features = false }
 fixed-hash = { path = "../fixed-hash", version = "0.6", default-features = false, features = ["byteorder", "rustc-hex"] }
 uint-crate = { path = "../uint", package = "uint", version = "0.8", default-features = false }
-primitive-types = { path = "../primitive-types", version = "0.7", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.7", features = ["byteorder", "rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3.0", default-features = false, optional = true }
-impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
+impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false, optional = true }
 impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.41"
 
 [features]
-default = ["std", "serialize"]
+default = ["std", "rlp", "serialize"]
 std = ["uint-crate/std", "fixed-hash/std", "ethbloom/std", "primitive-types/std"]
 serialize = ["std", "impl-serde", "primitive-types/serde", "ethbloom/serialize"]
 arbitrary = ["ethbloom/arbitrary", "fixed-hash/arbitrary", "uint-crate/arbitrary"]
+rlp = ["impl-rlp", "ethbloom/rlp"]
 codec = ["impl-codec", "ethbloom/codec"]

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -10,6 +10,7 @@ use crate::{U128, U256, U512, U64};
 use fixed_hash::*;
 #[cfg(feature = "codec")]
 use impl_codec::impl_fixed_hash_codec;
+#[cfg(feature = "rlp")]
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
@@ -22,6 +23,7 @@ pub trait BigEndianHash {
 }
 
 construct_fixed_hash! { pub struct H32(4); }
+#[cfg(feature = "rlp")]
 impl_fixed_hash_rlp!(H32, 4);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H32, 4);
@@ -29,6 +31,7 @@ impl_fixed_hash_serde!(H32, 4);
 impl_fixed_hash_codec!(H32, 4);
 
 construct_fixed_hash! { pub struct H64(8); }
+#[cfg(feature = "rlp")]
 impl_fixed_hash_rlp!(H64, 8);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H64, 8);
@@ -36,6 +39,7 @@ impl_fixed_hash_serde!(H64, 8);
 impl_fixed_hash_codec!(H64, 8);
 
 construct_fixed_hash! { pub struct H128(16); }
+#[cfg(feature = "rlp")]
 impl_fixed_hash_rlp!(H128, 16);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H128, 16);
@@ -46,6 +50,7 @@ pub use primitive_types::H160;
 pub use primitive_types::H256;
 
 construct_fixed_hash! { pub struct H264(33); }
+#[cfg(feature = "rlp")]
 impl_fixed_hash_rlp!(H264, 33);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H264, 33);
@@ -55,6 +60,7 @@ impl_fixed_hash_codec!(H264, 33);
 pub use primitive_types::H512;
 
 construct_fixed_hash! { pub struct H520(65); }
+#[cfg(feature = "rlp")]
 impl_fixed_hash_rlp!(H520, 65);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H520, 65);

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -8,6 +8,7 @@
 
 #[cfg(feature = "codec")]
 use impl_codec::impl_uint_codec;
+#[cfg(feature = "rlp")]
 use impl_rlp::impl_uint_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_uint_serde;
@@ -19,6 +20,7 @@ construct_uint! {
 	/// Unsigned 64-bit integer.
 	pub struct U64(1);
 }
+#[cfg(feature = "rlp")]
 impl_uint_rlp!(U64, 1);
 #[cfg(feature = "serialize")]
 impl_uint_serde!(U64, 1);


### PR DESCRIPTION
For symmetry with serde and SCALE impls. Also, RLP is on its way out of Ethereum, so for future-proofing as well.