### PR TITLE
Remove U64 and U128

### DIFF
--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{U128, U256, U512, U64};
+use crate::{U256, U512};
 use fixed_hash::*;
 #[cfg(feature = "codec")]
 use impl_codec::impl_fixed_hash_codec;
@@ -67,6 +67,22 @@ impl_fixed_hash_serde!(H520, 65);
 #[cfg(feature = "codec")]
 impl_fixed_hash_codec!(H520, 65);
 
+macro_rules! impl_core_uint_conversions {
+	($hash: ident, $uint: ident) => {
+		impl BigEndianHash for $hash {
+			type Uint = $uint;
+
+			fn from_uint(value: &$uint) -> Self {
+				$hash(value.to_be_bytes())
+			}
+
+			fn into_uint(&self) -> $uint {
+				$uint::from_be_bytes(self.0)
+			}
+		}
+	};
+}
+
 macro_rules! impl_uint_conversions {
 	($hash: ident, $uint: ident) => {
 		impl BigEndianHash for $hash {
@@ -85,8 +101,8 @@ macro_rules! impl_uint_conversions {
 	};
 }
 
-impl_uint_conversions!(H64, U64);
-impl_uint_conversions!(H128, U128);
+impl_core_uint_conversions!(H64, u64);
+impl_core_uint_conversions!(H128, u128);
 impl_uint_conversions!(H256, U256);
 impl_uint_conversions!(H512, U512);
 

--- a/ethereum-types/src/lib.rs
+++ b/ethereum-types/src/lib.rs
@@ -15,7 +15,7 @@ pub use ethbloom::{Bloom, BloomRef, Input as BloomInput};
 pub use hash::{BigEndianHash, H128, H160, H256, H264, H32, H512, H520, H64};
 #[cfg(feature = "num-traits")]
 pub use primitive_types::{FromStrRadixErr, FromStrRadixErrKind};
-pub use uint::{FromDecStrErr, U128, U256, U512, U64};
+pub use uint::{FromDecStrErr, U256, U512};
 
 pub type Address = H160;
 pub type Secret = H256;

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -16,18 +16,7 @@ use uint_crate::*;
 
 pub use uint_crate::FromDecStrErr;
 
-construct_uint! {
-	/// Unsigned 64-bit integer.
-	pub struct U64(1);
-}
-#[cfg(feature = "rlp")]
-impl_uint_rlp!(U64, 1);
-#[cfg(feature = "serialize")]
-impl_uint_serde!(U64, 1);
-#[cfg(feature = "codec")]
-impl_uint_codec!(U64, 1);
-
-pub use primitive_types::{U128, U256, U512};
+pub use primitive_types::{U256, U512};
 
 #[cfg(test)]
 mod tests {

--- a/parity-util-mem/src/ethereum_impls.rs
+++ b/parity-util-mem/src/ethereum_impls.rs
@@ -9,6 +9,6 @@
 //! Implementation of `MallocSize` for common ethereum types: fixed hashes
 //! and uints.
 
-use ethereum_types::{Bloom, H128, H264, H32, H520, H64, U64};
+use ethereum_types::{Bloom, H128, H264, H32, H520, H64};
 
-malloc_size_of_is_0!(U64, H32, H64, H128, H264, H520, Bloom);
+malloc_size_of_is_0!(H32, H64, H128, H264, H520, Bloom);

--- a/parity-util-mem/src/primitives_impls.rs
+++ b/parity-util-mem/src/primitives_impls.rs
@@ -8,9 +8,9 @@
 
 //! Implementation of `MallocSize` primitive types.
 
-use primitive_types::{H160, H256, H512, U128, U256, U512};
+use primitive_types::{H160, H256, H512, U256, U512};
 
-malloc_size_of_is_0!(U128, U256, U512, H160, H256, H512);
+malloc_size_of_is_0!(U256, U512, H160, H256, H512);
 
 #[cfg(test)]
 mod tests {

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -32,11 +32,6 @@ pub enum Error {
 }
 
 construct_uint! {
-	/// 128-bit unsigned integer.
-	#[cfg_attr(feature = "scale-info", derive(TypeInfo))]
-	pub struct U128(2);
-}
-construct_uint! {
 	/// 256-bit unsigned integer.
 	#[cfg_attr(feature = "scale-info", derive(TypeInfo))]
 	pub struct U256(4);
@@ -84,7 +79,6 @@ mod serde {
 	use super::*;
 	use impl_serde::{impl_fixed_hash_serde, impl_uint_serde};
 
-	impl_uint_serde!(U128, 2);
 	impl_uint_serde!(U256, 4);
 	impl_uint_serde!(U512, 8);
 
@@ -99,7 +93,6 @@ mod codec {
 	use super::*;
 	use impl_codec::{impl_fixed_hash_codec, impl_uint_codec};
 
-	impl_uint_codec!(U128, 2);
 	impl_uint_codec!(U256, 4);
 	impl_uint_codec!(U512, 8);
 
@@ -114,7 +107,6 @@ mod rlp {
 	use super::*;
 	use impl_rlp::{impl_fixed_hash_rlp, impl_uint_rlp};
 
-	impl_uint_rlp!(U128, 2);
 	impl_uint_rlp!(U256, 4);
 	impl_uint_rlp!(U512, 8);
 
@@ -147,21 +139,6 @@ impl From<U256> for U512 {
 	}
 }
 
-impl TryFrom<U256> for U128 {
-	type Error = Error;
-
-	fn try_from(value: U256) -> Result<U128, Error> {
-		let U256(ref arr) = value;
-		if arr[2] | arr[3] != 0 {
-			return Err(Error::Overflow);
-		}
-		let mut ret = [0; 2];
-		ret[0] = arr[0];
-		ret[1] = arr[1];
-		Ok(U128(ret))
-	}
-}
-
 impl TryFrom<U512> for U256 {
 	type Error = Error;
 
@@ -176,41 +153,6 @@ impl TryFrom<U512> for U256 {
 		ret[2] = arr[2];
 		ret[3] = arr[3];
 		Ok(U256(ret))
-	}
-}
-
-impl TryFrom<U512> for U128 {
-	type Error = Error;
-
-	fn try_from(value: U512) -> Result<U128, Error> {
-		let U512(ref arr) = value;
-		if arr[2] | arr[3] | arr[4] | arr[5] | arr[6] | arr[7] != 0 {
-			return Err(Error::Overflow);
-		}
-		let mut ret = [0; 2];
-		ret[0] = arr[0];
-		ret[1] = arr[1];
-		Ok(U128(ret))
-	}
-}
-
-impl From<U128> for U512 {
-	fn from(value: U128) -> U512 {
-		let U128(ref arr) = value;
-		let mut ret = [0; 8];
-		ret[0] = arr[0];
-		ret[1] = arr[1];
-		U512(ret)
-	}
-}
-
-impl From<U128> for U256 {
-	fn from(value: U128) -> U256 {
-		let U128(ref arr) = value;
-		let mut ret = [0; 4];
-		ret[0] = arr[0];
-		ret[1] = arr[1];
-		U256(ret)
 	}
 }
 


### PR DESCRIPTION
Obsoleted by `u64` and `u128` in Rust standard library.