### PR TITLE
parity-crypto: remove UB test

### DIFF
--- a/parity-crypto/src/hmac/test.rs
+++ b/parity-crypto/src/hmac/test.rs
@@ -232,21 +232,3 @@ fn ietf_test_vectors() {
 		),
 	);
 }
-
-#[test]
-fn secrets_are_zeroed_on_drop() {
-	let ptr: *const KeyInner;
-	let zeros = KeyInner::Sha256(DisposableBox::from_slice(&[0u8; 6][..]));
-	let expected = KeyInner::Sha256(DisposableBox::from_slice(b"sikrit"));
-	{
-		let secret = b"sikrit";
-		let signing_key = SigKey::sha256(secret);
-		ptr = &signing_key.0;
-		unsafe {
-			assert_eq!(*ptr, expected);
-		}
-	}
-	unsafe {
-		assert_eq!(*ptr, zeros);
-	}
-}

--- a/rlp/src/traits.rs
+++ b/rlp/src/traits.rs
@@ -7,8 +7,6 @@
 // except according to those terms.
 
 //! Common RLP traits
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use bytes::BytesMut;
 
 use crate::{error::DecoderError, rlpin::Rlp, stream::RlpStream};


### PR DESCRIPTION
Closes #472.

Since inspecting memory after drop is UB, it's better to rely on tests in zeroize and rust drop semantics instead of this test.

Also a unrelated warning fix.