### PR TITLE
fix: make from_str parse 0x-prefixed strings

### DIFF
--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -135,6 +135,11 @@ mod tests {
 	}
 
 	#[test]
+	fn test_parse_0x() {
+		assert!("0x0000000000000000000000000000000000000000000000000000000000000000".parse::<H256>().is_ok())
+	}
+
+	#[test]
 	fn test_serialize_invalid() {
 		assert!(ser::from_str::<H256>("\"0x000000000000000000000000000000000000000000000000000000000000000\"")
 			.unwrap_err()

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -588,7 +588,11 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 			/// - When encountering invalid non hex-digits
 			/// - Upon empty string input or invalid input length in general
 			fn from_str(input: &str) -> $crate::core_::result::Result<$name, $crate::rustc_hex::FromHexError> {
-				let input = if input.starts_with("0x") { &input[2..] } else { input };
+                let input = if input.starts_with("0x") {
+                    &input[2..]
+                } else {
+                    input
+                };
 				let mut iter = $crate::rustc_hex::FromHexIter::new(input);
 				let mut result = Self::zero();
 				for byte in result.as_mut() {

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -588,11 +588,11 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 			/// - When encountering invalid non hex-digits
 			/// - Upon empty string input or invalid input length in general
 			fn from_str(input: &str) -> $crate::core_::result::Result<$name, $crate::rustc_hex::FromHexError> {
-                let input = if input.starts_with("0x") {
-                    &input[2..]
-                } else {
-                    input
-                };
+				let input = if input.starts_with("0x") {
+					&input[2..]
+				} else {
+					input
+				};
 				let mut iter = $crate::rustc_hex::FromHexIter::new(input);
 				let mut result = Self::zero();
 				for byte in result.as_mut() {

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -588,11 +588,7 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 			/// - When encountering invalid non hex-digits
 			/// - Upon empty string input or invalid input length in general
 			fn from_str(input: &str) -> $crate::core_::result::Result<$name, $crate::rustc_hex::FromHexError> {
-				let input = if input.starts_with("0x") {
-					&input[2..]
-				} else {
-					input
-				};
+				let input = if input.starts_with("0x") { &input[2..] } else { input };
 				let mut iter = $crate::rustc_hex::FromHexIter::new(input);
 				let mut result = Self::zero();
 				for byte in result.as_mut() {

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -588,7 +588,7 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 			/// - When encountering invalid non hex-digits
 			/// - Upon empty string input or invalid input length in general
 			fn from_str(input: &str) -> $crate::core_::result::Result<$name, $crate::rustc_hex::FromHexError> {
-				let input = if input.starts_with("0x") { &input[2..] } else { input };
+				let input = input.strip_prefix("0x").unwrap_or(input);
 				let mut iter = $crate::rustc_hex::FromHexIter::new(input);
 				let mut result = Self::zero();
 				for byte in result.as_mut() {

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -588,6 +588,7 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
 			/// - When encountering invalid non hex-digits
 			/// - Upon empty string input or invalid input length in general
 			fn from_str(input: &str) -> $crate::core_::result::Result<$name, $crate::rustc_hex::FromHexError> {
+				let input = if input.starts_with("0x") { &input[2..] } else { input };
 				let mut iter = $crate::rustc_hex::FromHexIter::new(input);
 				let mut result = Self::zero();
 				for byte in result.as_mut() {

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1688,11 +1688,7 @@ macro_rules! construct_uint {
 			type Err = $crate::FromHexError;
 
 			fn from_str(value: &str) -> $crate::core_::result::Result<$name, Self::Err> {
-				let value = if value.starts_with("0x") {
-					&value[2..]
-				} else {
-					value
-				};
+                let value = value.strip_prefix("0x").unwrap_or(value);
 				const BYTES_LEN: usize = $n_words * 8;
 				const MAX_ENCODED_LEN: usize = BYTES_LEN * 2;
 

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1688,11 +1688,11 @@ macro_rules! construct_uint {
 			type Err = $crate::FromHexError;
 
 			fn from_str(value: &str) -> $crate::core_::result::Result<$name, Self::Err> {
-                let value = if value.starts_with("0x") {
-                    &value[2..]
-                } else {
-                    value
-                };
+				let value = if value.starts_with("0x") {
+					&value[2..]
+				} else {
+					value
+				};
 				const BYTES_LEN: usize = $n_words * 8;
 				const MAX_ENCODED_LEN: usize = BYTES_LEN * 2;
 

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1688,6 +1688,11 @@ macro_rules! construct_uint {
 			type Err = $crate::FromHexError;
 
 			fn from_str(value: &str) -> $crate::core_::result::Result<$name, Self::Err> {
+                let value = if value.starts_with("0x") {
+                    &value[2..]
+                } else {
+                    value
+                };
 				const BYTES_LEN: usize = $n_words * 8;
 				const MAX_ENCODED_LEN: usize = BYTES_LEN * 2;
 

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -132,7 +132,9 @@ fn uint256_from() {
 	);
 
 	// test initializtion from string
+	let sa2 = U256::from_str("0x0a").unwrap();
 	let sa = U256::from_str("0a").unwrap();
+	assert_eq!(sa2, sa);
 	assert_eq!(e, sa);
 	assert_eq!(U256([0, 0, 0, 0]), U256::from_str("").unwrap());
 	assert_eq!(U256([0x1, 0, 0, 0]), U256::from_str("1").unwrap());

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -132,7 +132,7 @@ fn uint256_from() {
 	);
 
 	// test initializtion from string
-    let sa = U256::from_str("0a").unwrap();
+	let sa = U256::from_str("0a").unwrap();
 	let sa2 = U256::from_str("0x0a").unwrap();
 	assert_eq!(sa2, sa);
 	assert_eq!(e, sa);

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -132,8 +132,8 @@ fn uint256_from() {
 	);
 
 	// test initializtion from string
+    let sa = U256::from_str("0a").unwrap();
 	let sa2 = U256::from_str("0x0a").unwrap();
-	let sa = U256::from_str("0a").unwrap();
 	assert_eq!(sa2, sa);
 	assert_eq!(e, sa);
 	assert_eq!(U256([0, 0, 0, 0]), U256::from_str("").unwrap());


### PR DESCRIPTION
As title

Travis' error seems unrelated
![image](https://user-images.githubusercontent.com/17802178/103205270-db6bc480-4901-11eb-99b2-cc523b33428d.png)
