### PR TITLE
triehash: patch release

### DIFF
--- a/triehash/CHANGELOG.md
+++ b/triehash/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.8.4] - 2020-01-08
+- Updated `rlp` to 0.5. [#463](https://github.com/paritytech/parity-common/pull/463)
 ## [0.8.3] - 2020-03-16
 - License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
 ## [0.8.2] - 2019-12-15

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triehash"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
This is a minor bump, because `rlp` is not exposed publicly.
It's possible to use the `triehash` 0.8.3 with `ethereum-types` 0.10, but it would be nice to deduplicate dependencies.