### PR TITLE
ethereum-types: fix wasm builds for serialize feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       rust: stable
       install:
         - cargo install cross
+        - rustup target add wasm64-unknown-unknown
       script:
         - cross test --target=aarch64-linux-android -p parity-util-mem
     - os: osx
@@ -42,6 +43,8 @@ script:
     cd contract-address/ && cargo test --features=external_doc && cd ..;
     fi
   - cd ethbloom/ && cargo test --no-default-features --features="rustc-hex" && cargo check --benches && cd ..
+  - cd ethbloom/ && cargo build --no-default-features --features="serialize,rlp,codec" --target=wasm32-unknown-unknown && cd ..
+  - cd ethereum-types/ && cargo build --no-default-features --features="serialize,rlp" --target=wasm32-unknown-unknown && cd ..
   - cd fixed-hash/ && cargo test --all-features && cargo test --no-default-features --features="byteorder,rustc-hex" && cd ..
   - cd uint/ && cargo test --all-features && cargo test --no-default-features && cd ..
   - cd keccak-hash/ && cargo test --no-default-features && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       rust: stable
       install:
         - cargo install cross
-        - rustup target add wasm64-unknown-unknown
+        - rustup target add wasm32-unknown-unknown
       script:
         - cross test --target=aarch64-linux-android -p parity-util-mem
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ script:
     cd contract-address/ && cargo test --features=external_doc && cd ..;
     fi
   - cd ethbloom/ && cargo test --no-default-features --features="rustc-hex" && cargo check --benches && cd ..
-  - cd ethbloom/ && cargo build --no-default-features --features="serialize,rlp,codec" --target=wasm32-unknown-unknown && cd ..
   - cd ethereum-types/ && cargo build --no-default-features --features="serialize,rlp" --target=wasm32-unknown-unknown && cd ..
   - cd fixed-hash/ && cargo test --all-features && cargo test --no-default-features --features="byteorder,rustc-hex" && cd ..
   - cd uint/ && cargo test --all-features && cargo test --no-default-features && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
       rust: stable
       install:
         - cargo install cross
-        - rustup target add wasm32-unknown-unknown
       script:
         - cross test --target=aarch64-linux-android -p parity-util-mem
     - os: osx
@@ -27,6 +26,7 @@ matrix:
   allow_failures:
     - rust: nightly
 install:
+  - rustup target add wasm32-unknown-unknown
   - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | sh
   - source ~/.nvm/nvm.sh
   - nvm install --lts

--- a/ethbloom/CHANGELOG.md
+++ b/ethbloom/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Potentially-breaking
+- `serialize` feature no longer pulls `std`. [#503](https://github.com/paritytech/parity-common/pull/503)
 
 ## [0.10.0] - 2021-01-05
 ### Breaking

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -25,7 +25,7 @@ hex-literal = "0.3.1"
 [features]
 default = ["std", "rlp", "serialize", "rustc-hex"]
 std = ["fixed-hash/std", "crunchy/std"]
-serialize = ["std", "impl-serde"]
+serialize = ["impl-serde"]
 rustc-hex = ["fixed-hash/rustc-hex"]
 arbitrary = ["fixed-hash/arbitrary"]
 rlp = ["impl-rlp"]

--- a/ethereum-types/CHANGELOG.md
+++ b/ethereum-types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Potentially-breaking
+- `serialize` feature no longer pulls `std`. [#503](https://github.com/paritytech/parity-common/pull/503)
 
 ## [0.10.0] - 2021-01-05
 ### Breaking

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.41"
 [features]
 default = ["std", "rlp", "serialize"]
 std = ["uint-crate/std", "fixed-hash/std", "ethbloom/std", "primitive-types/std"]
-serialize = ["std", "impl-serde", "primitive-types/serde", "ethbloom/serialize"]
+serialize = ["impl-serde", "primitive-types/serde_no_std", "ethbloom/serialize"]
 arbitrary = ["ethbloom/arbitrary", "fixed-hash/arbitrary", "uint-crate/arbitrary"]
 rlp = ["impl-rlp", "ethbloom/rlp", "primitive-types/rlp"]
 codec = ["impl-codec", "ethbloom/codec"]


### PR DESCRIPTION
~~no longer required for https://github.com/paritytech/substrate/pull/7831#issuecomment-757944213.~~

Given how dependencies leak in cargo's feature resolver v1, it's better to pull the bare minimum in features until v2 stabilizes (https://github.com/rust-lang/cargo/pull/8997). 
`std` can be enabled explicitly.
I guess this is technically a [possibly-breaking change](https://doc.rust-lang.org/cargo/reference/semver.html), although I'd lean towards a minor bump. 