### PR TITLE
fix clippy warning

### DIFF
--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -24,9 +24,9 @@
 /// ```
 /// use fixed_hash::construct_fixed_hash;
 /// construct_fixed_hash!{
-/// 	/// My unformatted 160 bytes sized hash type.
-/// 	#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-/// 	pub struct H160(20);
+///     /// My unformatted 160 bytes sized hash type.
+///     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+///     pub struct H160(20);
 /// }
 /// assert_eq!(std::mem::size_of::<H160>(), 20);
 /// ```


### PR DESCRIPTION
 cargo clippy
warning: using tabs in doc comments is not recommended
  --> fixed-hash/src/hash.rs:27:5
   |
27 | ///     /// My unformatted 160 bytes sized hash type.
   |     ^^^^ help: consider using four spaces per tab
   |
   = note: `#[warn(clippy::tabs_in_doc_comments)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments

warning: using tabs in doc comments is not recommended
  --> fixed-hash/src/hash.rs:28:5
   |
28 | ///     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
   |     ^^^^ help: consider using four spaces per tab
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments

warning: using tabs in doc comments is not recommended
  --> fixed-hash/src/hash.rs:29:5
   |
29 | ///     pub struct H160(20);
   |     ^^^^ help: consider using four spaces per tab
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments
