### PR TITLE
Update codec and crates depending

### DIFF
--- a/contract-address/CHANGELOG.md
+++ b/contract-address/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.6.0] - 2021-01-27
+### Breaking
+- Updated `ethereum-types` to 0.11. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `keccak-hash` to 0.7. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.5.0] - 2021-01-05
 ### Breaking
 - Updated `ethereum-types` to 0.10. [#463](https://github.com/paritytech/parity-common/pull/463)

--- a/contract-address/Cargo.toml
+++ b/contract-address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-address"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -11,9 +11,9 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-ethereum-types = { version = "0.10.0", path = "../ethereum-types" }
+ethereum-types = { version = "0.11.0", path = "../ethereum-types" }
 rlp = { version = "0.5", path = "../rlp" }
-keccak-hash = { version = "0.6", path = "../keccak-hash", default-features = false }
+keccak-hash = { version = "0.7", path = "../keccak-hash", default-features = false }
 
 [features]
 default = []

--- a/ethbloom/CHANGELOG.md
+++ b/ethbloom/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+## [0.11.0] - 2021-01-27
+### Breaking
+- Updated `ethbloom` to 0.11. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `primitive-types` to 0.8. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `impl-codec` to 0.5. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ### Potentially-breaking
 - `serialize` feature no longer pulls `std`. [#503](https://github.com/paritytech/parity-common/pull/503)
 

--- a/ethbloom/CHANGELOG.md
+++ b/ethbloom/CHANGELOG.md
@@ -8,8 +8,6 @@ The format is based on [Keep a Changelog].
 
 ## [0.11.0] - 2021-01-27
 ### Breaking
-- Updated `ethbloom` to 0.11. [#510](https://github.com/paritytech/parity-common/pull/510)
-- Updated `primitive-types` to 0.8. [#510](https://github.com/paritytech/parity-common/pull/510)
 - Updated `impl-codec` to 0.5. [#510](https://github.com/paritytech/parity-common/pull/510)
 
 ### Potentially-breaking

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ crunchy = { version = "0.2.2", default-features = false, features = ["limit_256"
 fixed-hash = { path = "../fixed-hash", version = "0.7", default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.3", default-features = false, optional = true }
-impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.5.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/ethereum-types/CHANGELOG.md
+++ b/ethereum-types/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+## [0.11.0] - 2021-01-27
+### Breaking
+- Updated `ethbloom` to 0.11. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `primitive-types` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `impl-codec` to 0.5. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ### Potentially-breaking
 - `serialize` feature no longer pulls `std`. [#503](https://github.com/paritytech/parity-common/pull/503)
 

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -8,13 +8,13 @@ description = "Ethereum types"
 edition = "2018"
 
 [dependencies]
-ethbloom = { path = "../ethbloom", version = "0.10", default-features = false }
+ethbloom = { path = "../ethbloom", version = "0.11", default-features = false }
 fixed-hash = { path = "../fixed-hash", version = "0.7", default-features = false, features = ["byteorder", "rustc-hex"] }
 uint-crate = { path = "../uint", package = "uint", version = "0.9", default-features = false }
-primitive-types = { path = "../primitive-types", version = "0.8", features = ["byteorder", "rustc-hex"], default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.9", features = ["byteorder", "rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.3.0", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.3", default-features = false, optional = true }
-impl-codec = { version = "0.4.1", path = "../primitive-types/impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.5.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/keccak-hash/CHANGELOG.md
+++ b/keccak-hash/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.7.0] - 2021-01-27
+### Breaking
+- Updated `primitive-types` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.6.0] - 2021-01-05
 ### Breaking
 - Updated `primitive-types` to 0.8. [#463](https://github.com/paritytech/parity-common/pull/463)

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hash"
-version = "0.6.0"
+version = "0.7.0"
 description = "`keccak-hash` is a set of utility functions to facilitate working with Keccak hashes (256/512 bits long)."
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 tiny-keccak = { version = "2.0", features = ["keccak"] }
-primitive-types = { path = "../primitive-types", version = "0.8", default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.9", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/kvdb-memorydb/CHANGELOG.md
+++ b/kvdb-memorydb/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-01-27
+### Breaking
+- Updated `parity-util-mem` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `kvdb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.8.0] - 2021-01-05
 ### Breaking
 - Updated dependencies. [#470](https://github.com/paritytech/parity-common/pull/470)

--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-memorydb"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "A key-value in-memory database that implements the  `KeyValueDB` trait"
@@ -8,12 +8,12 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-parity-util-mem = { path = "../parity-util-mem", version = "0.8", default-features = false, features = ["std"] }
+parity-util-mem = { path = "../parity-util-mem", version = "0.9", default-features = false, features = ["std"] }
 parking_lot = "0.11.1"
-kvdb = { version = "0.8", path = "../kvdb" }
+kvdb = { version = "0.9", path = "../kvdb" }
 
 [dev-dependencies]
-kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.6" }
+kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.7" }
 
 [features]
 default = []

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.11.0] - 2021-01-27
+### Breaking
+- Updated `kvdb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `parity-util-mem` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.10.0] - 2021-01-05
 ### Breaking
 - Updated dependencies. [#470](https://github.com/paritytech/parity-common/pull/470)

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by RocksDB"
@@ -14,20 +14,20 @@ harness = false
 [dependencies]
 smallvec = "1.0.0"
 fs-swap = "0.2.5"
-kvdb = { path = "../kvdb", version = "0.8" }
+kvdb = { path = "../kvdb", version = "0.9" }
 log = "0.4.8"
 num_cpus = "1.10.1"
 parking_lot = "0.11.1"
 regex = "1.3.1"
 rocksdb = { version = "0.15", features = ["snappy"], default-features = false }
 owning_ref = "0.4.0"
-parity-util-mem = { path = "../parity-util-mem", version = "0.8", default-features = false, features = ["std", "smallvec"] }
+parity-util-mem = { path = "../parity-util-mem", version = "0.9", default-features = false, features = ["std", "smallvec"] }
 
 [dev-dependencies]
 alloc_counter = "0.0.4"
 criterion = "0.3"
 ethereum-types = { path = "../ethereum-types" }
-kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.6" }
+kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.7" }
 rand = "0.8.0"
 tempfile = "3.1.0"
 keccak-hash = { path = "../keccak-hash" }

--- a/kvdb-shared-tests/CHANGELOG.md
+++ b/kvdb-shared-tests/CHANGELOG.md
@@ -5,3 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+## [0.7.0] - 2021-01-27
+### Breaking
+- Updated `kvdb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)

--- a/kvdb-shared-tests/Cargo.toml
+++ b/kvdb-shared-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "kvdb-shared-tests"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Shared tests for kvdb functionality, to be executed against actual implementations"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-kvdb = { path = "../kvdb", version = "0.8" }
+kvdb = { path = "../kvdb", version = "0.9" }

--- a/kvdb-web/CHANGELOG.md
+++ b/kvdb-web/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-01-27
+### Breaking
+- Updated `kvdb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `kvdb-memorydb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `parity-util-mem` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.8.0] - 2021-01-05
 ### Breaking
 - Updated dependencies. [#470](https://github.com/paritytech/parity-common/pull/470)

--- a/kvdb-web/Cargo.toml
+++ b/kvdb-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-web"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "A key-value database for use in browsers"
@@ -11,12 +11,12 @@ edition = "2018"
 [dependencies]
 wasm-bindgen = "0.2.69"
 js-sys = "0.3.46"
-kvdb = { version = "0.8", path = "../kvdb" }
-kvdb-memorydb = { version = "0.8", path = "../kvdb-memorydb" }
+kvdb = { version = "0.9", path = "../kvdb" }
+kvdb-memorydb = { version = "0.9", path = "../kvdb-memorydb" }
 futures = "0.3.8"
 log = "0.4.11"
 send_wrapper = "0.5.0"
-parity-util-mem = { path = "../parity-util-mem", version = "0.8", default-features = false }
+parity-util-mem = { path = "../parity-util-mem", version = "0.9", default-features = false }
 # TODO: https://github.com/paritytech/parity-common/issues/479
 # This is hack to enable `wasm-bindgen` feature of `parking_lot` in other dependencies.
 # Thus, it's not direct dependency and do not remove until a proper fix exists.
@@ -44,6 +44,6 @@ features = [
 
 [dev-dependencies]
 console_log = "0.2.0"
-kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.6" }
+kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.7" }
 wasm-bindgen-test = "0.3.19"
 wasm-bindgen-futures = "0.4.19"

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-01-27
+### Breaking
+- Updated `parity-util-mem` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.8.0] - 2021-01-05
 ### Breaking
 - Updated `parity-util-mem` to 0.8. [#470](https://github.com/paritytech/parity-common/pull/470)

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Generic key-value trait"
@@ -9,4 +9,4 @@ edition = "2018"
 
 [dependencies]
 smallvec = "1.0.0"
-parity-util-mem = { path = "../parity-util-mem", version = "0.8", default-features = false }
+parity-util-mem = { path = "../parity-util-mem", version = "0.9", default-features = false }

--- a/parity-crypto/CHANGELOG.md
+++ b/parity-crypto/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.8.0] - 2021-01-27
+### Breaking
+- Updated `ethereum-types` to 0.11. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.7.0] - 2021-01-05
 ### Breaking
 - Bump `rust-secp256k1` to v0.19, always allow zero signatures. [#438](https://github.com/paritytech/parity-common/pull/438)

--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-crypto"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Crypto utils used by ethstore and network."

--- a/parity-crypto/Cargo.toml
+++ b/parity-crypto/Cargo.toml
@@ -18,7 +18,7 @@ aes = "0.6.0"
 aes-ctr = "0.6.0"
 block-modes = "0.7.0"
 digest = "0.9.0"
-ethereum-types = { version = "0.10.0", optional = true, path = "../ethereum-types" }
+ethereum-types = { version = "0.11.0", optional = true, path = "../ethereum-types" }
 hmac = "0.10.1"
 lazy_static = { version = "1.4.0", optional = true }
 pbkdf2 = "0.6.0"

--- a/parity-util-mem/CHANGELOG.md
+++ b/parity-util-mem/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-01-27
+### Breaking
+- Updated `ethereum-types` to 0.11. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `primitive-types` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.8.0] - 2021-01-05
 - Updated dlmalloc to 0.2.1. [#452](https://github.com/paritytech/parity-common/pull/452)
 ### Breaking

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-util-mem"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Collection of memory related utilities"
@@ -26,9 +26,9 @@ parity-util-mem-derive = { path = "derive", version = "0.1" }
 impl-trait-for-tuples = "0.2.0"
 
 smallvec = { version = "1.0.0", optional = true }
-ethereum-types = { version = "0.10.0", optional = true, path = "../ethereum-types" }
+ethereum-types = { version = "0.11.0", optional = true, path = "../ethereum-types" }
 parking_lot = { version = "0.11.1", optional = true }
-primitive-types = { version = "0.8", path = "../primitive-types", default-features = false, optional = true }
+primitive-types = { version = "0.9", path = "../primitive-types", default-features = false, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", features = ["heapapi"] }

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog].
 ## [0.9.0] - 2021-01-27
 ### Breaking
 - Updated `impl-codec` to 0.5. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `scale-info` to 0.5. [#510](https://github.com/paritytech/parity-common/pull/510)
 
 ## [0.8.0] - 2021-01-05
 - Added `num-traits` feature. [#480](https://github.com/paritytech/parity-common/pull/480)

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-01-27
+### Breaking
+- Updated `impl-codec` to 0.5. [#510](https://github.com/paritytech/parity-common/pull/510)
+
 ## [0.8.0] - 2021-01-05
 - Added `num-traits` feature. [#480](https://github.com/paritytech/parity-common/pull/480)
 ### Breaking

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -14,7 +14,7 @@ impl-serde = { version = "0.3.1", path = "impls/serde", default-features = false
 impl-codec = { version = "0.5.0", path = "impls/codec", default-features = false, optional = true }
 impl-num-traits = { version = "0.1.0", path = "impls/num-traits", default-features = false, optional = true }
 impl-rlp = { version = "0.3", path = "impls/rlp", default-features = false, optional = true }
-scale-info = { version = "0.4", features = ["derive"], default-features = false, optional = true }
+scale-info = { version = "0.5", features = ["derive"], default-features = false, optional = true }
 
 [features]
 default = ["std"]

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -11,7 +11,7 @@ edition = "2018"
 fixed-hash = { version = "0.7", path = "../fixed-hash", default-features = false }
 uint = { version = "0.9.0", path = "../uint", default-features = false }
 impl-serde = { version = "0.3.1", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.4.1", path = "impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.5.0", path = "impls/codec", default-features = false, optional = true }
 impl-num-traits = { version = "0.1.0", path = "impls/num-traits", default-features = false, optional = true }
 impl-rlp = { version = "0.3", path = "impls/rlp", default-features = false, optional = true }
 scale-info = { version = "0.4", features = ["derive"], default-features = false, optional = true }

--- a/primitive-types/impls/codec/CHANGELOG.md
+++ b/primitive-types/impls/codec/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-The format is based on [Keep a Changelog]. 
+The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+## [0.5.0] - 2021-01-27
+### Breaking
+- Updated `parity-scale-codec` to 2.0. [#510](https://github.com/paritytech/parity-common/pull/510)

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-codec"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -8,7 +8,7 @@ description = "Parity Codec serialization support for uint and fixed hash."
 edition = "2018"
 
 [dependencies]
-parity-scale-codec = { version = "1.0.6", default-features = false }
+parity-scale-codec = { version = "2.0.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/primitive-types/tests/scale_info.rs
+++ b/primitive-types/tests/scale_info.rs
@@ -14,7 +14,7 @@ use scale_info::{build::Fields, Path, Type, TypeInfo};
 #[test]
 fn u256_scale_info() {
 	let r#type =
-		Type::builder().path(Path::new("U256", "primitive_types")).composite(Fields::unnamed().field_of::<[u64; 4]>());
+		Type::builder().path(Path::new("U256", "primitive_types")).composite(Fields::unnamed().field_of::<[u64; 4]>("[u64; 4]"));
 
 	assert_eq!(U256::type_info(), r#type.into());
 }
@@ -22,7 +22,7 @@ fn u256_scale_info() {
 #[test]
 fn h256_scale_info() {
 	let r#type =
-		Type::builder().path(Path::new("H256", "primitive_types")).composite(Fields::unnamed().field_of::<[u8; 32]>());
+		Type::builder().path(Path::new("H256", "primitive_types")).composite(Fields::unnamed().field_of::<[u8; 32]>("[u8; 32]"));
 
 	assert_eq!(H256::type_info(), r#type.into());
 }

--- a/primitive-types/tests/scale_info.rs
+++ b/primitive-types/tests/scale_info.rs
@@ -13,16 +13,18 @@ use scale_info::{build::Fields, Path, Type, TypeInfo};
 
 #[test]
 fn u256_scale_info() {
-	let r#type =
-		Type::builder().path(Path::new("U256", "primitive_types")).composite(Fields::unnamed().field_of::<[u64; 4]>("[u64; 4]"));
+	let r#type = Type::builder()
+		.path(Path::new("U256", "primitive_types"))
+		.composite(Fields::unnamed().field_of::<[u64; 4]>("[u64; 4]"));
 
 	assert_eq!(U256::type_info(), r#type.into());
 }
 
 #[test]
 fn h256_scale_info() {
-	let r#type =
-		Type::builder().path(Path::new("H256", "primitive_types")).composite(Fields::unnamed().field_of::<[u8; 32]>("[u8; 32]"));
+	let r#type = Type::builder()
+		.path(Path::new("H256", "primitive_types"))
+		.composite(Fields::unnamed().field_of::<[u8; 32]>("[u8; 32]"));
 
 	assert_eq!(H256::type_info(), r#type.into());
 }

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -14,7 +14,7 @@ rustc-hex = { version = "2.0.1", default-features = false }
 [dev-dependencies]
 criterion = "0.3.0"
 hex-literal = "0.3.1"
-primitive-types = { path = "../primitive-types", version = "0.8", features = ["impl-rlp"] }
+primitive-types = { path = "../primitive-types", version = "0.9", features = ["impl-rlp"] }
 
 [features]
 default = ["std"]

--- a/transaction-pool/Cargo.toml
+++ b/transaction-pool/Cargo.toml
@@ -12,4 +12,4 @@ log = "0.4.8"
 smallvec = "1.6.0"
 
 [dev-dependencies]
-ethereum-types = { version = "0.10.0", path = "../ethereum-types" }
+ethereum-types = { version = "0.11.0", path = "../ethereum-types" }

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triehash"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
@@ -14,7 +14,7 @@ rlp = { version = "0.5", path = "../rlp", default-features = false }
 [dev-dependencies]
 criterion = "0.3.0"
 keccak-hasher = "0.15.2"
-ethereum-types = { version = "0.10.0", path = "../ethereum-types" }
+ethereum-types = { version = "0.11.0", path = "../ethereum-types" }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 trie-standardmap = "0.15.2"
 hex-literal = "0.3.1"

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triehash"
-version = "0.9.0"
+version = "0.8.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
I think we should wait on the update of scale-info https://github.com/paritytech/scale-info/pull/55

Also I haven't check if some other dependency could be updated alongside.

All in all I just update impl-codec, and then every crate that depends on it directly or indirectly and it ends up updating most crates :-/ is it expected ?

I don't need a release of all crates though I just need a release of primitive-types and impl-codec