### PR TITLE
parity-util-mem: use ios compilation conditions same as macos.

### DIFF
--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -46,7 +46,7 @@ cfg_if::cfg_if! {
 
 pub mod allocators;
 
-#[cfg(any(all(target_os = "macos", not(feature = "jemalloc-global"),), feature = "estimate-heapsize"))]
+#[cfg(any(all(any(target_os = "macos", target_os = "ios"), not(feature = "jemalloc-global"),), feature = "estimate-heapsize"))]
 pub mod sizeof;
 
 /// This is a copy of patched crate `malloc_size_of` as a module.

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -46,7 +46,10 @@ cfg_if::cfg_if! {
 
 pub mod allocators;
 
-#[cfg(any(all(any(target_os = "macos", target_os = "ios"), not(feature = "jemalloc-global"),), feature = "estimate-heapsize"))]
+#[cfg(any(
+	all(any(target_os = "macos", target_os = "ios"), not(feature = "jemalloc-global"),),
+	feature = "estimate-heapsize"
+))]
 pub mod sizeof;
 
 /// This is a copy of patched crate `malloc_size_of` as a module.

--- a/parity-util-mem/src/malloc_size.rs
+++ b/parity-util-mem/src/malloc_size.rs
@@ -216,7 +216,7 @@ pub trait MallocConditionalShallowSizeOf {
 	fn conditional_shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize;
 }
 
-#[cfg(not(any(all(target_os = "macos", not(feature = "jemalloc-global"),), feature = "estimate-heapsize")))]
+#[cfg(not(any(all(any(target_os = "macos", target_os = "ios"), not(feature = "jemalloc-global"),), feature = "estimate-heapsize")))]
 pub mod inner_allocator_use {
 
 	use super::*;

--- a/parity-util-mem/src/malloc_size.rs
+++ b/parity-util-mem/src/malloc_size.rs
@@ -216,7 +216,10 @@ pub trait MallocConditionalShallowSizeOf {
 	fn conditional_shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize;
 }
 
-#[cfg(not(any(all(any(target_os = "macos", target_os = "ios"), not(feature = "jemalloc-global"),), feature = "estimate-heapsize")))]
+#[cfg(not(any(
+	all(any(target_os = "macos", target_os = "ios"), not(feature = "jemalloc-global"),),
+	feature = "estimate-heapsize"
+)))]
 pub mod inner_allocator_use {
 
 	use super::*;


### PR DESCRIPTION
Fixes #521 