### PR TITLE
[kvdb-rocksdb] add DatabaseConfig max_total_wal_size

### DIFF
--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -177,6 +177,9 @@ pub struct DatabaseConfig {
 	/// if the secondary instance reads and applies state changes before the primary instance compacts them.
 	/// More info: https://github.com/facebook/rocksdb/wiki/Secondary-instance
 	pub secondary: Option<String>,
+        /// Limit the size of write ahead logs
+        /// More info: https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log
+        pub max_total_wal_size: Option<u64>,
 }
 
 impl DatabaseConfig {
@@ -227,6 +230,7 @@ impl Default for DatabaseConfig {
 			keep_log_file_num: 1,
 			enable_statistics: false,
 			secondary: None,
+                        max_total_wal_size: None,
 		}
 	}
 }
@@ -325,6 +329,9 @@ fn generate_options(config: &DatabaseConfig) -> Options {
 	opts.set_bytes_per_sync(1 * MB as u64);
 	opts.set_keep_log_file_num(1);
 	opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
+        if let Some(m) = config.max_total_wal_size {
+            opts.set_max_total_wal_size(m);
+        }
 
 	opts
 }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -905,6 +905,7 @@ mod tests {
 			keep_log_file_num: 1,
 			enable_statistics: false,
 			secondary: None,
+			max_total_wal_size: None,
 		};
 
 		let db = Database::open(&config, tempdir.path().to_str().unwrap()).unwrap();

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -177,9 +177,9 @@ pub struct DatabaseConfig {
 	/// if the secondary instance reads and applies state changes before the primary instance compacts them.
 	/// More info: https://github.com/facebook/rocksdb/wiki/Secondary-instance
 	pub secondary: Option<String>,
-        /// Limit the size of write ahead logs
-        /// More info: https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log
-        pub max_total_wal_size: Option<u64>,
+	/// Limit the size of write ahead logs
+	/// More info: https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log
+	pub max_total_wal_size: Option<u64>,
 }
 
 impl DatabaseConfig {
@@ -329,9 +329,9 @@ fn generate_options(config: &DatabaseConfig) -> Options {
 	opts.set_bytes_per_sync(1 * MB as u64);
 	opts.set_keep_log_file_num(1);
 	opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
-        if let Some(m) = config.max_total_wal_size {
-            opts.set_max_total_wal_size(m);
-        }
+	if let Some(m) = config.max_total_wal_size {
+	    opts.set_max_total_wal_size(m);
+	}
 
 	opts
 }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -330,7 +330,7 @@ fn generate_options(config: &DatabaseConfig) -> Options {
 	opts.set_keep_log_file_num(1);
 	opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
 	if let Some(m) = config.max_total_wal_size {
-	    opts.set_max_total_wal_size(m);
+		opts.set_max_total_wal_size(m);
 	}
 
 	opts

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -177,7 +177,7 @@ pub struct DatabaseConfig {
 	/// if the secondary instance reads and applies state changes before the primary instance compacts them.
 	/// More info: https://github.com/facebook/rocksdb/wiki/Secondary-instance
 	pub secondary: Option<String>,
-	/// Limit the size of write ahead logs
+	/// Limit the size (in bytes) of write ahead logs
 	/// More info: https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log
 	pub max_total_wal_size: Option<u64>,
 }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -230,7 +230,7 @@ impl Default for DatabaseConfig {
 			keep_log_file_num: 1,
 			enable_statistics: false,
 			secondary: None,
-                        max_total_wal_size: None,
+			max_total_wal_size: None,
 		}
 	}
 }


### PR DESCRIPTION
It would be useful to be able to limit the disk usage of write ahead logs. The default value set up by `rocksdb` can be rather large, in some `openethereum` nodes I am testing with it's about 50GB or more, considerably raising disk space requirements.