### PR TITLE
bump kvdb-rocksdb and update changelog

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.11.1] - 2021-05-03
+- Updated `rocksdb` to 0.16. [#537](https://github.com/paritytech/parity-common/pull/537)
+
 ## [0.11.0] - 2021-01-27
 ### Breaking
 - Updated `kvdb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by RocksDB"
@@ -13,7 +13,7 @@ harness = false
 
 [dependencies]
 smallvec = "1.0.0"
-fs-swap = "0.2.5"
+fs-swap = "0.2.6"
 kvdb = { path = "../kvdb", version = "0.9" }
 log = "0.4.8"
 num_cpus = "1.10.1"


### PR DESCRIPTION
Closes #541.

I believe #537 was a [possibly-breaking change](https://doc.rust-lang.org/cargo/reference/semver.html#change-categories), but we don't expose rocksdb types in the public API AFAIK.