### PR TITLE
primitive-types/impl-codec: Bump to include new `parity_scale_codec::MaxEncodedLen` impls

### DIFF
--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.10.1] - 2021-07-02
+### Added
+- Implemented `parity_scale_codec::MaxEncodedLen` trait for `{U128, U256, U512}` and `{H128, H160, H256, H512}` types.
+
+## [0.10.0] - 2021-07-02
 ### Added
 - Added `U128::full_mul` method. [#546](https://github.com/paritytech/parity-common/pull/546)
 ### Breaking

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -11,7 +11,7 @@ edition = "2018"
 fixed-hash = { version = "0.7", path = "../fixed-hash", default-features = false }
 uint = { version = "0.9.0", path = "../uint", default-features = false }
 impl-serde = { version = "0.3.1", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.5.0", path = "impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.5.1", path = "impls/codec", default-features = false, optional = true }
 impl-num-traits = { version = "0.1.0", path = "impls/num-traits", default-features = false, optional = true }
 impl-rlp = { version = "0.3", path = "impls/rlp", default-features = false, optional = true }
 scale-info-crate = { package = "scale-info", version = ">=0.9, <2", features = ["derive"], default-features = false, optional = true }

--- a/primitive-types/impls/codec/CHANGELOG.md
+++ b/primitive-types/impls/codec/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 
 ## [0.5.1] - 2021-07-02
-### Breaking
+### Dependencies
 - Updated `parity-scale-codec` to 2.2. [#552](https://github.com/paritytech/parity-common/pull/552)
 
 ## [0.5.0] - 2021-01-27

--- a/primitive-types/impls/codec/CHANGELOG.md
+++ b/primitive-types/impls/codec/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.5.1] - 2021-07-02
+### Breaking
+- Updated `parity-scale-codec` to 2.2. [#552](https://github.com/paritytech/parity-common/pull/552)
+
 ## [0.5.0] - 2021-01-27
 ### Breaking
 - Updated `parity-scale-codec` to 2.0. [#510](https://github.com/paritytech/parity-common/pull/510)

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-codec"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -8,7 +8,7 @@ description = "Parity Codec serialization support for uint and fixed hash."
 edition = "2018"
 
 [dependencies]
-parity-scale-codec = { version = "2.0.0", default-features = false }
+parity-scale-codec = { version = "2.2.0", default-features = false, features = ["max-encoded-len"] }
 
 [features]
 default = ["std"]

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -32,6 +32,12 @@ macro_rules! impl_uint_codec {
 				<[u8; $len * 8] as $crate::codec::Decode>::decode(input).map(|b| $name::from_little_endian(&b))
 			}
 		}
+
+		impl $crate::codec::MaxEncodedLen for $name {
+			fn max_encoded_len() -> usize {
+				::core::mem::size_of::<$name>()
+			}
+		}
 	};
 }
 
@@ -50,6 +56,12 @@ macro_rules! impl_fixed_hash_codec {
 		impl $crate::codec::Decode for $name {
 			fn decode<I: $crate::codec::Input>(input: &mut I) -> core::result::Result<Self, $crate::codec::Error> {
 				<[u8; $len] as $crate::codec::Decode>::decode(input).map($name)
+			}
+		}
+
+		impl $crate::codec::MaxEncodedLen for $name {
+			fn max_encoded_len() -> usize {
+				::core::mem::size_of::<$name>()
 			}
 		}
 	};


### PR DESCRIPTION
Part of paritytech/substrate#9163.

~Needs https://github.com/paritytech/scale-info/pull/102 to be released first.~

The gist of this PR is to implement `parity_scale_codec::MaxEncodedLen` for fixed hashes as required by Substrate (and other uints, which is done for consistency) and to update the rest of the crates using the new release candidate of the SCALE codec since Cargo requires us to explicitly opt-in for the RCs.