### PR TITLE
parity-util-mem: fix for FreeBSD

### DIFF
--- a/parity-util-mem/CHANGELOG.md
+++ b/parity-util-mem/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Fixed `malloc_usable_size` for FreeBSD. [#553](https://github.com/paritytech/parity-common/pull/553)
 
 ## [0.9.0] - 2021-01-27
 ### Breaking

--- a/parity-util-mem/src/allocators.rs
+++ b/parity-util-mem/src/allocators.rs
@@ -97,9 +97,12 @@ mod usable_size {
 				libmimalloc_sys::mi_usable_size(ptr as *mut _)
 			}
 
-		} else if #[cfg(any(target_os = "linux", target_os = "android"))] {
-
-			/// Linux call system allocator (currently malloc).
+		} else if #[cfg(any(
+			target_os = "linux",
+			target_os = "android",
+			target_os = "freebsd",
+		))] {
+			/// Linux/BSD call system allocator (currently malloc).
 			extern "C" {
 				pub fn malloc_usable_size(ptr: *const c_void) -> usize;
 			}


### PR DESCRIPTION
Fixes #543.

No CI for now.