### PR TITLE
rlp: fix bool encoding/decoding

### DIFF
--- a/rlp/CHANGELOG.md
+++ b/rlp/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Fix rlp encoding/decoding for bool. [#572](https://github.com/paritytech/parity-common/pull/572)
 
 ## [0.5.0] - 2021-01-05
 ### Breaking

--- a/rlp/src/impls.rs
+++ b/rlp/src/impls.rs
@@ -48,17 +48,19 @@ impl<T: Decodable> Decodable for Box<T> {
 
 impl Encodable for bool {
 	fn rlp_append(&self, s: &mut RlpStream) {
-		s.encoder().encode_iter(once(if *self { 1u8 } else { 0 }));
+		let as_uint = u8::from(*self);
+		Encodable::rlp_append(&as_uint, s);
 	}
 }
 
 impl Decodable for bool {
 	fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-		rlp.decoder().decode_value(|bytes| match bytes.len() {
+		let as_uint = <u8 as Decodable>::decode(rlp)?;
+		match as_uint {
 			0 => Ok(false),
-			1 => Ok(bytes[0] != 0),
-			_ => Err(DecoderError::RlpIsTooBig),
-		})
+			1 => Ok(true),
+			_ => Err(DecoderError::Custom("invalid boolean value")),
+		}
 	}
 }
 

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -619,8 +619,17 @@ fn test_rlp_is_int() {
 	for b in 0xb8..0xc0 {
 		let data: Vec<u8> = vec![b];
 		let rlp = Rlp::new(&data);
-		assert_eq!(rlp.is_int(), false);
+		assert!(!rlp.is_int());
 	}
+}
+
+#[test]
+fn test_bool_same_as_int() {
+	assert_eq!(rlp::encode(&false), rlp::encode(&0x00u8));
+	assert_eq!(rlp::encode(&true), rlp::encode(&0x01u8));
+	let two = rlp::encode(&0x02u8);
+	let invalid: Result<bool, _> = rlp::decode(&two);
+	invalid.unwrap_err();
 }
 
 // test described in


### PR DESCRIPTION
Fixes #571.

I don't know if `bool`s are actually used anywhere where rlp encoding is expected, but if they are, this is a breaking change.