### PR TITLE
add to kvdb-rocksdb create_if_missing config option

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.13.0] - 2021-08-02
+### Breaking
+- `DatabaseConfig` is now `#[non_exhaustive]`. [#576](https://github.com/paritytech/parity-common/pull/576)
+- Added `create_if_missing` to `DatabaseConfig`. [#576](https://github.com/paritytech/parity-common/pull/576)
+
 ## [0.12.1] - 2021-07-30
 - Bumped `rocksdb` to 0.17. [#573](https://github.com/paritytech/parity-common/pull/573)
 

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.13.0] - 2021-08-02
+## [0.13.0] - 2021-08-04
 ### Breaking
 - `DatabaseConfig` is now `#[non_exhaustive]`. [#576](https://github.com/paritytech/parity-common/pull/576)
 - Added `create_if_missing` to `DatabaseConfig`. [#576](https://github.com/paritytech/parity-common/pull/576)

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by RocksDB"

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -142,6 +142,7 @@ impl CompactionProfile {
 
 /// Database configuration
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DatabaseConfig {
 	/// Max number of open files.
 	pub max_open_files: i32,


### PR DESCRIPTION
will be used to implement "auto backend" https://github.com/paritytech/substrate/issues/9201

changes: 
- add to kvdb-rocksdb create_if_missing config option
- add `#[non_exhaustive]` above the DatabaseConfig