### PR TITLE
Switch from `jemallocator` to `tikv-jemallocator`

### DIFF
--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-util-mem"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "Collection of memory related utilities"

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -33,12 +33,12 @@ primitive-types = { version = "0.10", path = "../primitive-types", default-featu
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", features = ["heapapi"] }
 
-[target.'cfg(not(target_os = "windows"))'.dependencies.jemallocator]
-version = "0.3.2"
+[target.'cfg(not(target_os = "windows"))'.dependencies.tikv-jemallocator]
+version = "0.4.1"
 optional = true
 
-[target.'cfg(not(target_os = "windows"))'.dependencies.jemalloc-ctl]
-version = "0.3.3"
+[target.'cfg(not(target_os = "windows"))'.dependencies.tikv-jemalloc-ctl]
+version = "0.4.2"
 optional = true
 
 [features]
@@ -49,7 +49,7 @@ dlmalloc-global = ["dlmalloc", "estimate-heapsize"]
 # use wee_alloc as global allocator
 weealloc-global = ["wee_alloc", "estimate-heapsize"]
 # use jemalloc as global allocator
-jemalloc-global = ["jemallocator", "jemalloc-ctl"]
+jemalloc-global = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 # use mimalloc as global allocator
 mimalloc-global = ["mimalloc", "libmimalloc-sys"]
 # implement additional types

--- a/parity-util-mem/src/allocators.rs
+++ b/parity-util-mem/src/allocators.rs
@@ -16,13 +16,13 @@
 //! 	 - mimalloc: use mimallocator crate
 //! - arch x86:
 //! 	 - no features: use default alloc
-//! 	 - jemalloc: use jemallocator crate
+//! 	 - jemalloc: use tikv-jemallocator crate
 //! 	 - weealloc: default to `estimate_size`
 //! 	 - dlmalloc: default to `estimate_size`
 //! 	 - mimalloc: use mimallocator crate
 //! - arch x86/macos:
 //! 	 - no features: use default alloc, requires using `estimate_size`
-//! 	 - jemalloc: use jemallocator crate
+//! 	 - jemalloc: use tikv-jemallocator crate
 //! 	 - weealloc: default to `estimate_size`
 //! 	 - dlmalloc: default to `estimate_size`
 //! 	 - mimalloc: use mimallocator crate
@@ -85,7 +85,7 @@ mod usable_size {
 
 			/// Use of jemalloc usable size C function through jemallocator crate call.
 			pub unsafe extern "C" fn malloc_usable_size(ptr: *const c_void) -> usize {
-				jemallocator::usable_size(ptr)
+				tikv_jemallocator::usable_size(ptr)
 			}
 
 		} else if #[cfg(feature = "mimalloc-global")] {

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -23,7 +23,7 @@ cfg_if::cfg_if! {
 	))] {
 		/// Global allocator
 		#[global_allocator]
-		pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+		pub static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 		mod memory_stats_jemalloc;
 		use memory_stats_jemalloc as memory_stats;

--- a/parity-util-mem/src/memory_stats_jemalloc.rs
+++ b/parity-util-mem/src/memory_stats_jemalloc.rs
@@ -6,12 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use jemalloc_ctl::Error;
-use jemalloc_ctl::{epoch, stats};
+pub use tikv_jemalloc_ctl::Error;
+use tikv_jemalloc_ctl::{epoch, stats};
 
 #[derive(Clone)]
 pub struct MemoryAllocationTracker {
-	epoch: jemalloc_ctl::epoch_mib,
+	epoch: tikv_jemalloc_ctl::epoch_mib,
 	allocated: stats::allocated_mib,
 	resident: stats::resident_mib,
 }


### PR DESCRIPTION
Closes https://github.com/paritytech/parity-common/issues/586

One thing I'm not entirely sure of is to whether I should bump the version to `0.10.2` or to `0.11.0`. It feels like this should not be a breaking change, but if someone was linking to e.g. `jemalloc-ctl` directly before then the whole thing will stop compiling due to two jemallocs being compiled in at the same time, and I guess the `ALLOC` symbol is public (but only if an allocator was actually enabled) and its type *did* change.