### PR TITLE
Stop calling `state.finish()` for fixed hashes

### DIFF
--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -274,7 +274,6 @@ macro_rules! construct_fixed_hash {
 		impl $crate::core_::hash::Hash for $name {
 			fn hash<H>(&self, state: &mut H) where H: $crate::core_::hash::Hasher {
 				state.write(&self.0);
-				state.finish();
 			}
 		}
 


### PR DESCRIPTION
Calling [`state.finish();`][Hasher::finish] is a no-op. At call site, `state` is read-only and the return value is ignored. The call and may be removed.

[Hasher::finish]: https://doc.rust-lang.org/std/hash/trait.Hasher.html#tymethod.finish