### PR TITLE
uint: Fix overflowing_neg by implementing two's complement

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1162,7 +1162,7 @@ macro_rules! construct_uint {
 			pub fn overflowing_neg(self) -> ($name, bool) {
 				if self.is_zero() {
 					(self, false)
-				else {
+				} else {
 					(!self + 1, true)
 				}
 			}

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1160,11 +1160,50 @@ macro_rules! construct_uint {
 
 			/// Negation with overflow.
 			pub fn overflowing_neg(self) -> ($name, bool) {
-				if self.is_zero() {
-					(self, false)
-				} else {
-					(!self, true)
+				use $crate::core_ as core;
+				let $name(ref me) = self;
+
+				let mut ret = [0u64; $n_words];
+				let ret_ptr = &mut ret as *mut [u64; $n_words] as *mut u64;
+				$crate::static_assertions::const_assert!(
+					core::isize::MAX as usize / core::mem::size_of::<u64>() > $n_words
+				);
+
+				// `unroll!` is recursive, but doesn’t use `$crate::unroll`, so we need to ensure that it
+				// is in scope unqualified.
+				use $crate::unroll;
+				let (res, overflow) = u64::overflowing_neg(me[0]);
+				let mut seen_one: bool = overflow;
+				unsafe {
+					// SAFETY: accesses first entry of non-empty array
+					*ret_ptr = res
 				}
+				unroll! {
+					for i in 1..$n_words {
+						use core::ptr;
+
+						// compute two's complement negation, until we have seen the first 1 bit,
+						// then switch to bit-wise NOT
+						if !seen_one {
+							let (res, overflow) = u64::overflowing_neg(me[i]);
+							seen_one = overflow;
+
+							unsafe {
+								// SAFETY: `i` is within bounds and `i * size_of::<u64>() < isize::MAX`
+								*ret_ptr.offset(i as _) = res
+							}
+						} else {
+							let res = !me[i];
+
+							unsafe {
+								// SAFETY: `i` is within bounds and `i * size_of::<u64>() < isize::MAX`
+								*ret_ptr.offset(i as _) = res
+							}
+						}
+					}
+				}
+
+				($name(ret), seen_one)
 			}
 
 			/// Checked negation. Returns `None` unless `self == 0`.

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -470,6 +470,39 @@ fn uint256_sub_overflow() {
 }
 
 #[test]
+fn uint256_neg_overflow() {
+	assert_eq!(U256::from_str("0").unwrap().overflowing_neg(), (U256::from_str("0").unwrap(), false));
+	assert_eq!(
+		U256::from_str("1").unwrap().overflowing_neg(),
+		(U256::from_str("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap(), true)
+	);
+	assert_eq!(
+		U256::from_str("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+			.unwrap()
+			.overflowing_neg(),
+		(U256::from_str("1").unwrap(), true)
+	);
+	assert_eq!(
+		U256::from_str("8000000000000000000000000000000000000000000000000000000000000000")
+			.unwrap()
+			.overflowing_neg(),
+		(U256::from_str("8000000000000000000000000000000000000000000000000000000000000000").unwrap(), true)
+	);
+	assert_eq!(
+		U256::from_str("ffffffffffffffff0000000000000000ffffffffffffffff0000000000000000")
+			.unwrap()
+			.overflowing_neg(),
+		(U256::from_str("0000000000000000ffffffffffffffff00000000000000010000000000000000").unwrap(), true)
+	);
+	assert_eq!(
+		U256::from_str("0000000000000000ffffffffffffffff0000000000000000ffffffffffffffff")
+			.unwrap()
+			.overflowing_neg(),
+		(U256::from_str("ffffffffffffffff0000000000000000ffffffffffffffff0000000000000001").unwrap(), true)
+	);
+}
+
+#[test]
 #[should_panic]
 #[allow(unused_must_use)]
 fn uint256_sub_overflow_panic() {


### PR DESCRIPTION
The operation `overflowing_neg` on the primitive integer types in the
Rust standard library computes the negation of the integer value using
two's complement, i.e., it returns `!self + 1`.

The current implementation of the uint library implemented
`overflowing_neg` using `!self` for non-zero values which is bit-wise
negation (NOT).  This lead to behavior where 0 - 1 != -1 for
U256 with the `overflowing_neg` and `overflow_sub` operations.

This patch adapts the `uint_overflowing_binop` macro to implement the
two's complement correctly: Starting from the least significant word
we apply `u64::overflowing_neg` until we have seen the first one-bit in
the original integer, i.e., until `overflowing_neg` reports an overflow.
Then we use bit-wise NOT for the remaining words
(cf. https://en.wikipedia.org/wiki/Two%27s_complement#Working_from_LSB_towards_MSB).