### PR TITLE
ethereum-types: make ethbloom optional

### DIFF
--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
 description = "Ethereum types"
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.60.0"
 
 [dependencies]
 ethbloom = { path = "../ethbloom", version = "0.12", optional = true, default-features = false }
@@ -23,7 +23,7 @@ serde_json = "1.0.41"
 
 [features]
 default = ["std", "ethbloom", "rlp", "serialize"]
-std = ["uint-crate/std", "fixed-hash/std", "ethbloom/std", "primitive-types/std"]
+std = ["uint-crate/std", "fixed-hash/std", "ethbloom?/std", "primitive-types/std"]
 serialize = ["impl-serde", "primitive-types/serde_no_std", "ethbloom/serialize"]
 arbitrary = ["ethbloom/arbitrary", "fixed-hash/arbitrary", "uint-crate/arbitrary"]
 rlp = ["impl-rlp", "ethbloom/rlp", "primitive-types/rlp"]

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-ethbloom = { path = "../ethbloom", version = "0.12", default-features = false }
+ethbloom = { path = "../ethbloom", version = "0.12", optional = true, default-features = false }
 fixed-hash = { path = "../fixed-hash", version = "0.7", default-features = false, features = ["byteorder", "rustc-hex"] }
 uint-crate = { path = "../uint", package = "uint", version = "0.9", default-features = false }
 primitive-types = { path = "../primitive-types", version = "0.11", features = ["byteorder", "rustc-hex"], default-features = false }
@@ -22,7 +22,7 @@ scale-info = { version = "1.0", features = ["derive"], default-features = false,
 serde_json = "1.0.41"
 
 [features]
-default = ["std", "rlp", "serialize"]
+default = ["std", "ethbloom", "rlp", "serialize"]
 std = ["uint-crate/std", "fixed-hash/std", "ethbloom/std", "primitive-types/std"]
 serialize = ["impl-serde", "primitive-types/serde_no_std", "ethbloom/serialize"]
 arbitrary = ["ethbloom/arbitrary", "fixed-hash/arbitrary", "uint-crate/arbitrary"]

--- a/ethereum-types/src/lib.rs
+++ b/ethereum-types/src/lib.rs
@@ -11,6 +11,7 @@
 mod hash;
 mod uint;
 
+#[cfg(feature = "ethbloom")]
 pub use ethbloom::{Bloom, BloomRef, Input as BloomInput};
 pub use hash::{BigEndianHash, H128, H160, H256, H264, H32, H512, H520, H64};
 pub use uint::{FromDecStrErr, FromStrRadixErr, FromStrRadixErrKind, U128, U256, U512, U64};


### PR DESCRIPTION
`ethbloom` pulls in `tiny-keccak` and `scale-info`, which may not be necessary for all `ethereum-types` users.