### PR TITLE
Update scale-info to v2

### DIFF
--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -15,7 +15,8 @@ impl-serde = { version = "0.3.1", path = "impls/serde", default-features = false
 impl-codec = { version = "0.6.0", path = "impls/codec", default-features = false, optional = true }
 impl-num-traits = { version = "0.1.0", path = "impls/num-traits", default-features = false, optional = true }
 impl-rlp = { version = "0.3", path = "impls/rlp", default-features = false, optional = true }
-scale-info-crate = { package = "scale-info", version = ">=0.9, <2", features = ["derive"], default-features = false, optional = true }
+# See https://github.com/paritytech/parity-common/pull/556#issuecomment-872127496 why this is here:
+scale-info-crate = { package = "scale-info", version = "2", features = ["derive"], default-features = false, optional = true }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
We should get to a release of primitive-types that could be included in a Substrate version that depends on Scale v3. Yeah :smile: