### PR TITLE
Disable jemalloc on OpenBSD and MSVC where it is not working

### DIFF
--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+## [0.15.2] - 2022-03-20
 - Disable `jemalloc` feature for `rocksdb` where it is not working. [#633](https://github.com/paritytech/parity-common/pull/633)
 
 ## [0.15.1] - 2022-02-18

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Disable `jemalloc` feature for `rocksdb` where it is not working. [#633](https://github.com/paritytech/parity-common/pull/633)
 
 ## [0.15.1] - 2022-02-18
 - Updated `rocksdb` to 0.18 and enable `jemalloc` feature. [#629](https://github.com/paritytech/parity-common/pull/629)

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvdb-rocksdb"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by RocksDB"
@@ -20,9 +20,20 @@ log = "0.4.8"
 num_cpus = "1.10.1"
 parking_lot = "0.12.0"
 regex = "1.3.1"
-rocksdb = { version = "0.18.0", features = ["snappy", "jemalloc"], default-features = false }
 owning_ref = "0.4.0"
 parity-util-mem = { path = "../parity-util-mem", version = "0.11", default-features = false, features = ["std", "smallvec"] }
+
+# OpenBSD and MSVC are unteested and shouldn't enable jemalloc:
+# https://github.com/tikv/jemallocator/blob/52de4257fab3e770f73d5174c12a095b49572fba/jemalloc-sys/build.rs#L26-L27
+[target.'cfg(any(target_os = "openbsd", target_env = "msvc"))'.dependencies.rocksdb]
+default-features = false
+features = ["snappy"]
+version = "0.18.0"
+
+[target.'cfg(not(any(target_os = "openbsd", target_env = "msvc")))'.dependencies.rocksdb]
+default-features = false
+features = ["snappy", "jemalloc"]
+version = "0.18.0"
 
 [dev-dependencies]
 alloc_counter = "0.0.4"


### PR DESCRIPTION
Fix for issue introduced by https://github.com/paritytech/parity-common/pull/629 on MSVC target: https://github.com/subspace/subspace/runs/5612067150?check_suite_focus=true