### PR TITLE
docs: improves `overflowing_add` documentation

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1057,7 +1057,7 @@ macro_rules! construct_uint {
 				}
 			}
 
-			/// Add with overflow.
+			/// Addition which overflows and returns a flag if it does.
 			#[inline(always)]
 			pub fn overflowing_add(self, other: $name) -> ($name, bool) {
 				$crate::uint_overflowing_binop!(


### PR DESCRIPTION
The proposed change makes this function's documentation more consistent with others already present in this file.