### PR TITLE
uint: make fn one const

### DIFF
--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Make `one` const.
 
 ## [0.9.3] - 2022-02-04
 - Simplified and faster `div_mod`. [#478](https://github.com/paritytech/parity-common/pull/478)

--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-- Make `one` const.
+- Make `one` const. [#650](https://github.com/paritytech/parity-common/pull/650)
 
 ## [0.9.3] - 2022-02-04
 - Simplified and faster `div_mod`. [#478](https://github.com/paritytech/parity-common/pull/478)

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -793,8 +793,10 @@ macro_rules! construct_uint {
 
 			/// One (multiplicative identity) of this type.
 			#[inline]
-			pub fn one() -> Self {
-				From::from(1u64)
+			pub const fn one() -> Self {
+				let mut words = [0; $n_words];
+				words[0] = 1u64;
+				Self(words)
 			}
 
 			/// The maximum value which can be inhabited by this type.

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -55,6 +55,12 @@ fn one() {
 
 	let one = U512::one();
 	assert_eq!(one.0, [1, 0, 0, 0, 0, 0, 0, 0]);
+
+	let any = U256::from(123456789);
+	assert_eq!(any * U256::one(), any);
+
+	let any = U512::from(123456789);
+	assert_eq!(any * U512::one(), any);
 }
 
 #[test]

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -49,6 +49,15 @@ fn const_matching_works() {
 }
 
 #[test]
+fn one() {
+	let one = U256::one();
+	assert_eq!(one.0, [1, 0, 0, 0]);
+
+	let one = U512::one();
+	assert_eq!(one.0, [1, 0, 0, 0, 0, 0, 0, 0]);
+}
+
+#[test]
 fn u128_conversions() {
 	let mut a = U256::from(u128::max_value());
 	assert_eq!(a.low_u128(), u128::max_value());


### PR DESCRIPTION
Hey there! I think this is a nice addition for API consistency with `zero()` and to allow basic math on a const context.