### PR TITLE
Streamline kvdb API and upgrade rocksdb to 0.19

### DIFF
--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -26,12 +26,12 @@ parity-util-mem = { path = "../parity-util-mem", version = "0.11", default-featu
 [target.'cfg(any(target_os = "openbsd", target_env = "msvc"))'.dependencies.rocksdb]
 default-features = false
 features = ["snappy"]
-version = "0.18.0"
+version = "0.19.0"
 
 [target.'cfg(not(any(target_os = "openbsd", target_env = "msvc")))'.dependencies.rocksdb]
 default-features = false
 features = ["snappy", "jemalloc"]
-version = "0.18.0"
+version = "0.19.0"
 
 [dev-dependencies]
 alloc_counter = "0.0.4"

--- a/kvdb-rocksdb/benches/bench_read_perf.rs
+++ b/kvdb-rocksdb/benches/bench_read_perf.rs
@@ -187,7 +187,7 @@ fn iter(c: &mut Criterion) {
 			let (alloc_stats, _) = count_alloc(|| {
 				let start = Instant::now();
 				for _ in 0..iterations {
-					black_box(db.iter(0).next().unwrap());
+					black_box(db.iter(0).next().unwrap().unwrap());
 				}
 				elapsed = start.elapsed();
 			});

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -66,7 +66,7 @@ impl<'a> Iterator for EndOnErrorIterator<'a> {
 				log::warn!("RocksDB error while iterating: {}", e);
 				None
 			},
-			_ => None,
+			None => None,
 		}
 	}
 }

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -15,58 +15,51 @@
 //! To work around this we set an upper bound to the prefix successor.
 //! See https://github.com/facebook/rocksdb/wiki/Prefix-Seek-API-Changes for details.
 
-use crate::DBAndColumns;
+use crate::{DBAndColumns, other_io_err};
 use rocksdb::{DBIterator, Direction, IteratorMode, ReadOptions};
+use std::io;
 
 /// A tuple holding key and value data, used as the iterator item type.
 pub type KeyValuePair = (Box<[u8]>, Box<[u8]>);
 
 /// Instantiate iterators yielding `KeyValuePair`s.
 pub trait IterationHandler {
-	type Iterator: Iterator<Item = KeyValuePair>;
+	type Iterator: Iterator<Item = io::Result<KeyValuePair>>;
 
 	/// Create an `Iterator` over a `ColumnFamily` corresponding to the passed index. Takes
 	/// `ReadOptions` to allow configuration of the new iterator (see
 	/// https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L1169).
-	fn iter(&self, col: u32, read_opts: ReadOptions) -> Self::Iterator;
+	fn iter(self, col: u32, read_opts: ReadOptions) -> Self::Iterator;
 	/// Create an `Iterator` over a `ColumnFamily` corresponding to the passed index. Takes
 	/// `ReadOptions` to allow configuration of the new iterator (see
 	/// https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L1169).
 	/// The `Iterator` iterates over keys which start with the provided `prefix`.
-	fn iter_with_prefix(&self, col: u32, prefix: &[u8], read_opts: ReadOptions) -> Self::Iterator;
+	fn iter_with_prefix(self, col: u32, prefix: &[u8], read_opts: ReadOptions) -> Self::Iterator;
 }
 
 impl<'a> IterationHandler for &'a DBAndColumns {
-	type Iterator = EndOnErrorIterator<'a>;
+	type Iterator = Iter<'a>;
 
-	fn iter(&self, col: u32, read_opts: ReadOptions) -> Self::Iterator {
+	fn iter(self, col: u32, read_opts: ReadOptions) -> Self::Iterator {
 		let inner = self.db.iterator_cf_opt(self.cf(col as usize), read_opts, IteratorMode::Start);
-		EndOnErrorIterator(inner)
+		Iter(inner)
 	}
 
-	fn iter_with_prefix(&self, col: u32, prefix: &[u8], read_opts: ReadOptions) -> Self::Iterator {
+	fn iter_with_prefix(self, col: u32, prefix: &[u8], read_opts: ReadOptions) -> Self::Iterator {
 		let inner =
 			self.db
 				.iterator_cf_opt(self.cf(col as usize), read_opts, IteratorMode::From(prefix, Direction::Forward));
-		EndOnErrorIterator(inner)
+		Iter(inner)
 	}
 }
 
-/// This iterator will stop early in case of `rocksdb::Error` is returned
-/// while iterating.
-pub struct EndOnErrorIterator<'a>(DBIterator<'a>);
+/// A simple wrapper around `DBIterator` that maps errors to `io::Error`.
+pub struct Iter<'a>(DBIterator<'a>);
 
-impl<'a> Iterator for EndOnErrorIterator<'a> {
-	type Item = KeyValuePair;
+impl<'a> Iterator for Iter<'a> {
+	type Item = io::Result<KeyValuePair>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		match self.0.next() {
-			Some(Ok(kv)) => Some(kv),
-			Some(Err(e)) => {
-				log::warn!("RocksDB error while iterating: {}", e);
-				None
-			},
-			None => None,
-		}
+		self.0.next().map(|r| r.map_err(other_io_err))
 	}
 }

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -62,6 +62,10 @@ impl<'a> Iterator for EndOnErrorIterator<'a> {
 	fn next(&mut self) -> Option<Self::Item> {
 		match self.0.next() {
 			Some(Ok(kv)) => Some(kv),
+			Some(Err(e)) => {
+				log::warn!("RocksDB error while iterating: {}", e);
+				None
+			},
 			_ => None,
 		}
 	}

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -15,12 +15,9 @@
 //! To work around this we set an upper bound to the prefix successor.
 //! See https://github.com/facebook/rocksdb/wiki/Prefix-Seek-API-Changes for details.
 
-use crate::{DBAndColumns, other_io_err};
+use crate::{other_io_err, DBAndColumns, KeyValuePair};
 use rocksdb::{DBIterator, Direction, IteratorMode, ReadOptions};
 use std::io;
-
-/// A tuple holding key and value data, used as the iterator item type.
-pub type KeyValuePair = (Box<[u8]>, Box<[u8]>);
 
 /// Instantiate iterators yielding `KeyValuePair`s.
 pub trait IterationHandler {

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -45,8 +45,9 @@ impl<'a> IterationHandler for &'a DBAndColumns {
 	}
 
 	fn iter_with_prefix(&self, col: u32, prefix: &[u8], read_opts: ReadOptions) -> Self::Iterator {
-		let inner = self.db
-			.iterator_cf_opt(self.cf(col as usize), read_opts, IteratorMode::From(prefix, Direction::Forward));
+		let inner =
+			self.db
+				.iterator_cf_opt(self.cf(col as usize), read_opts, IteratorMode::From(prefix, Direction::Forward));
 		EndOnErrorIterator(inner)
 	}
 }

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -257,7 +257,12 @@ impl MallocSizeOf for DBAndColumns {
 	fn size_of(&self, ops: &mut parity_util_mem::MallocSizeOfOps) -> usize {
 		let mut total = self.column_names.size_of(ops)
 			// we have at least one column always, so we can call property on it
-			+ self.static_property_or_warn(0, "rocksdb.block-cache-usage");
+			+ self.cf(0).map(|cf| self.db
+				.property_int_value_cf(cf, "rocksdb.block-cache-usage")
+				.unwrap_or(Some(0))
+				.map(|x| x as usize)
+				.unwrap_or(0)
+			).unwrap_or(0);
 
 		for v in 0..self.column_names.len() {
 			total += self.static_property_or_warn(v, "rocksdb.estimate-table-readers-mem");

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -531,13 +531,9 @@ impl Database {
 					let end_range = end_prefix.unwrap_or_else(|| vec![u8::max_value(); 16]);
 					batch.delete_range_cf(cf, &prefix[..], &end_range[..]);
 					if no_end {
-						use crate::iter::IterationHandler as _;
-
 						let prefix = if prefix.len() > end_range.len() { &prefix[..] } else { &end_range[..] };
-						// We call `iter_with_prefix` directly on `cfs` to avoid taking a lock twice
-						// See https://github.com/paritytech/parity-common/pull/396.
-						let read_opts = generate_read_options();
-						for (key, _) in cfs.iter_with_prefix(col, prefix, read_opts) {
+						for result in self.iter_with_prefix(col, prefix) {
+							let (key, _) = result?;
 							batch.delete_cf(cf, &key[..]);
 						}
 					}
@@ -572,28 +568,30 @@ impl Database {
 	}
 
 	/// Get value by partial key. Prefix size should match configured prefix size.
-	pub fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>> {
-		self.iter_with_prefix(col, prefix).next().map(|(_, v)| v)
+	pub fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> io::Result<Option<DBValue>> {
+		self.iter_with_prefix(col, prefix).next().transpose().map(|m| m.map(|(_k, v)| v.into_vec()))
 	}
 
 	/// Iterator over the data in the given database column index.
 	/// Will hold a lock until the iterator is dropped
 	/// preventing the database from being closed.
-	pub fn iter<'a>(&'a self, col: u32) -> impl Iterator<Item = KeyValuePair> + 'a {
+	pub fn iter<'a>(&'a self, col: u32) -> impl Iterator<Item = io::Result<KeyValuePair>> + 'a {
 		let read_opts = generate_read_options();
-		iter::IterationHandler::iter(&&self.inner, col, read_opts)
+		iter::IterationHandler::iter(&self.inner, col, read_opts)
 	}
 
 	/// Iterator over data in the `col` database column index matching the given prefix.
 	/// Will hold a lock until the iterator is dropped
 	/// preventing the database from being closed.
-	fn iter_with_prefix<'a>(&'a self, col: u32, prefix: &'a [u8]) -> impl Iterator<Item = iter::KeyValuePair> + 'a {
+	fn iter_with_prefix<'a>(&'a self, col: u32, prefix: &'a [u8])
+		-> impl Iterator<Item = io::Result<KeyValuePair>> + 'a
+	{
 		let mut read_opts = generate_read_options();
 		// rocksdb doesn't work with an empty upper bound
 		if let Some(end_prefix) = kvdb::end_prefix(prefix) {
 			read_opts.set_iterate_upper_bound(end_prefix);
 		}
-		iter::IterationHandler::iter_with_prefix(&&self.inner, col, prefix, read_opts)
+		iter::IterationHandler::iter_with_prefix(&self.inner, col, prefix, read_opts)
 	}
 
 	/// The number of column families in the db.
@@ -673,7 +671,7 @@ impl KeyValueDB for Database {
 		Database::get(self, col, key)
 	}
 
-	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>> {
+	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> io::Result<Option<DBValue>> {
 		Database::get_by_prefix(self, col, prefix)
 	}
 
@@ -681,12 +679,14 @@ impl KeyValueDB for Database {
 		Database::write(self, transaction)
 	}
 
-	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = KeyValuePair> + 'a> {
+	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = io::Result<KeyValuePair>> + 'a> {
 		let unboxed = Database::iter(self, col);
 		Box::new(unboxed.into_iter())
 	}
 
-	fn iter_with_prefix<'a>(&'a self, col: u32, prefix: &'a [u8]) -> Box<dyn Iterator<Item = KeyValuePair> + 'a> {
+	fn iter_with_prefix<'a>(&'a self, col: u32, prefix: &'a [u8])
+		-> Box<dyn Iterator<Item = io::Result<KeyValuePair>> + 'a>
+	{
 		let unboxed = Database::iter_with_prefix(self, col, prefix);
 		Box::new(unboxed.into_iter())
 	}

--- a/kvdb-shared-tests/src/lib.rs
+++ b/kvdb-shared-tests/src/lib.rs
@@ -71,7 +71,7 @@ pub fn test_iter(db: &dyn KeyValueDB) -> io::Result<()> {
 	transaction.put(0, key2, key2);
 	db.write(transaction)?;
 
-	let contents: Vec<_> = db.iter(0).into_iter().collect();
+	let contents: Vec<_> = db.iter(0).into_iter().map(Result::unwrap).collect();
 	assert_eq!(contents.len(), 2);
 	assert_eq!(&*contents[0].0, key1);
 	assert_eq!(&*contents[0].1, key1);
@@ -95,7 +95,7 @@ pub fn test_iter_with_prefix(db: &dyn KeyValueDB) -> io::Result<()> {
 	db.write(batch)?;
 
 	// empty prefix
-	let contents: Vec<_> = db.iter_with_prefix(0, b"").into_iter().collect();
+	let contents: Vec<_> = db.iter_with_prefix(0, b"").into_iter().map(Result::unwrap).collect();
 	assert_eq!(contents.len(), 4);
 	assert_eq!(&*contents[0].0, key1);
 	assert_eq!(&*contents[1].0, key2);
@@ -103,24 +103,24 @@ pub fn test_iter_with_prefix(db: &dyn KeyValueDB) -> io::Result<()> {
 	assert_eq!(&*contents[3].0, key4);
 
 	// prefix a
-	let contents: Vec<_> = db.iter_with_prefix(0, b"a").into_iter().collect();
+	let contents: Vec<_> = db.iter_with_prefix(0, b"a").into_iter().map(Result::unwrap).collect();
 	assert_eq!(contents.len(), 3);
 	assert_eq!(&*contents[0].0, key2);
 	assert_eq!(&*contents[1].0, key3);
 	assert_eq!(&*contents[2].0, key4);
 
 	// prefix abc
-	let contents: Vec<_> = db.iter_with_prefix(0, b"abc").into_iter().collect();
+	let contents: Vec<_> = db.iter_with_prefix(0, b"abc").into_iter().map(Result::unwrap).collect();
 	assert_eq!(contents.len(), 2);
 	assert_eq!(&*contents[0].0, key3);
 	assert_eq!(&*contents[1].0, key4);
 
 	// prefix abcde
-	let contents: Vec<_> = db.iter_with_prefix(0, b"abcde").into_iter().collect();
+	let contents: Vec<_> = db.iter_with_prefix(0, b"abcde").into_iter().map(Result::unwrap).collect();
 	assert_eq!(contents.len(), 0);
 
 	// prefix 0
-	let contents: Vec<_> = db.iter_with_prefix(0, b"0").into_iter().collect();
+	let contents: Vec<_> = db.iter_with_prefix(0, b"0").into_iter().map(Result::unwrap).collect();
 	assert_eq!(contents.len(), 1);
 	assert_eq!(&*contents[0].0, key1);
 	Ok(())
@@ -254,7 +254,7 @@ pub fn test_complex(db: &dyn KeyValueDB) -> io::Result<()> {
 
 	assert_eq!(&*db.get(0, key1)?.unwrap(), b"cat");
 
-	let contents: Vec<_> = db.iter(0).into_iter().collect();
+	let contents: Vec<_> = db.iter(0).into_iter().map(Result::unwrap).collect();
 	assert_eq!(contents.len(), 5);
 	assert_eq!(contents[0].0.to_vec(), key1.to_vec());
 	assert_eq!(&*contents[0].1, b"cat");
@@ -262,9 +262,9 @@ pub fn test_complex(db: &dyn KeyValueDB) -> io::Result<()> {
 	assert_eq!(&*contents[1].1, b"dog");
 
 	let mut prefix_iter = db.iter_with_prefix(0, b"04c0");
-	assert_eq!(*prefix_iter.next().unwrap().1, b"caterpillar"[..]);
-	assert_eq!(*prefix_iter.next().unwrap().1, b"beef"[..]);
-	assert_eq!(*prefix_iter.next().unwrap().1, b"fish"[..]);
+	assert_eq!(*prefix_iter.next().unwrap().unwrap().1, b"caterpillar"[..]);
+	assert_eq!(*prefix_iter.next().unwrap().unwrap().1, b"beef"[..]);
+	assert_eq!(*prefix_iter.next().unwrap().unwrap().1, b"fish"[..]);
 
 	let mut batch = db.transaction();
 	batch.delete(0, key1);
@@ -283,8 +283,8 @@ pub fn test_complex(db: &dyn KeyValueDB) -> io::Result<()> {
 	assert!(db.get(0, key1)?.is_none());
 	assert_eq!(&*db.get(0, key3)?.unwrap(), b"elephant");
 
-	assert_eq!(&*db.get_by_prefix(0, key3).unwrap(), b"elephant");
-	assert_eq!(&*db.get_by_prefix(0, key2).unwrap(), b"dog");
+	assert_eq!(&*db.get_by_prefix(0, key3).unwrap().unwrap(), b"elephant");
+	assert_eq!(&*db.get_by_prefix(0, key2).unwrap().unwrap(), b"dog");
 
 	let mut transaction = db.transaction();
 	transaction.put(0, key1, b"horse");

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog].
 - Streamlined API. [661](https://github.com/paritytech/parity-common/pull/661)
   - `fn get_by_prefix` return type changed to `io::Result<Option<DBValue>>`
   - `fn has_prefix` return type changed to `io::Result<bool>`
-  - Iterator item changed to `io::Result<KeyValuePair>`
+  - Iterator item changed to `io::Result<DBKeyValue>`
 
 ## [0.11.0] - 2022-02-04
 ### Breaking

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 ### Breaking
 - Removed `fn restore` from `KeyValueDB` trait. [662](https://github.com/paritytech/parity-common/pull/662)
+- Streamlined API. [661](https://github.com/paritytech/parity-common/pull/661)
+  - `fn get_by_prefix` return type changed to `io::Result<Option<DBValue>>`
+  - `fn has_prefix` return type changed to `io::Result<bool>`
+  - Iterator item changed to `io::Result<KeyValuePair>`
 
 ## [0.11.0] - 2022-02-04
 ### Breaking

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -20,6 +20,8 @@ pub const PREFIX_LEN: usize = 12;
 pub type DBValue = Vec<u8>;
 /// Database keys.
 pub type DBKey = SmallVec<[u8; 32]>;
+/// A tuple holding key and value data, used in the iterator item type.
+pub type KeyValuePair = (Box<[u8]>, Box<[u8]>);
 
 pub use io_stats::{IoStats, Kind as IoStatsKind};
 
@@ -118,8 +120,7 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	fn write(&self, transaction: DBTransaction) -> io::Result<()>;
 
 	/// Iterate over the data for a given column.
-	fn iter<'a>(&'a self, col: u32)
-		-> Box<dyn Iterator<Item = io::Result<(Box<[u8]>, Box<[u8]>)>> + 'a>;
+	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = io::Result<KeyValuePair>> + 'a>;
 
 	/// Iterate over the data for a given column, returning all key/value pairs
 	/// where the key starts with the given prefix.
@@ -127,7 +128,7 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 		&'a self,
 		col: u32,
 		prefix: &'a [u8],
-	) -> Box<dyn Iterator<Item = io::Result<(Box<[u8]>, Box<[u8]>)>> + 'a>;
+	) -> Box<dyn Iterator<Item = io::Result<KeyValuePair>> + 'a>;
 
 	/// Query statistics.
 	///

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -21,7 +21,7 @@ pub type DBValue = Vec<u8>;
 /// Database keys.
 pub type DBKey = SmallVec<[u8; 32]>;
 /// A tuple holding key and value data, used in the iterator item type.
-pub type KeyValuePair = (Box<[u8]>, Box<[u8]>);
+pub type DBKeyValue = (DBKey, DBValue);
 
 pub use io_stats::{IoStats, Kind as IoStatsKind};
 
@@ -120,7 +120,7 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	fn write(&self, transaction: DBTransaction) -> io::Result<()>;
 
 	/// Iterate over the data for a given column.
-	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = io::Result<KeyValuePair>> + 'a>;
+	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = io::Result<DBKeyValue>> + 'a>;
 
 	/// Iterate over the data for a given column, returning all key/value pairs
 	/// where the key starts with the given prefix.
@@ -128,7 +128,7 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 		&'a self,
 		col: u32,
 		prefix: &'a [u8],
-	) -> Box<dyn Iterator<Item = io::Result<KeyValuePair>> + 'a>;
+	) -> Box<dyn Iterator<Item = io::Result<DBKeyValue>> + 'a>;
 
 	/// Query statistics.
 	///

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -112,13 +112,14 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	fn get(&self, col: u32, key: &[u8]) -> io::Result<Option<DBValue>>;
 
 	/// Get the first value matching the given prefix.
-	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>>;
+	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> io::Result<Option<DBValue>>;
 
 	/// Write a transaction of changes to the backing store.
 	fn write(&self, transaction: DBTransaction) -> io::Result<()>;
 
 	/// Iterate over the data for a given column.
-	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
+	fn iter<'a>(&'a self, col: u32)
+		-> Box<dyn Iterator<Item = io::Result<(Box<[u8]>, Box<[u8]>)>> + 'a>;
 
 	/// Iterate over the data for a given column, returning all key/value pairs
 	/// where the key starts with the given prefix.
@@ -126,12 +127,12 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 		&'a self,
 		col: u32,
 		prefix: &'a [u8],
-	) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
+	) -> Box<dyn Iterator<Item = io::Result<(Box<[u8]>, Box<[u8]>)>> + 'a>;
 
 	/// Query statistics.
 	///
 	/// Not all kvdb implementations are able or expected to implement this, so by
-	/// default, empty statistics is returned. Also, not all kvdb implementation
+	/// default, empty statistics is returned. Also, not all kvdb implementations
 	/// can return every statistic or configured to do so (some statistics gathering
 	/// may impede the performance and might be off by default).
 	fn io_stats(&self, _kind: IoStatsKind) -> IoStats {
@@ -144,8 +145,8 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 	}
 
 	/// Check for the existence of a value by prefix.
-	fn has_prefix(&self, col: u32, prefix: &[u8]) -> bool {
-		self.get_by_prefix(col, prefix).is_some()
+	fn has_prefix(&self, col: u32, prefix: &[u8]) -> io::Result<bool> {
+		self.get_by_prefix(col, prefix).map(|opt| opt.is_some())
 	}
 }
 

--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -35,11 +35,11 @@ primitive-types = { version = "0.11", path = "../primitive-types", default-featu
 winapi = { version = "0.3.8", features = ["heapapi"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies.tikv-jemallocator]
-version = "0.4.1"
+version = "0.5.0"
 optional = true
 
 [target.'cfg(not(target_os = "windows"))'.dependencies.tikv-jemalloc-ctl]
-version = "0.4.2"
+version = "0.5.0"
 optional = true
 
 [features]


### PR DESCRIPTION
The rocksdb upgrade seems non-breaking, but it uses `tikv-jemalloc-sys` transitively which links to the native library `jemalloc`.
It's about time we release a new version of each crate anyway.

Depends on: #662.