### PR TITLE
rocksdb: remove and simplify a bunch of stuff

### DIFF
--- a/kvdb-memorydb/CHANGELOG.md
+++ b/kvdb-memorydb/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Updated `kvdb` to 0.12. [662](https://github.com/paritytech/parity-common/pull/662)
 
 ## [0.11.0] - 2022-02-04
 ### Breaking

--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -117,10 +117,6 @@ impl KeyValueDB for InMemory {
 			None => Box::new(None.into_iter()),
 		}
 	}
-
-	fn restore(&self, _new_db: &str) -> io::Result<()> {
-		Err(io::Error::new(io::ErrorKind::Other, "Attempted to restore in-memory database"))
-	}
 }
 
 #[cfg(test)]

--- a/kvdb-rocksdb/CHANGELOG.md
+++ b/kvdb-rocksdb/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Removed `owning_ref` from dependencies :tada:. [662](https://github.com/paritytech/parity-common/pull/662)
+### Breaking
+- Update `kvdb` to 0.12. [662](https://github.com/paritytech/parity-common/pull/662)
+  - `add_column` and `remove_last_column` now require `&mut self`
 
 ## [0.15.2] - 2022-03-20
 - Disable `jemalloc` feature for `rocksdb` where it is not working. [#633](https://github.com/paritytech/parity-common/pull/633)

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -14,13 +14,11 @@ harness = false
 
 [dependencies]
 smallvec = "1.0.0"
-fs-swap = "0.2.6"
 kvdb = { path = "../kvdb", version = "0.11" }
 log = "0.4.8"
 num_cpus = "1.10.1"
 parking_lot = "0.12.0"
 regex = "1.3.1"
-owning_ref = "0.4.0"
 parity-util-mem = { path = "../parity-util-mem", version = "0.11", default-features = false, features = ["std", "smallvec"] }
 
 # OpenBSD and MSVC are unteested and shouldn't enable jemalloc:

--- a/kvdb-rocksdb/src/iter.rs
+++ b/kvdb-rocksdb/src/iter.rs
@@ -16,58 +16,10 @@
 //! See https://github.com/facebook/rocksdb/wiki/Prefix-Seek-API-Changes for details.
 
 use crate::DBAndColumns;
-use owning_ref::{OwningHandle, StableAddress};
-use parking_lot::RwLockReadGuard;
 use rocksdb::{DBIterator, Direction, IteratorMode, ReadOptions};
-use std::ops::{Deref, DerefMut};
 
 /// A tuple holding key and value data, used as the iterator item type.
 pub type KeyValuePair = (Box<[u8]>, Box<[u8]>);
-
-/// Iterator with built-in synchronization.
-pub struct ReadGuardedIterator<'a, I, T> {
-	inner: OwningHandle<UnsafeStableAddress<'a, Option<T>>, DerefWrapper<Option<I>>>,
-}
-
-// We can't implement `StableAddress` for a `RwLockReadGuard`
-// directly due to orphan rules.
-#[repr(transparent)]
-struct UnsafeStableAddress<'a, T>(RwLockReadGuard<'a, T>);
-
-impl<'a, T> Deref for UnsafeStableAddress<'a, T> {
-	type Target = T;
-
-	fn deref(&self) -> &Self::Target {
-		self.0.deref()
-	}
-}
-
-// RwLockReadGuard dereferences to a stable address; qed
-unsafe impl<'a, T> StableAddress for UnsafeStableAddress<'a, T> {}
-
-struct DerefWrapper<T>(T);
-
-impl<T> Deref for DerefWrapper<T> {
-	type Target = T;
-
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
-}
-
-impl<T> DerefMut for DerefWrapper<T> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
-	}
-}
-
-impl<'a, I: Iterator, T> Iterator for ReadGuardedIterator<'a, I, T> {
-	type Item = I::Item;
-
-	fn next(&mut self) -> Option<Self::Item> {
-		self.inner.deref_mut().as_mut().and_then(|iter| iter.next())
-	}
-}
 
 /// Instantiate iterators yielding `KeyValuePair`s.
 pub trait IterationHandler {
@@ -82,38 +34,6 @@ pub trait IterationHandler {
 	/// https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L1169).
 	/// The `Iterator` iterates over keys which start with the provided `prefix`.
 	fn iter_with_prefix(&self, col: u32, prefix: &[u8], read_opts: ReadOptions) -> Self::Iterator;
-}
-
-impl<'a, T> ReadGuardedIterator<'a, <&'a T as IterationHandler>::Iterator, T>
-where
-	&'a T: IterationHandler,
-{
-	/// Creates a new `ReadGuardedIterator` that maps `RwLock<RocksDB>` to `RwLock<DBIterator>`,
-	/// where `DBIterator` iterates over all keys.
-	pub fn new(read_lock: RwLockReadGuard<'a, Option<T>>, col: u32, read_opts: ReadOptions) -> Self {
-		Self { inner: Self::new_inner(read_lock, |db| db.iter(col, read_opts)) }
-	}
-
-	/// Creates a new `ReadGuardedIterator` that maps `RwLock<RocksDB>` to `RwLock<DBIterator>`,
-	/// where `DBIterator` iterates over keys which start with the given prefix.
-	pub fn new_with_prefix(
-		read_lock: RwLockReadGuard<'a, Option<T>>,
-		col: u32,
-		prefix: &[u8],
-		read_opts: ReadOptions,
-	) -> Self {
-		Self { inner: Self::new_inner(read_lock, |db| db.iter_with_prefix(col, prefix, read_opts)) }
-	}
-
-	fn new_inner(
-		rlock: RwLockReadGuard<'a, Option<T>>,
-		f: impl FnOnce(&'a T) -> <&'a T as IterationHandler>::Iterator,
-	) -> OwningHandle<UnsafeStableAddress<'a, Option<T>>, DerefWrapper<Option<<&'a T as IterationHandler>::Iterator>>> {
-		OwningHandle::new_with_fn(UnsafeStableAddress(rlock), move |rlock| {
-			let rlock = unsafe { rlock.as_ref().expect("initialized as non-null; qed") };
-			DerefWrapper(rlock.as_ref().map(f))
-		})
-	}
 }
 
 impl<'a> IterationHandler for &'a DBAndColumns {

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Breaking
+- Removed `fn remove` from `KeyValueDB` trait. [662](https://github.com/paritytech/parity-common/pull/662)
 
 ## [0.11.0] - 2022-02-04
 ### Breaking

--- a/kvdb/CHANGELOG.md
+++ b/kvdb/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 ### Breaking
-- Removed `fn remove` from `KeyValueDB` trait. [662](https://github.com/paritytech/parity-common/pull/662)
+- Removed `fn restore` from `KeyValueDB` trait. [662](https://github.com/paritytech/parity-common/pull/662)
 
 ## [0.11.0] - 2022-02-04
 ### Breaking

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -128,9 +128,6 @@ pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
 		prefix: &'a [u8],
 	) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
 
-	/// Attempt to replace this database with a new one located at the given path.
-	fn restore(&self, new_db: &str) -> io::Result<()>;
-
 	/// Query statistics.
 	///
 	/// Not all kvdb implementations are able or expected to implement this, so by


### PR DESCRIPTION
Summary of changes:
* `KeyValueDB::restore` is removed. IIRC this was mainly used the parity-ethereum. I grepped usage in substrate and didn't find any
* `RwLock` around the inner db was needed for this method and now it's gone
* `add_column` and `remove_last_column` now require `&mut self`
* `owning_ref` is gone :tada: 

Closes #659