### PR TITLE
Allow deserializing from newtype structs too

### DIFF
--- a/primitive-types/impls/serde/CHANGELOG.md
+++ b/primitive-types/impls/serde/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.4.0] - 2022-08-31
+## [0.4.0] - 2022-09-02
 - Support deserializing H256 et al from bytes or sequences of bytes, too. [#668](https://github.com/paritytech/parity-common/pull/668)
 - Support deserializing H256 et al from newtype structs containing anything compatible, too. [#672](https://github.com/paritytech/parity-common/pull/672)
 - Migrated to 2021 edition, enforcing MSRV of `1.56.1`. [#601](https://github.com/paritytech/parity-common/pull/601)

--- a/primitive-types/impls/serde/CHANGELOG.md
+++ b/primitive-types/impls/serde/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [0.4.0] - 2022-08-31
 - Support deserializing H256 et al from bytes or sequences of bytes, too. [#668](https://github.com/paritytech/parity-common/pull/668)
+- Support deserializing H256 et al from newtype structs containing anything compatible, too. [#672](https://github.com/paritytech/parity-common/pull/672)
 - Migrated to 2021 edition, enforcing MSRV of `1.56.1`. [#601](https://github.com/paritytech/parity-common/pull/601)
 
 ## [0.3.2] - 2021-11-10

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -501,5 +501,4 @@ mod tests {
 		assert_eq!(n, 3);
 		assert_eq!(output, vec![1, 2, 3, 0, 0]);
 	}
-
 }

--- a/primitive-types/impls/serde/src/serialize.rs
+++ b/primitive-types/impls/serde/src/serialize.rs
@@ -231,6 +231,10 @@ where
 			}
 			Ok(bytes)
 		}
+
+		fn visit_newtype_struct<D: Deserializer<'b>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+			deserializer.deserialize_bytes(self)
+		}
 	}
 
 	deserializer.deserialize_str(Visitor)
@@ -308,6 +312,10 @@ where
 				v.push(n);
 			}
 			self.visit_byte_buf(v)
+		}
+
+		fn visit_newtype_struct<D: Deserializer<'b>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+			deserializer.deserialize_bytes(self)
 		}
 	}
 
@@ -493,4 +501,5 @@ mod tests {
 		assert_eq!(n, 3);
 		assert_eq!(output, vec![1, 2, 3, 0, 0]);
 	}
+
 }


### PR DESCRIPTION
Since H256 et al are newtype wrappers around bytes, I geuss it makes sense to support deserializing from such newtype wrappers of compatible things, too :)