### PR TITLE
parity-util-mem: remove wee_alloc

### DIFF
--- a/parity-util-mem/Cargo.toml
+++ b/parity-util-mem/Cargo.toml
@@ -18,7 +18,6 @@ build = "build.rs"
 [dependencies]
 cfg-if = "1.0.0"
 dlmalloc = { version = "0.2.1", features = ["global"], optional = true }
-wee_alloc = { version = "0.4.5", optional = true }
 lru = { version = "0.7", optional = true }
 hashbrown = { version = "0.12", optional = true }
 mimalloc = { version = "0.1.18", optional = true }
@@ -47,8 +46,6 @@ default = ["std", "ethereum-impls", "lru", "hashbrown", "smallvec", "primitive-t
 std = ["parking_lot"]
 # use dlmalloc as global allocator
 dlmalloc-global = ["dlmalloc", "estimate-heapsize"]
-# use wee_alloc as global allocator
-weealloc-global = ["wee_alloc", "estimate-heapsize"]
 # use jemalloc as global allocator
 jemalloc-global = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 # use mimalloc as global allocator

--- a/parity-util-mem/src/allocators.rs
+++ b/parity-util-mem/src/allocators.rs
@@ -10,25 +10,21 @@
 //! Features are:
 //! - windows:
 //! 	 - no features: default implementation from servo `heapsize` crate
-//! 	 - weealloc: default to `estimate_size`
 //! 	 - dlmalloc: default to `estimate_size`
 //! 	 - jemalloc: default windows allocator is used instead
 //! 	 - mimalloc: use mimallocator crate
 //! - arch x86:
 //! 	 - no features: use default alloc
 //! 	 - jemalloc: use tikv-jemallocator crate
-//! 	 - weealloc: default to `estimate_size`
 //! 	 - dlmalloc: default to `estimate_size`
 //! 	 - mimalloc: use mimallocator crate
 //! - arch x86/macos:
 //! 	 - no features: use default alloc, requires using `estimate_size`
 //! 	 - jemalloc: use tikv-jemallocator crate
-//! 	 - weealloc: default to `estimate_size`
 //! 	 - dlmalloc: default to `estimate_size`
 //! 	 - mimalloc: use mimallocator crate
 //! - arch wasm32:
 //! 	 - no features: default to `estimate_size`
-//! 	 - weealloc: default to `estimate_size`
 //! 	 - dlmalloc: default to `estimate_size`
 //! 	 - jemalloc: compile error
 //! 	 - mimalloc: compile error (until https://github.com/microsoft/mimalloc/pull/32 is merged)
@@ -50,7 +46,6 @@ mod usable_size {
 		if #[cfg(any(
 			target_arch = "wasm32",
 			feature = "estimate-heapsize",
-			feature = "weealloc-global",
 			feature = "dlmalloc-global",
 		))] {
 

--- a/parity-util-mem/src/lib.rs
+++ b/parity-util-mem/src/lib.rs
@@ -34,13 +34,6 @@ cfg_if::cfg_if! {
 
 		mod memory_stats_noop;
 		use memory_stats_noop as memory_stats;
-	} else if #[cfg(feature = "weealloc-global")] {
-		/// Global allocator
-		#[global_allocator]
-		pub static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
-		mod memory_stats_noop;
-		use memory_stats_noop as memory_stats;
 	} else if #[cfg(all(
 			feature = "mimalloc-global",
 			not(target_arch = "wasm32")


### PR DESCRIPTION
We don't use it and it's unmaintained.