### PR TITLE
Uint: Add support for bit and,or,xor assign traits

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1508,6 +1508,12 @@ macro_rules! construct_uint {
 			}
 		}
 
+		impl $crate::core_::ops::BitAndAssign<$name> for $name {
+			fn bitand_assign(&mut self, rhs: $name) {
+				*self = *self & rhs;
+			}
+		}
+
 		impl $crate::core_::ops::BitXor<$name> for $name {
 			type Output = $name;
 
@@ -1523,6 +1529,12 @@ macro_rules! construct_uint {
 			}
 		}
 
+		impl $crate::core_::ops::BitXorAssign<$name> for $name {
+			fn bitxor_assign(&mut self, rhs: $name) {
+				*self = *self ^ rhs;
+			}
+		}
+
 		impl $crate::core_::ops::BitOr<$name> for $name {
 			type Output = $name;
 
@@ -1535,6 +1547,12 @@ macro_rules! construct_uint {
 					ret[i] = arr1[i] | arr2[i];
 				}
 				$name(ret)
+			}
+		}
+
+		impl $crate::core_::ops::BitOrAssign<$name> for $name {
+			fn bitor_assign(&mut self, rhs: $name) {
+				*self = *self | rhs;
 			}
 		}
 

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -1151,6 +1151,47 @@ fn trailing_zeros() {
 	assert_eq!(U256::from("0000000000000000000000000000000000000000000000000000000000000000").trailing_zeros(), 256);
 }
 
+#[test]
+fn bit_assign() {
+	fn check(a: U256, b: U256) {
+		// and
+		{
+			let mut x = a;
+			x &= b;
+			assert_eq!(x, a & b);
+		}
+		// or
+		{
+			let mut x = a;
+			x |= b;
+			assert_eq!(x, a | b);
+		}
+		// xor
+		{
+			let mut x = a;
+			x ^= b;
+			assert_eq!(x, a ^ b);
+		}
+		// shr
+		{
+			let mut x = a;
+			x >>= b;
+			assert_eq!(x, a >> b);
+		}
+		// shl
+		{
+			let mut x = a;
+			x <<= b;
+			assert_eq!(x, a << b);
+		}
+	}
+
+	check(U256::from(9), U256::from(999999));
+	check(U256::from(0), U256::from(0));
+	check(U256::from(23432), U256::from(u32::MAX));	
+	check(U256::MAX, U256::zero());	
+}
+
 #[cfg(feature = "quickcheck")]
 pub mod laws {
 	use super::construct_uint;

--- a/uint/tests/uint_tests.rs
+++ b/uint/tests/uint_tests.rs
@@ -1188,8 +1188,8 @@ fn bit_assign() {
 
 	check(U256::from(9), U256::from(999999));
 	check(U256::from(0), U256::from(0));
-	check(U256::from(23432), U256::from(u32::MAX));	
-	check(U256::MAX, U256::zero());	
+	check(U256::from(23432), U256::from(u32::MAX));
+	check(U256::MAX, U256::zero());
 }
 
 #[cfg(feature = "quickcheck")]


### PR DESCRIPTION
Add support uint support for traits `BitAndAssign`, `BitXorAssign ` and `BitOrAssign `.

Fixes #401