### PR TITLE
uint: add casting from/to U64

### DIFF
--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -31,6 +31,11 @@ pub enum Error {
 }
 
 construct_uint! {
+	/// 64-bit unsigned integer.
+	#[cfg_attr(feature = "scale-info", derive(TypeInfo))]
+	pub struct U64(1);
+}
+construct_uint! {
 	/// 128-bit unsigned integer.
 	#[cfg_attr(feature = "scale-info", derive(TypeInfo))]
 	pub struct U128(2);
@@ -141,6 +146,15 @@ mod rlp {
 
 impl_fixed_hash_conversions!(H256, H160);
 
+impl U64 {
+	/// Multiplies two 64-bit integers to produce full 128-bit integer.
+	/// Overflow is not possible.
+	#[inline(always)]
+	pub fn full_mul(self, other: Self) -> U128 {
+		U128(uint_full_mul_reg!(Self, 1, self, other))
+	}
+}
+
 impl U128 {
 	/// Multiplies two 128-bit integers to produce full 256-bit integer.
 	/// Overflow is not possible.
@@ -159,6 +173,24 @@ impl U256 {
 	}
 }
 
+impl From<U64> for U128 {
+	fn from(value: U64) -> Self {
+		Self([value.0[0], 0])
+	}
+}
+
+impl From<U64> for U256 {
+	fn from(value: U64) -> Self {
+		Self([value.0[0], 0, 0, 0])
+	}
+}
+
+impl From<U64> for U512 {
+	fn from(value: U64) -> Self {
+		Self([value.0[0], 0, 0, 0, 0, 0, 0, 0])
+	}
+}
+
 impl From<U256> for U512 {
 	fn from(value: U256) -> U512 {
 		let U256(ref arr) = value;
@@ -168,6 +200,42 @@ impl From<U256> for U512 {
 		ret[2] = arr[2];
 		ret[3] = arr[3];
 		U512(ret)
+	}
+}
+
+impl TryFrom<U128> for U64 {
+	type Error = Error;
+
+	fn try_from(value: U128) -> Result<Self, Error> {
+		let U128(ref arr) = value;
+		if arr[1] != 0 {
+			return Err(Error::Overflow)
+		}
+		Ok(Self([arr[0]]))
+	}
+}
+
+impl TryFrom<U256> for U64 {
+	type Error = Error;
+
+	fn try_from(value: U256) -> Result<Self, Error> {
+		let U256(ref arr) = value;
+		if arr[1] | arr[2]| arr[3] != 0 {
+			return Err(Error::Overflow)
+		}
+		Ok(Self([arr[0]]))
+	}
+}
+
+impl TryFrom<U512> for U64 {
+	type Error = Error;
+
+	fn try_from(value: U512) -> Result<Self, Error> {
+		let U512(ref arr) = value;
+		if arr[1] | arr[2]| arr[3]| arr[4] | arr[5] | arr[6] | arr[7] != 0 {
+			return Err(Error::Overflow)
+		}
+		Ok(Self([arr[0]]))
 	}
 }
 

--- a/primitive-types/tests/cast.rs
+++ b/primitive-types/tests/cast.rs
@@ -1,0 +1,44 @@
+use primitive_types::{Error, U128, U256, U512, U64};
+
+
+#[test]
+#[allow(non_snake_case)]
+fn from_U64() {
+    let a = U64::from(222);
+
+    assert_eq!(U128::from(a), U128::from(222), "U64 -> U128");
+    assert_eq!(U256::from(a), U256::from(222), "U64 -> U256");
+    assert_eq!(U512::from(a), U512::from(222), "U64 -> U512");		
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn to_U64() {
+    // U128 -> U64
+    assert_eq!(U64::try_from(U128([222, 0])), Ok(U64::from(222)), "U128 -> U64");
+    assert_eq!(U64::try_from(U128([222, 1])), Err(Error::Overflow), "U128 -> U64 :: Overflow");
+
+    // U256 -> U64
+    assert_eq!(U64::try_from(U256([222, 0, 0, 0])), Ok(U64::from(222)), "U256 -> U64");
+    for i in 1..4 {
+        let mut arr = [222, 0, 0, 0];
+        arr[i] = 1;
+        assert_eq!(U64::try_from(U256(arr)), Err(Error::Overflow), "U256 -> U64 :: Overflow");
+    }
+
+    // U512 -> U64
+    assert_eq!(U64::try_from(U512([222, 0, 0, 0, 0, 0, 0, 0])),Ok(U64::from(222)), "U512 -> U64");
+    for i in 1..8 {
+        let mut arr = [222, 0, 0, 0, 0, 0, 0, 0];
+        arr[i] = 1;
+        assert_eq!(U64::try_from(U512(arr)), Err(Error::Overflow), "U512 -> U64");
+    }
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn full_mul_U64() {
+    let a = U64::MAX;
+    let b = U64::from(2);
+    assert_eq!(a.full_mul(b), U128::from(a)*U128::from(b))
+}


### PR DESCRIPTION
Add uint casting support for U64 in `primitive-types` 
- implement From trait for casting uint from U64
- implement TryFrom trait for casting uint to U64
- implement `full_mul` for U64
- add tests for added functionality 

Fixes  #568