### PR TITLE
Remove `parity-util-mem`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,26 +106,6 @@ jobs:
           command: test
           args: -p uint --target=mips64-unknown-linux-gnuabi64
 
-      - name: Test parity-util-mem on Android
-        if: runner.os == 'Linux'
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: -p parity-util-mem --target=aarch64-linux-android
-
-      - name: Test parity-util-mem estimate-heapsize 
-        run: cargo test -p parity-util-mem --features='estimate-heapsize'
-
-      - name: Test parity-util-mem jemalloc-global 
-        run: cargo test -p parity-util-mem --features='jemalloc-global'
-
-      - name: Test parity-util-mem mimalloc-global 
-        run: cargo test -p parity-util-mem --features='mimalloc-global'
-
-      - name: Test parity-util-mem dlmalloc-global 
-        run: cargo test -p parity-util-mem --no-default-features --features='dlmalloc-global'
-
   test_windows:
     name: Test Windows
     runs-on: windows-latest

--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-parity-util-mem = { path = "../parity-util-mem", version = "0.12", default-features = false, features = ["std"] }
 parking_lot = "0.12.0"
 kvdb = { version = "0.12", path = "../kvdb" }
 

--- a/kvdb-memorydb/src/lib.rs
+++ b/kvdb-memorydb/src/lib.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 use kvdb::{DBKeyValue, DBOp, DBTransaction, DBValue, KeyValueDB};
-use parity_util_mem::MallocSizeOf;
 use parking_lot::RwLock;
 use std::{
 	collections::{BTreeMap, HashMap},
@@ -16,7 +15,7 @@ use std::{
 
 /// A key-value database fulfilling the `KeyValueDB` trait, living in memory.
 /// This is generally intended for tests and is not particularly optimized.
-#[derive(Default, MallocSizeOf)]
+#[derive(Default)]
 pub struct InMemory {
 	columns: RwLock<HashMap<u32, BTreeMap<Vec<u8>, DBValue>>>,
 }

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -19,7 +19,6 @@ log = "0.4.8"
 num_cpus = "1.10.1"
 parking_lot = "0.12.0"
 regex = "1.3.1"
-parity-util-mem = { path = "../parity-util-mem", version = "0.12", default-features = false, features = ["std", "smallvec"] }
 
 # OpenBSD and MSVC are unteested and shouldn't enable jemalloc:
 # https://github.com/tikv/jemallocator/blob/52de4257fab3e770f73d5174c12a095b49572fba/jemalloc-sys/build.rs#L26-L27

--- a/kvdb-rocksdb/examples/memtest.rs
+++ b/kvdb-rocksdb/examples/memtest.rs
@@ -145,7 +145,6 @@ fn main() {
 			println!("{}", timestamp);
 			println!("\tData written: {} keys - {} Mb", step + 1, ((step + 1) * 64 * 128) / 1024 / 1024);
 			println!("\tProcess memory used as seen by the OS: {} Mb", proc_memory_usage() / 1024);
-			println!("\tMemory used as reported by rocksdb: {} Mb\n", parity_util_mem::malloc_size(&db) / 1024 / 1024);
 		}
 
 		step += 1;

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -10,4 +10,3 @@ rust-version = "1.56.1"
 
 [dependencies]
 smallvec = "1.0.0"
-parity-util-mem = { path = "../parity-util-mem", version = "0.12", default-features = false }

--- a/kvdb/src/lib.rs
+++ b/kvdb/src/lib.rs
@@ -104,7 +104,7 @@ impl DBTransaction {
 ///
 /// The API laid out here, along with the `Sync` bound implies interior synchronization for
 /// implementation.
-pub trait KeyValueDB: Sync + Send + parity_util_mem::MallocSizeOf {
+pub trait KeyValueDB: Sync + Send {
 	/// Helper to create a new transaction.
 	fn transaction(&self) -> DBTransaction {
 		DBTransaction::new()


### PR DESCRIPTION
# PULL REQUEST

## Overview

Removes `parity-util-mem` from `kvdb`, `kvdb-memorydb` and `kvdb-rocksdb`.

Note that we will still need to update the versions, changelogs, and git tags for these crates, and then publish them. I can do that in this PR, if desired, or someone else can.

## Related Issues

See https://github.com/paritytech/substrate/issues/12658.