### PR TITLE
Uint: Fix clippy warnings

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -128,7 +128,7 @@ impl From<FromHexError> for FromStrRadixErr {
 }
 
 /// Conversion from decimal string error
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FromDecStrErr {
 	/// Char not from range 0-9
 	InvalidCharacter,
@@ -1001,13 +1001,13 @@ macro_rules! construct_uint {
 				while n > u_one {
 					if is_even(&n) {
 						x = x * x;
-						n = n >> 1usize;
+						n >>= 1usize;
 					} else {
 						y = x * y;
 						x = x * x;
 						// to reduce odd number by 1 we should just clear the last bit
-						n.0[$n_words-1] = n.0[$n_words-1] & ((!0u64)>>1);
-						n = n >> 1usize;
+						n.0[$n_words-1] &= (!0u64)>>1;
+						n >>= 1usize;
 					}
 				}
 				x * y
@@ -1028,7 +1028,7 @@ macro_rules! construct_uint {
 				while n > u_one {
 					if is_even(&n) {
 						x = $crate::overflowing!(x.overflowing_mul(x), overflow);
-						n = n >> 1usize;
+						n >>= 1usize;
 					} else {
 						y = $crate::overflowing!(x.overflowing_mul(y), overflow);
 						x = $crate::overflowing!(x.overflowing_mul(x), overflow);
@@ -1678,7 +1678,7 @@ macro_rules! construct_uint {
 				loop {
 					let digit = (current % ten).low_u64() as u8;
 					buf[i] = digit + b'0';
-					current = current / ten;
+					current /= ten;
 					if current.is_zero() {
 						break;
 					}


### PR DESCRIPTION
Fixes #660 (I could not find the source for manual_range_contains, nor did clippy complain, so I assume it was already fixed by accident or the clippy rules changed)

This change allows using the uint crate while using clippy without having to disable the `assign_op_pattern` rule.

- In the uint crate
- When using the uint crate