### PR TITLE
Make alloc public and bump version

### DIFF
--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/bounded-collections/src/lib.rs
+++ b/bounded-collections/src/lib.rs
@@ -9,7 +9,7 @@
 //! Collection types that have an upper limit on how many elements that they can contain, and
 //! supporting traits that aid in defining the limit.
 
-extern crate alloc;
+pub extern crate alloc;
 
 pub mod bounded_btree_map;
 pub mod bounded_btree_set;


### PR DESCRIPTION
Local testing of substrate is failing with:

```
error[E0603]: crate `alloc` is private
   --> /home/keith/.cargo/registry/src/github.com-1ecc6299db9ec823/bounded-collections-0.1.0/src/lib.rs:238:12
    |
238 |             $crate::alloc::vec![$($values),*].try_into().unwrap()
    |                     ^^^^^ private crate
    |
note: the crate `alloc` is defined here
   --> /home/keith/.cargo/registry/src/github.com-1ecc6299db9ec823/bounded-collections-0.1.0/src/lib.rs:12:1
    |
12  | extern crate alloc;
    | ^^^^^^^^^^^^^^^^^^^
```

when attempting to switch over to the `bounded-collections` crate, and hence we need to make `extern crate alloc` public.