### PR TITLE
bounded-collections: Fixes `Hash` impl

### DIFF
--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.1.5] - 2023-02-13
+- Fixed `Hash` impl (previously it could not be used in practice, because the size bound was required to also implement `Hash`).
+
 ## [0.1.4] - 2023-01-28
 - Fixed unnecessary decoding and allocations for bounded types, when the decoded length is greater than the allowed bound.
 - Add `Hash` derivation (when `feature = "std"`) for bounded types.

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
Previously it could not be used in practice, because the size bound was required to also implement `Hash`.

See https://github.com/paritytech/polkadot/pull/6603#discussion_r1098914268.

Also bumps the patch version.