### PR TITLE
doc: unsigned int byte() order

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -732,7 +732,7 @@ macro_rules! construct_uint {
 				r
 			}
 
-			/// Return specific byte.
+			/// Return specific byte. Byte 0 is the least significant value (ie~ little endian).
 			///
 			/// # Panics
 			///


### PR DESCRIPTION
Would have saved me a couple minutes if the docs had reminded me that U256 is represented as little-endian