### PR TITLE
fixed-hash: Derive PartialEq and Eq instead of implementing them manually

### DIFF
--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -43,6 +43,7 @@ macro_rules! construct_fixed_hash {
 	( $(#[$attr:meta])* $visibility:vis struct $name:ident ( $n_bytes:expr ); ) => {
 		#[repr(C)]
 		$(#[$attr])*
+		#[derive(PartialEq, Eq)]
 		$visibility struct $name (pub [u8; $n_bytes]);
 
 		impl From<[u8; $n_bytes]> for $name {
@@ -262,8 +263,6 @@ macro_rules! construct_fixed_hash {
 				ret
 			}
 		}
-
-		impl $crate::core_::cmp::Eq for $name {}
 
 		impl $crate::core_::cmp::PartialOrd for $name {
 			fn partial_cmp(&self, other: &Self) -> Option<$crate::core_::cmp::Ordering> {
@@ -531,13 +530,6 @@ macro_rules! impl_rand_for_fixed_hash {
 #[doc(hidden)]
 macro_rules! impl_cmp_for_fixed_hash {
 	( $name:ident ) => {
-		impl $crate::core_::cmp::PartialEq for $name {
-			#[inline]
-			fn eq(&self, other: &Self) -> bool {
-				self.as_bytes() == other.as_bytes()
-			}
-		}
-
 		impl $crate::core_::cmp::Ord for $name {
 			#[inline]
 			fn cmp(&self, other: &Self) -> $crate::core_::cmp::Ordering {

--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -349,6 +349,16 @@ fn display_and_debug() {
 	test_for(0x1000, "0000000000001000", "0000…1000");
 }
 
+
+#[test]
+fn const_matching_works() {
+	const ONES: H32 = H32::repeat_byte(1);
+	match H32::repeat_byte(0) {
+		ONES => unreachable!(),
+		_ => {}
+	}
+}
+
 mod ops {
 	use super::*;
 

--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -349,13 +349,12 @@ fn display_and_debug() {
 	test_for(0x1000, "0000000000001000", "0000…1000");
 }
 
-
 #[test]
 fn const_matching_works() {
 	const ONES: H32 = H32::repeat_byte(1);
 	match H32::repeat_byte(0) {
 		ONES => unreachable!(),
-		_ => {}
+		_ => {},
 	}
 }
 


### PR DESCRIPTION
The motivation for this is that Rust only lets you use named constants (as opposed to literals) for pattern matching if the value's type has derived `PartialEq` and `Eq` implementations. So trying to compile the following code:
```
use ethereum_types::H160;

const ONE: H160 = H160::repeat_byte(1);;
const TWO: H160 = H160::repeat_byte(2);

fn main() {
    let x = H160::repeat_byte(3);
    match x {
        ONE => println!("it's a one!"),
        TWO => println!("it's a two!"),
        _ => println!("something else"),
    }
}
```
currently results in the following compilation error:
```
error: to use a constant of type `H160` in a pattern, `H160` must be annotated with `#[derive(PartialEq, Eq)]`
 --> src/main.rs:9:9
  |
9 |         ONE => println!("it's a one!"),
  |         ^^^

error: to use a constant of type `H160` in a pattern, `H160` must be annotated with `#[derive(PartialEq, Eq)]`
  --> src/main.rs:10:9
   |
10 |         TWO => println!("it's a two!"),
   |         ^^^
```
As far as I can tell, the existing explicit `PartialEq` implementation exists for historical reasons and isn't necessary any more, the derived implementation should be equivalent. Assuming that is true, the only potential drawback of this change that I can see is that it poses a backwards compatibility hazard, i.e. if in the future you would want to manually implement `PartialEq` again for some reason, doing so would break the code of anyone using e.g. named `H160` constants in pattern matches.