### PR TITLE
Make `Const*` types `Clone+Default` and fix `Debug`

### DIFF
--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.1.6] - 2023-04-27
+- Added `Clone` and `Default` derive to the `impl_const_get!` macro and thereby all `Const*` types.
+- Fixed `Debug` impl for `impl_const_get!` and all `Const*` types to also print the value and not just the type name.
+
 ## [0.1.5] - 2023-02-13
 - Fixed `Hash` impl (previously it could not be used in practice, because the size bound was required to also implement `Hash`).
 

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/bounded-collections/src/lib.rs
+++ b/bounded-collections/src/lib.rs
@@ -58,8 +58,15 @@ impl<T: Default> Get<T> for GetDefault {
 macro_rules! impl_const_get {
 	($name:ident, $t:ty) => {
 		/// Const getter for a basic type.
-		#[cfg_attr(feature = "std", derive(core::fmt::Debug))]
+		#[derive(Default, Clone)]
 		pub struct $name<const T: $t>;
+
+		#[cfg(feature = "std")]
+		impl<const T: $t> core::fmt::Debug for $name<T> {
+			fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+				fmt.write_str(&format!("{}<{}>", stringify!($name), T))
+			}
+		}
 		#[cfg(not(feature = "std"))]
 		impl<const T: $t> core::fmt::Debug for $name<T> {
 			fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/bounded-collections/src/lib.rs
+++ b/bounded-collections/src/lib.rs
@@ -18,6 +18,8 @@ pub mod bounded_btree_set;
 pub mod bounded_vec;
 pub mod weak_bounded_vec;
 
+mod test;
+
 pub use bounded_btree_map::BoundedBTreeMap;
 pub use bounded_btree_set::BoundedBTreeSet;
 pub use bounded_vec::{BoundedSlice, BoundedVec};

--- a/bounded-collections/src/test.rs
+++ b/bounded-collections/src/test.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![cfg(test)]
+
+use crate::*;
+use core::fmt::Debug;
+
+#[test]
+fn const_debug_fmt() {
+	assert_eq!(format!("{:?}", ConstBool::<true> {}), "ConstBool<true>");
+	assert_eq!(format!("{:?}", ConstBool::<false> {}), "ConstBool<false>");
+	assert_eq!(format!("{:?}", ConstU8::<255> {}), "ConstU8<255>");
+	assert_eq!(format!("{:?}", ConstU16::<50> {}), "ConstU16<50>");
+	assert_eq!(format!("{:?}", ConstU32::<10> {}), "ConstU32<10>");
+	assert_eq!(format!("{:?}", ConstU64::<99> {}), "ConstU64<99>");
+	assert_eq!(format!("{:?}", ConstU128::<100> {}), "ConstU128<100>");
+	assert_eq!(format!("{:?}", ConstI8::<-127> {}), "ConstI8<-127>");
+	assert_eq!(format!("{:?}", ConstI16::<-50> {}), "ConstI16<-50>");
+	assert_eq!(format!("{:?}", ConstI32::<-10> {}), "ConstI32<-10>");
+	assert_eq!(format!("{:?}", ConstI64::<-99> {}), "ConstI64<-99>");
+	assert_eq!(format!("{:?}", ConstI128::<-100> {}), "ConstI128<-100>");
+}
+
+#[test]
+#[allow(path_statements)]
+fn const_impl_default_clone_debug() {
+	struct ImplsDefault<T: Default + Clone + Debug>(T);
+
+	ImplsDefault::<ConstBool<true>>;
+	ImplsDefault::<ConstBool<false>>;
+	ImplsDefault::<ConstU8<255>>;
+	ImplsDefault::<ConstU16<50>>;
+	ImplsDefault::<ConstU32<10>>;
+	ImplsDefault::<ConstU64<99>>;
+	ImplsDefault::<ConstU128<100>>;
+	ImplsDefault::<ConstI8<-127>>;
+	ImplsDefault::<ConstI16<-50>>;
+	ImplsDefault::<ConstI32<-10>>;
+	ImplsDefault::<ConstI64<-99>>;
+	ImplsDefault::<ConstI128<-100>>;
+}

--- a/bounded-collections/src/test.rs
+++ b/bounded-collections/src/test.rs
@@ -6,26 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Tests for the `bounded-collections` crate.
+
 #![cfg(test)]
 
 use crate::*;
 use core::fmt::Debug;
-
-#[test]
-fn const_debug_fmt() {
-	assert_eq!(format!("{:?}", ConstBool::<true> {}), "ConstBool<true>");
-	assert_eq!(format!("{:?}", ConstBool::<false> {}), "ConstBool<false>");
-	assert_eq!(format!("{:?}", ConstU8::<255> {}), "ConstU8<255>");
-	assert_eq!(format!("{:?}", ConstU16::<50> {}), "ConstU16<50>");
-	assert_eq!(format!("{:?}", ConstU32::<10> {}), "ConstU32<10>");
-	assert_eq!(format!("{:?}", ConstU64::<99> {}), "ConstU64<99>");
-	assert_eq!(format!("{:?}", ConstU128::<100> {}), "ConstU128<100>");
-	assert_eq!(format!("{:?}", ConstI8::<-127> {}), "ConstI8<-127>");
-	assert_eq!(format!("{:?}", ConstI16::<-50> {}), "ConstI16<-50>");
-	assert_eq!(format!("{:?}", ConstI32::<-10> {}), "ConstI32<-10>");
-	assert_eq!(format!("{:?}", ConstI64::<-99> {}), "ConstI64<-99>");
-	assert_eq!(format!("{:?}", ConstI128::<-100> {}), "ConstI128<-100>");
-}
 
 #[test]
 #[allow(path_statements)]
@@ -44,4 +30,20 @@ fn const_impl_default_clone_debug() {
 	ImplsDefault::<ConstI32<-10>>;
 	ImplsDefault::<ConstI64<-99>>;
 	ImplsDefault::<ConstI128<-100>>;
+}
+
+#[test]
+fn const_debug_fmt() {
+	assert_eq!(format!("{:?}", ConstBool::<true> {}), "ConstBool<true>");
+	assert_eq!(format!("{:?}", ConstBool::<false> {}), "ConstBool<false>");
+	assert_eq!(format!("{:?}", ConstU8::<255> {}), "ConstU8<255>");
+	assert_eq!(format!("{:?}", ConstU16::<50> {}), "ConstU16<50>");
+	assert_eq!(format!("{:?}", ConstU32::<10> {}), "ConstU32<10>");
+	assert_eq!(format!("{:?}", ConstU64::<99> {}), "ConstU64<99>");
+	assert_eq!(format!("{:?}", ConstU128::<100> {}), "ConstU128<100>");
+	assert_eq!(format!("{:?}", ConstI8::<-127> {}), "ConstI8<-127>");
+	assert_eq!(format!("{:?}", ConstI16::<-50> {}), "ConstI16<-50>");
+	assert_eq!(format!("{:?}", ConstI32::<-10> {}), "ConstI32<-10>");
+	assert_eq!(format!("{:?}", ConstI64::<-99> {}), "ConstI64<-99>");
+	assert_eq!(format!("{:?}", ConstI128::<-100> {}), "ConstI128<-100>");
 }

--- a/bounded-collections/src/test.rs
+++ b/bounded-collections/src/test.rs
@@ -33,6 +33,7 @@ fn const_impl_default_clone_debug() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn const_debug_fmt() {
 	assert_eq!(format!("{:?}", ConstBool::<true> {}), "ConstBool<true>");
 	assert_eq!(format!("{:?}", ConstBool::<false> {}), "ConstBool<false>");


### PR DESCRIPTION
This is needed for https://github.com/paritytech/substrate/issues/13955 to make the `GenesisConfig` print- and clonable.

Changes:
- Properly impl std-`Debug` for `Const*` types to also print the value, otherwise it just prints the type name.
- Derive `Clone` and `Default` (default not really needed, just for completeness).

TODO:
- [x] Changelog
- [x] Bump version. `0.1.6` I assume?