### PR TITLE
`serde` feature added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -p bounded-collections --no-default-features --features='serde'
+          args: -p bounded-collections --no-default-features --features=serde
 
       - name: Test bounded-collections all-features
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
           command: test
           args: -p bounded-collections --no-default-features
 
+      - name: Test bounded-collections no_std,serde
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p bounded-collections --no-default-features --features='serde'
+
       - name: Test bounded-collections all-features
         uses: actions-rs/cargo@v1
         with:

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.2.0] - 2023-05-05
+## [0.1.7] - 2023-05-05
 - Added `serde` feature, which can be enabled for no `std` deployments.
 
 ## [0.1.6] - 2023-04-27

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog].
 - Added `Clone` and `Default` derive to the `impl_const_get!` macro and thereby all `Const*` types.
 - Fixed `Debug` impl for `impl_const_get!` and all `Const*` types to also print the value and not just the type name.
 
-
 ## [0.1.5] - 2023-02-13
 - Fixed `Hash` impl (previously it could not be used in practice, because the size bound was required to also implement `Hash`).
 

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.1.6] - 2023-05-05
+- Added `serde` feature, which can be enabled for no `std` deployments.
+
 ## [0.1.5] - 2023-02-13
 - Fixed `Hash` impl (previously it could not be used in practice, because the size bound was required to also implement `Hash`).
 

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.1.7] - 2023-05-05
+## [0.2.0] - 2023-05-05
 - Added `serde` feature, which can be enabled for no `std` deployments.
 
 ## [0.1.6] - 2023-04-27

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.2.0"
+version = "0.1.7"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.60.0"
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, optional = true }
+serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }
 codec = { version = "3.3.0", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false }
 log = { version = "0.4.17", default-features = false }
@@ -19,10 +19,12 @@ serde_json = "1.0.41"
 
 [features]
 default = ["std"]
+serde = [
+    "dep:serde"
+]
 std = [
     "log/std",
     "codec/std",
     "scale-info/std",
-    "serde",
-    "serde/derive",
+    "serde/std",
 ]

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.60.0"
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }
+serde = { version = "1.0.160", default-features = false, optional = true, features=["alloc", "derive"] }
 codec = { version = "3.3.0", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false }
 log = { version = "0.4.17", default-features = false }

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.60.0"
 
 [dependencies]
-serde = { version = "1.0.160", default-features = false, optional = true, features=["alloc", "derive"] }
+serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }
 codec = { version = "3.3.0", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false }
 log = { version = "0.4.17", default-features = false }

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -19,9 +19,6 @@ serde_json = "1.0.41"
 
 [features]
 default = ["std"]
-serde = [
-    "dep:serde"
-]
 std = [
     "log/std",
     "codec/std",

--- a/bounded-collections/src/bounded_vec.rs
+++ b/bounded-collections/src/bounded_vec.rs
@@ -27,7 +27,7 @@ use core::{
 	ops::{Deref, Index, IndexMut, RangeBounds},
 	slice::SliceIndex,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
 	de::{Error, SeqAccess, Visitor},
 	Deserialize, Deserializer, Serialize,
@@ -40,10 +40,10 @@ use serde::{
 ///
 /// As the name suggests, the length of the queue is always bounded. All internal operations ensure
 /// this bound is respected.
-#[cfg_attr(feature = "std", derive(Serialize), serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(transparent))]
 #[derive(Encode, scale_info::TypeInfo)]
 #[scale_info(skip_type_params(S))]
-pub struct BoundedVec<T, S>(pub(super) Vec<T>, #[cfg_attr(feature = "std", serde(skip_serializing))] PhantomData<S>);
+pub struct BoundedVec<T, S>(pub(super) Vec<T>, #[cfg_attr(feature = "serde", serde(skip_serializing))] PhantomData<S>);
 
 /// Create an object through truncation.
 pub trait TruncateFrom<T> {
@@ -51,7 +51,7 @@ pub trait TruncateFrom<T> {
 	fn truncate_from(unbound: T) -> Self;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<'de, T, S: Get<u32>> Deserialize<'de> for BoundedVec<T, S>
 where
 	T: Deserialize<'de>,
@@ -68,7 +68,7 @@ where
 		{
 			type Value = Vec<T>;
 
-			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+			fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
 				formatter.write_str("a sequence")
 			}
 

--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -45,10 +45,10 @@ use serde::{
 #[scale_info(skip_type_params(S))]
 pub struct WeakBoundedVec<T, S>(
 	pub(super) Vec<T>,
-	#[cfg_attr(feature = "std", serde(skip_serializing))] PhantomData<S>,
+	#[cfg_attr(feature = "serde", serde(skip_serializing))] PhantomData<S>,
 );
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<'de, T, S: Get<u32>> Deserialize<'de> for WeakBoundedVec<T, S>
 where
 	T: Deserialize<'de>,

--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -27,7 +27,7 @@ use core::{
 	ops::{Deref, Index, IndexMut},
 	slice::SliceIndex,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
 	de::{Error, SeqAccess, Visitor},
 	Deserialize, Deserializer, Serialize,
@@ -40,7 +40,7 @@ use serde::{
 ///
 /// The length of the vec is not strictly bounded. Decoding a vec with more element that the bound
 /// is accepted, and some method allow to bypass the restriction with warnings.
-#[cfg_attr(feature = "std", derive(Serialize), serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(transparent))]
 #[derive(Encode, scale_info::TypeInfo)]
 #[scale_info(skip_type_params(S))]
 pub struct WeakBoundedVec<T, S>(
@@ -65,7 +65,7 @@ where
 		{
 			type Value = Vec<T>;
 
-			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+			fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
 				formatter.write_str("a sequence")
 			}
 


### PR DESCRIPTION
Support for `serde` derivations in no_std.

Part of: https://github.com/paritytech/substrate/issues/12994,
Required for: https://github.com/paritytech/substrate/issues/13334