### PR TITLE
fix(rlp): `len()` changes as `RlpIterator` is consumed

### DIFF
--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -367,7 +367,7 @@ impl<'a, 'view> Iterator for RlpIterator<'a, 'view> {
 
 impl<'a, 'view> ExactSizeIterator for RlpIterator<'a, 'view> {
 	fn len(&self) -> usize {
-		self.rlp.item_count().unwrap_or(0)
+		self.rlp.item_count().unwrap_or(0).saturating_sub(self.index)
 	}
 }
 

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -105,13 +105,19 @@ fn rlp_iter() {
 		let rlp = Rlp::new(&data);
 		let mut iter = rlp.iter();
 
+		assert_eq!(iter.len(), 2);
+
 		let cat = iter.next().unwrap();
 		assert!(cat.is_data());
 		assert_eq!(cat.as_raw(), &[0x83, b'c', b'a', b't']);
 
+		assert_eq!(iter.len(), 1);
+
 		let dog = iter.next().unwrap();
 		assert!(dog.is_data());
 		assert_eq!(dog.as_raw(), &[0x83, b'd', b'o', b'g']);
+
+		assert_eq!(iter.len(), 0);
 
 		let none = iter.next();
 		assert!(none.is_none());


### PR DESCRIPTION
  Fixes #761  
## Problem
The issue is described in #761  
## Solution
The `RlpIterator::len` function returns `item_count - current_index`.
### Tests
No new tests were added, only changed the `rlp_iter` test in `rlp/tests/tests.rs`. You can run it with 
```sh
cargo test -p rlp --test tests -- rlp_iter
```