### PR TITLE
Fixed clippy::incorrect_clone_impl_on_copy_type in fixed-hash

### DIFF
--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -258,9 +258,7 @@ macro_rules! construct_fixed_hash {
 		#[cfg_attr(feature = "dev", allow(expl_impl_clone_on_copy))]
 		impl $crate::core_::clone::Clone for $name {
 			fn clone(&self) -> $name {
-				let mut ret = $name::zero();
-				ret.0.copy_from_slice(&self.0);
-				ret
+				*self
 			}
 		}
 


### PR DESCRIPTION
There's this new lint: https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_clone_impl_on_copy_type which causes clippy failures in nightly builds. TLDR: if type is `Copy`, then `Clone` impl must be just `*self`