### PR TITLE
Try fixing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.74.0
           override: true
 
       - name: Rust Cache


### PR DESCRIPTION
`mips64-unknown-linux-muslabi64 target` (used to test bigendian) was removed in 1.75.0.

The workaround for now is to pin the toolchain to 1.74.0. We could try using `cross` instead in the future.