### PR TITLE
Release 0.2.0

### DIFF
--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.2.0] - 2023-11-13
+## [0.2.0] - 2024-01-29
 - Added `try_rotate_left` and `try_rotate_right` to `BoundedVec`. [#800](https://github.com/paritytech/parity-common/pull/800)
 
 ## [0.1.9] - 2023-10-10

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
Did not bump the crate version in https://github.com/paritytech/parity-common/pull/800 🤦‍♂️  
Maybe we can also go `1.0`? Seems quite stable to me.