### PR TITLE
primitive-types: add repository URL to Cargo.toml

### DIFF
--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.12.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
+repository = "https://github.com/paritytech/parity-common"
 description = "Primitive types shared by Ethereum and Substrate"
 edition = "2021"
 rust-version = "1.60.0"


### PR DESCRIPTION
This adds the repository URL to the Cargo manifest of `primitive-types`, so that the crate published on crates.io can be automatically linked back to the source repository.