### PR TITLE
Upgrade rocksdb to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
 	"fixed-hash",
 	"keccak-hash",

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -29,3 +29,4 @@ arbitrary = ["ethbloom/arbitrary", "fixed-hash/arbitrary", "uint-crate/arbitrary
 rlp = ["impl-rlp", "ethbloom/rlp", "primitive-types/rlp"]
 codec = ["impl-codec", "ethbloom/codec", "scale-info", "primitive-types/scale-info"]
 num-traits = ["primitive-types/num-traits"]
+rand = ["primitive-types/rand"]

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -24,21 +24,21 @@ regex = "1.3.1"
 [target.'cfg(any(target_os = "openbsd", target_env = "msvc"))'.dependencies.rocksdb]
 default-features = false
 features = ["snappy"]
-version = "0.21"
+version = "0.22.0"
 
 [target.'cfg(not(any(target_os = "openbsd", target_env = "msvc")))'.dependencies.rocksdb]
 default-features = false
 features = ["snappy", "jemalloc"]
-version = "0.21"
+version = "0.22.0"
 
 [dev-dependencies]
 alloc_counter = "0.0.4"
 criterion = "0.5"
-ethereum-types = { path = "../ethereum-types" }
+ethereum-types = { path = "../ethereum-types", features = ["rand"] }
 kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.11" }
 rand = "0.8.0"
 tempfile = "3.1.0"
 keccak-hash = { path = "../keccak-hash" }
-sysinfo = "0.29.0"
+sysinfo = "0.30.13"
 ctrlc = "3.1.4"
 chrono = "0.4"

--- a/kvdb-rocksdb/examples/memtest.rs
+++ b/kvdb-rocksdb/examples/memtest.rs
@@ -24,7 +24,7 @@ use std::sync::{
 	atomic::{AtomicBool, Ordering as AtomicOrdering},
 	Arc,
 };
-use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
+use sysinfo::{get_current_pid, System};
 
 const COLUMN_COUNT: u32 = 100;
 

--- a/kvdb-rocksdb/src/lib.rs
+++ b/kvdb-rocksdb/src/lib.rs
@@ -905,7 +905,7 @@ rocksdb.db.get.micros P50 : 2.000000 P95 : 3.000000 P99 : 4.000000 P100 : 5.0000
 		assert!(settings.contains(" block_size: 323232"));
 
 		// LRU cache (default column)
-		assert!(settings.contains("block_cache_options:\n    capacity : 8388608"));
+		assert!(settings.contains("block_cache_options:\n    capacity : 115343360"));
 		// LRU cache for non-default columns is ⅓ of memory budget (including default column)
 		let lru_size = (330 * MB) / 3;
 		let needle = format!("block_cache_options:\n    capacity : {}", lru_size);

--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -16,7 +16,7 @@ std = ["serde/std"]
 serde = { version = "1.0.101", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-criterion = "0.3.0"
+criterion = "0.5.1"
 serde_derive = "1.0.101"
 serde_json = "1.0.41"
 uint = { version = "0.9.5", path = "../../../uint" }


### PR DESCRIPTION
Although Parity has recommended `paritydb` for a long time, `polkadot-sdk` still has not started the deprecation process for `rocksdb`.

I think we should give some love to the rocksdb. This PR upgrade to its latest version would help to reduce a few outdated dependencies. for example, bitflags 1.3.0