### PR TITLE
another missing bump (impl-codec)

### DIFF
--- a/ethbloom/CHANGELOG.md
+++ b/ethbloom/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.14.0] - 2024-09-11
+## [0.14.1] - 2024-09-12
 - Updated `impl-serde` to 0.5. [#859](https://github.com/paritytech/parity-common/pull/859)
+- Updated `impl-codec` to 0.7. [#860](https://github.com/paritytech/parity-common/pull/860)
 
 ## [0.13.0] - 2022-09-20
 - Updated `fixed-hash` to 0.8. [#680](https://github.com/paritytech/parity-common/pull/680)

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ crunchy = { version = "0.2.2", default-features = false, features = ["limit_256"
 fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.5", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.4", default-features = false, optional = true }
-impl-codec = { version = "0.6.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.7.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false, optional = true }
 
 [dev-dependencies]

--- a/ethereum-types/CHANGELOG.md
+++ b/ethereum-types/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.15.0] - 2024-09-11
+## [0.15.1] - 2024-09-12
 - Updated `uint` to 0.10. [#859](https://github.com/paritytech/parity-common/pull/859)
 
 ## [0.14.1] - 2022-11-29

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
@@ -15,7 +15,7 @@ uint-crate = { path = "../uint", package = "uint", version = "0.10", default-fea
 primitive-types = { path = "../primitive-types", version = "0.13", features = ["byteorder", "rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.5.0", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.4", default-features = false, optional = true }
-impl-codec = { version = "0.6.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.7.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false, optional = true }
 
 [dev-dependencies]

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.13.0] - 2024-09-11
+## [0.13.1] - 2024-09-12
 - Updated `uint` to 0.10. [#859](https://github.com/paritytech/parity-common/pull/859)
 
 ## [0.12.2] - 2023-10-10

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.60.0"
 fixed-hash = { version = "0.8", path = "../fixed-hash", default-features = false }
 uint = { version = "0.10.0", path = "../uint", default-features = false }
 impl-serde = { version = "0.5.0", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.6.0", path = "impls/codec", default-features = false, optional = true }
+impl-codec = { version = "0.7.0", path = "impls/codec", default-features = false, optional = true }
 impl-num-traits = { version = "0.2.0", path = "impls/num-traits", default-features = false, optional = true }
 impl-rlp = { version = "0.4", path = "impls/rlp", default-features = false, optional = true }
 scale-info-crate = { package = "scale-info", version = ">=0.9, <3", features = ["derive"], default-features = false, optional = true }

--- a/primitive-types/impls/codec/CHANGELOG.md
+++ b/primitive-types/impls/codec/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.7.0] - 2024-09-12
+### Breaking
+- Updated to `uint` 0.10. [#860](https://github.com/paritytech/parity-common/pull/860)
+
 ## [0.6.0] - 2022-02-04
 ### Breaking
 - Migrated to 2021 edition, enforcing MSRV of `1.56.1`. [#601](https://github.com/paritytech/parity-common/pull/601)

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-codec"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/rlp/CHANGELOG.md
+++ b/rlp/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [0.6.1] - 2024-09-11
 - Migrated to 2021 edition, enforcing MSRV of `1.56.1`. [#601](https://github.com/paritytech/parity-common/pull/601)
-- Updated `rlp` to 0.2.0. [#860](https://github.com/paritytech/parity-common/pull/860)
+- Updated `rlp-derive` to 0.2.0. [#860](https://github.com/paritytech/parity-common/pull/860)
 
 ## [0.5.2] - 2022-10-21
 - Add optional `derive` feature. [#613](https://github.com/paritytech/parity-common/pull/613)


### PR DESCRIPTION
cc #862 @pgherveou 

I'll publish impl-codec 0.7 and primitive-types 0.13.1 and yank 0.13.0 (same for ethereum-types and ethbloom).

Hopefully, that's the only missing bump.