### PR TITLE
Serde Serialize & Deserialize for BoundedBTreeMap

### DIFF
--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.2.1] - 2024-10-05
+## [0.2.1] - 2024-10-07
 - Added `serde` support for `BoundedBTreeMap`. [#870](https://github.com/paritytech/parity-common/pull/870)
 
 ## [0.2.0] - 2024-01-29

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.2.1] - 2024-10-07
+## [0.2.1] - 2024-10-08
 - Added `serde` support for `BoundedBTreeMap`. [#870](https://github.com/paritytech/parity-common/pull/870)
 
 ## [0.2.0] - 2024-01-29

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.2.1] - 2024-10-05
+- Added `serde` support for `BoundedBTreeMap`. [#870](https://github.com/paritytech/parity-common/pull/870)
+
 ## [0.2.0] - 2024-01-29
 - Added `try_rotate_left` and `try_rotate_right` to `BoundedVec`. [#800](https://github.com/paritytech/parity-common/pull/800)
 

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -47,7 +47,6 @@ impl<'de, K, V, S: Get<u32>> Deserialize<'de> for BoundedBTreeMap<K, V, S>
 where
 	K: Deserialize<'de> + Ord,
 	V: Deserialize<'de>,
-	S: Clone,
 {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -60,7 +59,7 @@ where
 		where
 			K: Deserialize<'de> + Ord,
 			V: Deserialize<'de>,
-			S: Get<u32> + Clone,
+			S: Get<u32>,
 		{
 			type Value = BTreeMap<K, V>;
 

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -21,6 +21,11 @@ use crate::{Get, TryCollect};
 use alloc::collections::BTreeMap;
 use codec::{Compact, Decode, Encode, MaxEncodedLen};
 use core::{borrow::Borrow, marker::PhantomData, ops::Deref};
+#[cfg(feature = "serde")]
+use serde::{
+	de::{Error, MapAccess, Visitor},
+	Deserialize, Deserializer, Serialize,
+};
 
 /// A bounded map based on a B-Tree.
 ///
@@ -29,9 +34,74 @@ use core::{borrow::Borrow, marker::PhantomData, ops::Deref};
 ///
 /// Unlike a standard `BTreeMap`, there is an enforced upper limit to the number of items in the
 /// map. All internal operations ensure this bound is respected.
+#[cfg_attr(feature = "serde", derive(Serialize), serde(transparent))]
 #[derive(Encode, scale_info::TypeInfo)]
 #[scale_info(skip_type_params(S))]
-pub struct BoundedBTreeMap<K, V, S>(BTreeMap<K, V>, PhantomData<S>);
+pub struct BoundedBTreeMap<K, V, S>(
+	BTreeMap<K, V>,
+	#[cfg_attr(feature = "serde", serde(skip_serializing))] PhantomData<S>,
+);
+
+#[cfg(feature = "serde")]
+impl<'de, K, V, S: Get<u32>> Deserialize<'de> for BoundedBTreeMap<K, V, S>
+where
+	K: Deserialize<'de> + Ord,
+	V: Deserialize<'de>,
+	S: Clone,
+{
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		// Create a visitor to visit each element in the map
+		struct BTreeMapVisitor<K, V, S>(PhantomData<(K, V, S)>);
+
+		impl<'de, K, V, S> Visitor<'de> for BTreeMapVisitor<K, V, S>
+		where
+			K: Deserialize<'de> + Ord,
+			V: Deserialize<'de>,
+			S: Get<u32> + Clone,
+		{
+			type Value = BTreeMap<K, V>;
+
+			fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+				formatter.write_str("a map")
+			}
+
+			fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+			where
+				A: MapAccess<'de>,
+			{
+				let size = map.size_hint().unwrap_or(0);
+				let max = match usize::try_from(S::get()) {
+					Ok(n) => n,
+					Err(_) => return Err(A::Error::custom("can't convert to usize")),
+				};
+				if size > max {
+					Err(A::Error::custom("map exceeds the size of the bounds"))
+				} else {
+					let mut values = BTreeMap::new();
+
+					while let Some(key) = map.next_key()? {
+						if values.len() >= max {
+							return Err(A::Error::custom("map exceeds the size of the bounds"));
+						}
+						let value = map.next_value()?;
+						values.insert(key, value);
+					}
+
+					Ok(values)
+				}
+			}
+		}
+
+		let visitor: BTreeMapVisitor<K, V, S> = BTreeMapVisitor(PhantomData);
+		deserializer.deserialize_map(visitor).map(|v| {
+			BoundedBTreeMap::<K, V, S>::try_from(v)
+				.map_err(|_| Error::custom("failed to create a BoundedBTreeMap from the provided map"))
+		})?
+	}
+}
 
 impl<K, V, S> Decode for BoundedBTreeMap<K, V, S>
 where
@@ -44,7 +114,7 @@ where
 		// the len is too big.
 		let len: u32 = <Compact<u32>>::decode(input)?.into();
 		if len > S::get() {
-			return Err("BoundedBTreeMap exceeds its limit".into())
+			return Err("BoundedBTreeMap exceeds its limit".into());
 		}
 		input.descend_ref()?;
 		let inner = Result::from_iter((0..len).map(|_| Decode::decode(input)))?;
@@ -403,7 +473,7 @@ where
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
 	use super::*;
 	use crate::ConstU32;
@@ -423,6 +493,56 @@ mod test {
 		S: Get<u32>,
 	{
 		map_from_keys(keys).try_into().unwrap()
+	}
+
+	#[test]
+	fn test_bounded_btreemap_serializer() {
+		let mut map = BoundedBTreeMap::<u32, u32, ConstU32<6>>::new();
+		map.try_insert(0, 100).unwrap();
+		map.try_insert(1, 101).unwrap();
+		map.try_insert(2, 102).unwrap();
+
+		let serialized = serde_json::to_string(&map).unwrap();
+		assert_eq!(serialized, r#"{"0":100,"1":101,"2":102}"#);
+	}
+
+	#[test]
+	fn test_bounded_btreemap_deserializer() {
+		let json_str = r#"{"0":100,"1":101,"2":102}"#;
+		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<6>>, serde_json::Error> = serde_json::from_str(json_str);
+		assert!(map.is_ok());
+		let map = map.unwrap();
+
+		assert_eq!(map.len(), 3);
+		assert_eq!(map.get(&0), Some(&100));
+		assert_eq!(map.get(&1), Some(&101));
+		assert_eq!(map.get(&2), Some(&102));
+	}
+
+	#[test]
+	fn test_bounded_btreemap_deserializer_bound() {
+		let json_str = r#"{"0":100,"1":101,"2":102}"#;
+		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<3>>, serde_json::Error> = serde_json::from_str(json_str);
+		assert!(map.is_ok());
+		let map = map.unwrap();
+
+		assert_eq!(map.len(), 3);
+		assert_eq!(map.get(&0), Some(&100));
+		assert_eq!(map.get(&1), Some(&101));
+		assert_eq!(map.get(&2), Some(&102));
+	}
+
+	#[test]
+	fn test_bounded_btreemap_deserializer_failed() {
+		let json_str = r#"{"0":100,"1":101,"2":102,"3":103,"4":104}"#;
+		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<4>>, serde_json::Error> = serde_json::from_str(json_str);
+
+		match map {
+			Err(e) => {
+				assert!(e.to_string().contains("map exceeds the size of the bounds"));
+			},
+			_ => unreachable!("deserializer must raise error"),
+		}
 	}
 
 	#[test]

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -732,7 +732,7 @@ mod test {
 	#[cfg(feature = "serde")]
 	mod serde {
 		use super::*;
-		use crate::alloc::string::ToString as _;
+		use crate::alloc::string::ToString;
 
 		#[test]
 		fn test_bounded_btreemap_serializer() {

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -72,10 +72,7 @@ where
 				A: MapAccess<'de>,
 			{
 				let size = map.size_hint().unwrap_or(0);
-				let max = match usize::try_from(S::get()) {
-					Ok(n) => n,
-					Err(_) => return Err(A::Error::custom("can't convert to usize")),
-				};
+				let max = S::get() as usize;
 				if size > max {
 					Err(A::Error::custom("map exceeds the size of the bounds"))
 				} else {

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -732,6 +732,7 @@ mod test {
 	#[cfg(feature = "serde")]
 	mod serde {
 		use super::*;
+		use crate::alloc::string::ToString as _;
 
 		#[test]
 		fn test_bounded_btreemap_serializer() {

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -729,53 +729,58 @@ mod test {
 		let _foo = Foo::default();
 	}
 
-	#[test]
-	fn test_bounded_btreemap_serializer() {
-		let mut map = BoundedBTreeMap::<u32, u32, ConstU32<6>>::new();
-		map.try_insert(0, 100).unwrap();
-		map.try_insert(1, 101).unwrap();
-		map.try_insert(2, 102).unwrap();
+	#[cfg(feature = "serde")]
+	mod serde {
+		use super::*;
 
-		let serialized = serde_json::to_string(&map).unwrap();
-		assert_eq!(serialized, r#"{"0":100,"1":101,"2":102}"#);
-	}
-
-	#[test]
-	fn test_bounded_btreemap_deserializer() {
-		let json_str = r#"{"0":100,"1":101,"2":102}"#;
-		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<6>>, serde_json::Error> = serde_json::from_str(json_str);
-		assert!(map.is_ok());
-		let map = map.unwrap();
-
-		assert_eq!(map.len(), 3);
-		assert_eq!(map.get(&0), Some(&100));
-		assert_eq!(map.get(&1), Some(&101));
-		assert_eq!(map.get(&2), Some(&102));
-	}
-
-	#[test]
-	fn test_bounded_btreemap_deserializer_bound() {
-		let json_str = r#"{"0":100,"1":101,"2":102}"#;
-		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<3>>, serde_json::Error> = serde_json::from_str(json_str);
-		assert!(map.is_ok());
-		let map = map.unwrap();
-
-		assert_eq!(map.len(), 3);
-		assert_eq!(map.get(&0), Some(&100));
-		assert_eq!(map.get(&1), Some(&101));
-		assert_eq!(map.get(&2), Some(&102));
-	}
-
-	#[test]
-	fn test_bounded_btreemap_deserializer_failed() {
-		let json_str = r#"{"0":100,"1":101,"2":102,"3":103,"4":104}"#;
-		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<4>>, serde_json::Error> = serde_json::from_str(json_str);
-
-		match map {
-			Err(e) => {
-				assert!(e.to_string().contains("map exceeds the size of the bounds"));
-			},
-			_ => unreachable!("deserializer must raise error"),
+		#[test]
+		fn test_bounded_btreemap_serializer() {
+			let mut map = BoundedBTreeMap::<u32, u32, ConstU32<6>>::new();
+			map.try_insert(0, 100).unwrap();
+			map.try_insert(1, 101).unwrap();
+			map.try_insert(2, 102).unwrap();
+			
+			let serialized = serde_json::to_string(&map).unwrap();
+			assert_eq!(serialized, r#"{"0":100,"1":101,"2":102}"#);
+		}
+		
+		#[test]
+		fn test_bounded_btreemap_deserializer() {
+			let json_str = r#"{"0":100,"1":101,"2":102}"#;
+			let map: Result<BoundedBTreeMap<u32, u32, ConstU32<6>>, serde_json::Error> = serde_json::from_str(json_str);
+			assert!(map.is_ok());
+			let map = map.unwrap();
+			
+			assert_eq!(map.len(), 3);
+			assert_eq!(map.get(&0), Some(&100));
+			assert_eq!(map.get(&1), Some(&101));
+			assert_eq!(map.get(&2), Some(&102));
+		}
+		
+		#[test]
+		fn test_bounded_btreemap_deserializer_bound() {
+			let json_str = r#"{"0":100,"1":101,"2":102}"#;
+			let map: Result<BoundedBTreeMap<u32, u32, ConstU32<3>>, serde_json::Error> = serde_json::from_str(json_str);
+			assert!(map.is_ok());
+			let map = map.unwrap();
+			
+			assert_eq!(map.len(), 3);
+			assert_eq!(map.get(&0), Some(&100));
+			assert_eq!(map.get(&1), Some(&101));
+			assert_eq!(map.get(&2), Some(&102));
+		}
+		
+		#[test]
+		fn test_bounded_btreemap_deserializer_failed() {
+			let json_str = r#"{"0":100,"1":101,"2":102,"3":103,"4":104}"#;
+			let map: Result<BoundedBTreeMap<u32, u32, ConstU32<4>>, serde_json::Error> = serde_json::from_str(json_str);
+			
+			match map {
+				Err(e) => {
+					assert!(e.to_string().contains("map exceeds the size of the bounds"));
+				},
+				_ => unreachable!("deserializer must raise error"),
+			}
 		}
 	}
 }

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -473,7 +473,7 @@ where
 	}
 }
 
-#[cfg(all(test, feature = "std"))]
+#[cfg(test)]
 mod test {
 	use super::*;
 	use crate::ConstU32;
@@ -493,56 +493,6 @@ mod test {
 		S: Get<u32>,
 	{
 		map_from_keys(keys).try_into().unwrap()
-	}
-
-	#[test]
-	fn test_bounded_btreemap_serializer() {
-		let mut map = BoundedBTreeMap::<u32, u32, ConstU32<6>>::new();
-		map.try_insert(0, 100).unwrap();
-		map.try_insert(1, 101).unwrap();
-		map.try_insert(2, 102).unwrap();
-
-		let serialized = serde_json::to_string(&map).unwrap();
-		assert_eq!(serialized, r#"{"0":100,"1":101,"2":102}"#);
-	}
-
-	#[test]
-	fn test_bounded_btreemap_deserializer() {
-		let json_str = r#"{"0":100,"1":101,"2":102}"#;
-		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<6>>, serde_json::Error> = serde_json::from_str(json_str);
-		assert!(map.is_ok());
-		let map = map.unwrap();
-
-		assert_eq!(map.len(), 3);
-		assert_eq!(map.get(&0), Some(&100));
-		assert_eq!(map.get(&1), Some(&101));
-		assert_eq!(map.get(&2), Some(&102));
-	}
-
-	#[test]
-	fn test_bounded_btreemap_deserializer_bound() {
-		let json_str = r#"{"0":100,"1":101,"2":102}"#;
-		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<3>>, serde_json::Error> = serde_json::from_str(json_str);
-		assert!(map.is_ok());
-		let map = map.unwrap();
-
-		assert_eq!(map.len(), 3);
-		assert_eq!(map.get(&0), Some(&100));
-		assert_eq!(map.get(&1), Some(&101));
-		assert_eq!(map.get(&2), Some(&102));
-	}
-
-	#[test]
-	fn test_bounded_btreemap_deserializer_failed() {
-		let json_str = r#"{"0":100,"1":101,"2":102,"3":103,"4":104}"#;
-		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<4>>, serde_json::Error> = serde_json::from_str(json_str);
-
-		match map {
-			Err(e) => {
-				assert!(e.to_string().contains("map exceeds the size of the bounds"));
-			},
-			_ => unreachable!("deserializer must raise error"),
-		}
 	}
 
 	#[test]
@@ -781,5 +731,55 @@ mod test {
 			map: BoundedBTreeMap<String, usize, ConstU32<16>>,
 		}
 		let _foo = Foo::default();
+	}
+
+	#[test]
+	fn test_bounded_btreemap_serializer() {
+		let mut map = BoundedBTreeMap::<u32, u32, ConstU32<6>>::new();
+		map.try_insert(0, 100).unwrap();
+		map.try_insert(1, 101).unwrap();
+		map.try_insert(2, 102).unwrap();
+
+		let serialized = serde_json::to_string(&map).unwrap();
+		assert_eq!(serialized, r#"{"0":100,"1":101,"2":102}"#);
+	}
+
+	#[test]
+	fn test_bounded_btreemap_deserializer() {
+		let json_str = r#"{"0":100,"1":101,"2":102}"#;
+		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<6>>, serde_json::Error> = serde_json::from_str(json_str);
+		assert!(map.is_ok());
+		let map = map.unwrap();
+
+		assert_eq!(map.len(), 3);
+		assert_eq!(map.get(&0), Some(&100));
+		assert_eq!(map.get(&1), Some(&101));
+		assert_eq!(map.get(&2), Some(&102));
+	}
+
+	#[test]
+	fn test_bounded_btreemap_deserializer_bound() {
+		let json_str = r#"{"0":100,"1":101,"2":102}"#;
+		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<3>>, serde_json::Error> = serde_json::from_str(json_str);
+		assert!(map.is_ok());
+		let map = map.unwrap();
+
+		assert_eq!(map.len(), 3);
+		assert_eq!(map.get(&0), Some(&100));
+		assert_eq!(map.get(&1), Some(&101));
+		assert_eq!(map.get(&2), Some(&102));
+	}
+
+	#[test]
+	fn test_bounded_btreemap_deserializer_failed() {
+		let json_str = r#"{"0":100,"1":101,"2":102,"3":103,"4":104}"#;
+		let map: Result<BoundedBTreeMap<u32, u32, ConstU32<4>>, serde_json::Error> = serde_json::from_str(json_str);
+
+		match map {
+			Err(e) => {
+				assert!(e.to_string().contains("map exceeds the size of the bounds"));
+			},
+			_ => unreachable!("deserializer must raise error"),
+		}
 	}
 }

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -740,42 +740,42 @@ mod test {
 			map.try_insert(0, 100).unwrap();
 			map.try_insert(1, 101).unwrap();
 			map.try_insert(2, 102).unwrap();
-			
+
 			let serialized = serde_json::to_string(&map).unwrap();
 			assert_eq!(serialized, r#"{"0":100,"1":101,"2":102}"#);
 		}
-		
+
 		#[test]
 		fn test_bounded_btreemap_deserializer() {
 			let json_str = r#"{"0":100,"1":101,"2":102}"#;
 			let map: Result<BoundedBTreeMap<u32, u32, ConstU32<6>>, serde_json::Error> = serde_json::from_str(json_str);
 			assert!(map.is_ok());
 			let map = map.unwrap();
-			
+
 			assert_eq!(map.len(), 3);
 			assert_eq!(map.get(&0), Some(&100));
 			assert_eq!(map.get(&1), Some(&101));
 			assert_eq!(map.get(&2), Some(&102));
 		}
-		
+
 		#[test]
 		fn test_bounded_btreemap_deserializer_bound() {
 			let json_str = r#"{"0":100,"1":101,"2":102}"#;
 			let map: Result<BoundedBTreeMap<u32, u32, ConstU32<3>>, serde_json::Error> = serde_json::from_str(json_str);
 			assert!(map.is_ok());
 			let map = map.unwrap();
-			
+
 			assert_eq!(map.len(), 3);
 			assert_eq!(map.get(&0), Some(&100));
 			assert_eq!(map.get(&1), Some(&101));
 			assert_eq!(map.get(&2), Some(&102));
 		}
-		
+
 		#[test]
 		fn test_bounded_btreemap_deserializer_failed() {
 			let json_str = r#"{"0":100,"1":101,"2":102,"3":103,"4":104}"#;
 			let map: Result<BoundedBTreeMap<u32, u32, ConstU32<4>>, serde_json::Error> = serde_json::from_str(json_str);
-			
+
 			match map {
 				Err(e) => {
 					assert!(e.to_string().contains("map exceeds the size of the bounds"));


### PR DESCRIPTION
BoundedBTreeMap cannot currently be used for parachain genesis state due to missing implementations of Serde. This PR aims to resolve that, similar to [BoundedVec](https://github.com/paritytech/substrate/pull/11314) and [BoundedBTreeSet](https://github.com/paritytech/parity-common/pull/781)

Corresponding issue: #869 