### PR TITLE
fixed-hash: remove `byteorder` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           args: -p uint --all-features
 
       - name: Test fixed-hash no_std
-        run: cargo test -p fixed-hash --no-default-features --features='byteorder,rustc-hex'
+        run: cargo test -p fixed-hash --no-default-features --features='rustc-hex'
 
       - name: Test fixed-hash all-features
         uses: actions-rs/cargo@v1

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = "1.60.0"
 
 [dependencies]
 ethbloom = { path = "../ethbloom", version = "0.14", optional = true, default-features = false }
-fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false, features = ["byteorder", "rustc-hex"] }
+fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false, features = ["rustc-hex"] }
 uint-crate = { path = "../uint", package = "uint", version = "0.10", default-features = false }
-primitive-types = { path = "../primitive-types", version = "0.13", features = ["byteorder", "rustc-hex"], default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.13", features = ["rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.5.0", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.4", default-features = false, optional = true }
 impl-codec = { version = "0.7.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.60"
 features = ["quickcheck", "api-dummy"]
 
 [dependencies]
-byteorder = { version = "1.4.2", optional = true, default-features = false }
 quickcheck = { version = "1", optional = true }
 rand = { version = "0.8.0", optional = true, default-features = false }
 rustc-hex = { version = "2.0.1", optional = true, default-features = false }
@@ -28,8 +27,8 @@ criterion = "0.5.1"
 rand = { version = "0.8.0", default-features = false, features = ["std_rng"] }
 
 [features]
-default = ["std", "rand", "rustc-hex", "byteorder"]
-std = ["rustc-hex/std", "rand?/std", "byteorder/std"]
+default = ["std", "rand", "rustc-hex"]
+std = ["rustc-hex/std", "rand?/std"]
 
 api-dummy = [] # Feature used by docs.rs to display documentation of hash types
 

--- a/fixed-hash/README.md
+++ b/fixed-hash/README.md
@@ -39,7 +39,7 @@ construct_fixed_hash!{
 
 ## Features
 
-By default this is an standard library depending crate.  
+By default this is an standard library depending crate.
 For a `#[no_std]` environment use it as follows:
 
 ```
@@ -52,17 +52,12 @@ fixed-hash = { version = "0.3", default-features = false }
 	- Using this feature enables the following features
 		- `rustc-hex/std`
 		- `rand/std`
-		- `byteorder/std`
-    - Enabled by default.
-- `libc`: Use `libc` for implementations of `PartialEq` and `Ord`.
     - Enabled by default.
 - `rand`: Provide API based on the `rand` crate.
     - Enabled by default.
-- `byteorder`: Provide API based on the `byteorder` crate.
-    - Enabled by default.
 - `quickcheck`: Provide `quickcheck` implementation for hash types.
     - Disabled by default.
-- `api-dummy`: Generate a dummy hash type for API documentation.
-    - Enabled by default at `docs.rs`
 - `arbitrary`: Allow for creation of a hash from random unstructured input.
     - Disabled by default.
+- `api-dummy`: Generate a dummy hash type for API documentation.
+	- Enabled by default at `docs.rs`

--- a/fixed-hash/benches/cmp.rs
+++ b/fixed-hash/benches/cmp.rs
@@ -14,7 +14,7 @@ use fixed_hash::construct_fixed_hash;
 
 construct_fixed_hash! { pub struct H256(32); }
 
-criterion_group!(cmp, eq_equal, eq_nonequal, compare,);
+criterion_group!(cmp, eq_equal, eq_nonequal, compare);
 criterion_main!(cmp);
 
 fn eq_equal(c: &mut Criterion) {
@@ -26,7 +26,7 @@ fn eq_equal(c: &mut Criterion) {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xEF, 0x2D, 0x6D, 0x19, 0x40, 0x84,
 			0xC2, 0xDE, 0x36, 0xE0, 0xDA, 0xBF, 0xCE, 0x45, 0xD0, 0x46, 0xB3, 0x7D, 0x11, 0x06,
 		]),
-		H256([u8::max_value(); 32]),
+		H256([u8::MAX; 32]),
 	] {
 		group.bench_with_input(BenchmarkId::from_parameter(input), &input, |b, x| {
 			b.iter(|| black_box(x.eq(black_box(x))))

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -30,10 +30,6 @@ pub use static_assertions;
 #[doc(hidden)]
 pub use static_assertions::const_assert;
 
-#[cfg(feature = "byteorder")]
-#[doc(hidden)]
-pub use byteorder;
-
 #[cfg(feature = "rustc-hex")]
 #[doc(hidden)]
 pub use rustc_hex;

--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -155,7 +155,6 @@ mod is_zero {
 	}
 }
 
-#[cfg(feature = "byteorder")]
 mod to_low_u64 {
 	use super::*;
 
@@ -195,7 +194,6 @@ mod to_low_u64 {
 	}
 }
 
-#[cfg(feature = "byteorder")]
 mod from_low_u64 {
 	use super::*;
 
@@ -328,7 +326,6 @@ fn from_h256_to_h160_lossy() {
 	assert_eq!(h160, expected);
 }
 
-#[cfg(all(feature = "std", feature = "byteorder"))]
 #[test]
 fn display_and_debug() {
 	fn test_for(x: u64, hex: &'static str, display: &'static str) {

--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -327,6 +327,7 @@ fn from_h256_to_h160_lossy() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn display_and_debug() {
 	fn test_for(x: u64, hex: &'static str, display: &'static str) {
 		let hash = H64::from_low_u64_be(x);

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -28,7 +28,6 @@ jsonschema = { version = "0.17", default-features = false }
 default = ["std", "rand"]
 std = ["uint/std", "fixed-hash/std", "impl-codec?/std"]
 rand = ["fixed-hash/rand"]
-byteorder = ["fixed-hash/byteorder"]
 rustc-hex = ["fixed-hash/rustc-hex"]
 serde = ["std", "impl-serde", "impl-serde/std"]
 json-schema = ["dep:schemars"]


### PR DESCRIPTION
- remove `byteorder` feature
- rename `impl_ops_for_hash` => `impl_bit_ops_for_fixed_hash`
- remove `impl_cmp_for_fixed_hash` macro