### PR TITLE
fixed-hash: remove `rustc-hex` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           args: -p uint --all-features
 
       - name: Test fixed-hash no_std
-        run: cargo test -p fixed-hash --no-default-features --features='rustc-hex'
+        run: cargo test -p fixed-hash --no-default-features
 
       - name: Test fixed-hash all-features
         uses: actions-rs/cargo@v1

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/ethbloom"
 homepage = "https://github.com/paritytech/parity-common"
 repository = "https://github.com/paritytech/parity-common"
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.64.0"
 
 [dependencies]
 tiny-keccak = { version = "2.0", features = ["keccak"] }
@@ -25,10 +25,9 @@ rand = "0.8.0"
 hex-literal = "0.4.1"
 
 [features]
-default = ["std", "rlp", "serialize", "rustc-hex"]
+default = ["std", "rlp", "serialize"]
 std = ["fixed-hash/std", "crunchy/std"]
 serialize = ["impl-serde"]
-rustc-hex = ["fixed-hash/rustc-hex"]
 arbitrary = ["fixed-hash/arbitrary"]
 rlp = ["impl-rlp"]
 codec = ["impl-codec", "scale-info"]

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -6,16 +6,16 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
 description = "Ethereum types"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 [dependencies]
-ethbloom = { path = "../ethbloom", version = "0.14", optional = true, default-features = false }
-fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false, features = ["rustc-hex"] }
+ethbloom = { path = "../ethbloom", version = "0.14", default-features = false, optional = true }
+fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false }
 uint-crate = { path = "../uint", package = "uint", version = "0.10", default-features = false }
-primitive-types = { path = "../primitive-types", version = "0.13", features = ["rustc-hex"], default-features = false }
+primitive-types = { path = "../primitive-types", version = "0.13", default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.5.0", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.4", default-features = false, optional = true }
-impl-codec = { version = "0.7.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
+impl-codec = { path = "../primitive-types/impls/codec", version = "0.7.0", default-features = false, optional = true }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false, optional = true }
 
 [dev-dependencies]

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -9,26 +9,30 @@ description = "Macros to define custom fixed-size hash types"
 documentation = "https://docs.rs/fixed-hash/"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64.0"
 
 [package.metadata.docs.rs]
-features = ["quickcheck", "api-dummy"]
+features = ["arbitrary", "quickcheck", "api-dummy"]
 
 [dependencies]
-quickcheck = { version = "1", optional = true }
-rand = { version = "0.8.0", optional = true, default-features = false }
-rustc-hex = { version = "2.0.1", optional = true, default-features = false }
+const-hex = { version = "1.13", default-features = false }
+rand = { version = "0.8.0", default-features = false, optional = true }
 static_assertions = "1.0.0"
+
 arbitrary = { version = "1.0", optional = true }
+quickcheck = { version = "1", optional = true }
 
 [dev-dependencies]
-rand_xorshift = "0.3.0"
 criterion = "0.5.1"
 rand = { version = "0.8.0", default-features = false, features = ["std_rng"] }
+rand_xorshift = "0.3.0"
 
 [features]
-default = ["std", "rand", "rustc-hex"]
-std = ["rustc-hex/std", "rand?/std"]
+default = ["std", "rand"]
+std = ["const-hex/std", "rand?/std"]
+rand = ["dep:rand"]
+arbitrary = ["dep:arbitrary"]
+quickcheck = ["dep:quickcheck"]
 
 api-dummy = [] # Feature used by docs.rs to display documentation of hash types
 

--- a/fixed-hash/README.md
+++ b/fixed-hash/README.md
@@ -50,7 +50,6 @@ fixed-hash = { version = "0.3", default-features = false }
 
 - `std`: Use the standard library instead of the core library.
 	- Using this feature enables the following features
-		- `rustc-hex/std`
 		- `rand/std`
     - Enabled by default.
 - `rand`: Provide API based on the `rand` crate.

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -209,6 +209,8 @@ macro_rules! construct_fixed_hash {
 			}
 		}
 
+		$crate::impl_to_from_low_u64_for_fixed_hash!($name);
+
 		impl $crate::core_::fmt::Debug for $name {
 			fn fmt(&self, f: &mut $crate::core_::fmt::Formatter) -> $crate::core_::fmt::Result {
 				$crate::core_::write!(f, "{:#x}", self)
@@ -288,6 +290,26 @@ macro_rules! construct_fixed_hash {
 			}
 		}
 
+		impl $crate::core_::str::FromStr for $name {
+			type Err = $crate::const_hex::FromHexError;
+
+			/// Creates a hash type instance from the given string.
+			///
+			/// # Note
+			///
+			/// The given input string is interpreted in big endian.
+			///
+			/// # Errors
+			///
+			/// - When encountering invalid non hex-digits
+			/// - Upon empty string input or invalid input length in general
+			fn from_str(input: &str) -> $crate::core_::result::Result<$name, $crate::const_hex::FromHexError> {
+				let mut result = Self::zero();
+				$crate::const_hex::decode_to_slice(input, result.as_bytes_mut())?;
+				Ok(result)
+			}
+		}
+
 		impl<I> $crate::core_::ops::Index<I> for $name
 		where
 			I: $crate::core_::slice::SliceIndex<[u8]>
@@ -313,9 +335,6 @@ macro_rules! construct_fixed_hash {
 		$crate::impl_bit_ops_for_fixed_hash!($name, BitOr, bitor, BitOrAssign, bitor_assign, |, |=);
 		$crate::impl_bit_ops_for_fixed_hash!($name, BitAnd, bitand, BitAndAssign, bitand_assign, &, &=);
 		$crate::impl_bit_ops_for_fixed_hash!($name, BitXor, bitxor, BitXorAssign, bitxor_assign, ^, ^=);
-
-		$crate::impl_byteorder_for_fixed_hash!($name);
-		$crate::impl_from_str_for_fixed_hash!($name);
 
 		$crate::impl_rand_for_fixed_hash!($name);
 		$crate::impl_quickcheck_for_fixed_hash!($name);
@@ -373,7 +392,7 @@ macro_rules! impl_bit_ops_for_fixed_hash {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! impl_byteorder_for_fixed_hash {
+macro_rules! impl_to_from_low_u64_for_fixed_hash {
 	( $name:ident ) => {
 		impl $name {
 			/// Returns the least significant `n` bytes as slice.
@@ -469,32 +488,6 @@ macro_rules! impl_byteorder_for_fixed_hash {
 			#[inline]
 			pub fn from_low_u64_ne(val: u64) -> Self {
 				Self::from_low_u64_with_fn(val, u64::to_ne_bytes)
-			}
-		}
-	};
-}
-
-#[macro_export]
-#[doc(hidden)]
-macro_rules! impl_from_str_for_fixed_hash {
-	( $name:ident ) => {
-		impl $crate::core_::str::FromStr for $name {
-			type Err = $crate::const_hex::FromHexError;
-
-			/// Creates a hash type instance from the given string.
-			///
-			/// # Note
-			///
-			/// The given input string is interpreted in big endian.
-			///
-			/// # Errors
-			///
-			/// - When encountering invalid non hex-digits
-			/// - Upon empty string input or invalid input length in general
-			fn from_str(input: &str) -> $crate::core_::result::Result<$name, $crate::const_hex::FromHexError> {
-				let mut result = Self::zero();
-				$crate::const_hex::decode_to_slice(input, result.as_bytes_mut())?;
-				Ok(result)
 			}
 		}
 	};

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -30,9 +30,8 @@ pub use static_assertions;
 #[doc(hidden)]
 pub use static_assertions::const_assert;
 
-#[cfg(feature = "rustc-hex")]
 #[doc(hidden)]
-pub use rustc_hex;
+pub use const_hex;
 
 #[cfg(feature = "rand")]
 #[doc(hidden)]

--- a/fixed-hash/src/tests.rs
+++ b/fixed-hash/src/tests.rs
@@ -235,6 +235,33 @@ mod from_low_u64 {
 	}
 }
 
+mod from_str {
+	use super::*;
+
+	#[test]
+	fn valid() {
+		assert_eq!(
+			"0123456789ABCDEF".parse::<H64>().unwrap(),
+			H64::from([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF])
+		)
+	}
+
+	#[test]
+	fn empty_str() {
+		assert!("".parse::<H64>().is_err())
+	}
+
+	#[test]
+	fn invalid_digits() {
+		assert!("Hello, World!".parse::<H64>().is_err())
+	}
+
+	#[test]
+	fn too_many_digits() {
+		assert!("0123456789ABCDEF0".parse::<H64>().is_err())
+	}
+}
+
 #[cfg(feature = "rand")]
 mod rand {
 	use super::*;
@@ -244,39 +271,6 @@ mod rand {
 	fn random() {
 		let mut rng = StdRng::seed_from_u64(123);
 		assert_eq!(H32::random_using(&mut rng), H32::from([0xeb, 0x96, 0xaf, 0x1c]));
-	}
-}
-
-#[cfg(feature = "rustc-hex")]
-mod from_str {
-	use super::*;
-
-	#[test]
-	fn valid() {
-		use crate::core_::str::FromStr;
-
-		assert_eq!(
-			H64::from_str("0123456789ABCDEF").unwrap(),
-			H64::from([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF])
-		)
-	}
-
-	#[test]
-	fn empty_str() {
-		use crate::core_::str::FromStr;
-		assert!(H64::from_str("").is_err())
-	}
-
-	#[test]
-	fn invalid_digits() {
-		use crate::core_::str::FromStr;
-		assert!(H64::from_str("Hello, World!").is_err())
-	}
-
-	#[test]
-	fn too_many_digits() {
-		use crate::core_::str::FromStr;
-		assert!(H64::from_str("0123456789ABCDEF0").is_err())
 	}
 }
 

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -7,15 +7,15 @@ homepage = "https://github.com/paritytech/parity-common"
 repository = "https://github.com/paritytech/parity-common"
 description = "Primitive types shared by Ethereum and Substrate"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 [dependencies]
-fixed-hash = { version = "0.8", path = "../fixed-hash", default-features = false }
-uint = { version = "0.10.0", path = "../uint", default-features = false }
-impl-serde = { version = "0.5.0", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.7.0", path = "impls/codec", default-features = false, optional = true }
-impl-num-traits = { version = "0.2.0", path = "impls/num-traits", default-features = false, optional = true }
-impl-rlp = { version = "0.4", path = "impls/rlp", default-features = false, optional = true }
+fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false }
+uint = { path = "../uint", version = "0.10.0", default-features = false }
+impl-serde = { path = "impls/serde", version = "0.5.0", default-features = false, optional = true }
+impl-codec = { path = "impls/codec", version = "0.7.0", default-features = false, optional = true }
+impl-num-traits = {  path = "impls/num-traits", version = "0.2.0",default-features = false, optional = true }
+impl-rlp = { path = "impls/rlp", version = "0.4", default-features = false, optional = true }
 scale-info-crate = { package = "scale-info", version = ">=0.9, <3", features = ["derive"], default-features = false, optional = true }
 schemars = { version = ">=0.8.12", default-features = true, optional = true }
 
@@ -28,7 +28,6 @@ jsonschema = { version = "0.17", default-features = false }
 default = ["std", "rand"]
 std = ["uint/std", "fixed-hash/std", "impl-codec?/std"]
 rand = ["fixed-hash/rand"]
-rustc-hex = ["fixed-hash/rustc-hex"]
 serde = ["std", "impl-serde", "impl-serde/std"]
 json-schema = ["dep:schemars"]
 serde_no_std = ["impl-serde"]

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -14,7 +14,7 @@ fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false
 uint = { path = "../uint", version = "0.10.0", default-features = false }
 impl-serde = { path = "impls/serde", version = "0.5.0", default-features = false, optional = true }
 impl-codec = { path = "impls/codec", version = "0.7.0", default-features = false, optional = true }
-impl-num-traits = {  path = "impls/num-traits", version = "0.2.0",default-features = false, optional = true }
+impl-num-traits = { path = "impls/num-traits", version = "0.2.0",default-features = false, optional = true }
 impl-rlp = { path = "impls/rlp", version = "0.4", default-features = false, optional = true }
 scale-info-crate = { package = "scale-info", version = ">=0.9, <3", features = ["derive"], default-features = false, optional = true }
 schemars = { version = ">=0.8.12", default-features = true, optional = true }


### PR DESCRIPTION
~~merge #872 first~~

- remove `rustc-hex` feature (`rustc-hex` is only used for `std::str::FromStr` impl, so I don't think the feature is necessary)
- use `const-hex` instead of `rustc-hex` dependency (`rustc-hex` is no longer maintained, and `const-hex` has [better performance](https://github.com/DaniPopes/const-hex?tab=readme-ov-file#performance))

BTW, I'm considering replacing both `hex` and `rustc-hex` in dependency tree with `const-hex`.
