### PR TITLE
bounded-collections: Bump version to 0.2.2

### DIFF
--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [Unreleased]
+## [0.2.2] - 2024-11-08
 - Added `ConstInt` and `ConstUint` types. [#878](https://github.com/paritytech/parity-common/pull/878)
 
 ## [0.2.1] - 2024-10-08

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
This PR bumps the version of `bounded-collections` to publish.