### PR TITLE
fix: typos in documentation files

### DIFF
--- a/uint/CHANGELOG.md
+++ b/uint/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog].
 
 ## [0.9.2] - 2022-01-28
 - Migrated to 2021 edition, enforcing MSRV of `1.56.1`. [#601](https://github.com/paritytech/parity-common/pull/601)
-- Display formatting support. [#603](ttps://github.com/paritytech/parity-common/pull/603)
+- Display formatting support. [#603](https://github.com/paritytech/parity-common/pull/603)
 
 ## [0.9.1] - 2021-06-30
 - Added `integer_sqrt` method. [#554](https://github.com/paritytech/parity-common/pull/554)


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `(ttps://github.com/paritytech/parity-common/pull/603)` to `(https://github.com/paritytech/parity-common/pull/603)`. The letter `h` is missing at the beginning of the link.


Please review the changes and let me know if any additional changes are needed.

