### PR TITLE
Add `is_full` API to all bounded collections

### DIFF
--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -271,6 +271,11 @@ where
 				.collect::<Result<BTreeMap<_, _>, _>>()?,
 		))
 	}
+
+	/// Returns true if this map is full.
+	pub fn is_full(&self) -> bool {
+		self.len() >= Self::bound()
+	}
 }
 
 impl<K, V, S> Default for BoundedBTreeMap<K, V, S>
@@ -783,5 +788,17 @@ mod test {
 				_ => unreachable!("deserializer must raise error"),
 			}
 		}
+	}
+
+	#[test]
+	fn is_full_works() {
+		let mut bounded = boundedmap_from_keys::<u32, ConstU32<4>>(&[1, 2, 3]);
+		assert!(!bounded.is_full());
+		bounded.try_insert(0, ()).unwrap();
+		assert_eq!(*bounded, map_from_keys(&[1, 0, 2, 3]));
+
+		assert!(bounded.is_full());
+		assert!(bounded.try_insert(9, ()).is_err());
+		assert_eq!(*bounded, map_from_keys(&[1, 0, 2, 3]));
 	}
 }

--- a/bounded-collections/src/bounded_btree_set.rs
+++ b/bounded-collections/src/bounded_btree_set.rs
@@ -207,6 +207,11 @@ where
 	{
 		self.0.take(value)
 	}
+
+	/// Returns true if this set is full.
+	pub fn is_full(&self) -> bool {
+		self.len() >= Self::bound()
+	}
 }
 
 impl<T, S> Default for BoundedBTreeSet<T, S>
@@ -585,6 +590,18 @@ mod test {
 			set: BoundedBTreeSet<String, ConstU32<16>>,
 		}
 		let _foo = Foo::default();
+	}
+
+	#[test]
+	fn is_full_works() {
+		let mut bounded = boundedset_from_keys::<u32, ConstU32<4>>(&[1, 2, 3]);
+		assert!(!bounded.is_full());
+		bounded.try_insert(0).unwrap();
+		assert_eq!(*bounded, set_from_keys(&[1, 0, 2, 3]));
+
+		assert!(bounded.is_full());
+		assert!(bounded.try_insert(9).is_err());
+		assert_eq!(*bounded, set_from_keys(&[1, 0, 2, 3]));
 	}
 
 	#[cfg(feature = "serde")]

--- a/bounded-collections/src/bounded_vec.rs
+++ b/bounded-collections/src/bounded_vec.rs
@@ -437,7 +437,7 @@ impl<T, S: Get<u32>> BoundedVec<T, S> {
 		S::get() as usize
 	}
 
-	/// Returns true of this collection is full.
+	/// Returns true if this collection is full.
 	pub fn is_full(&self) -> bool {
 		self.len() >= Self::bound()
 	}
@@ -1367,5 +1367,17 @@ mod test {
 			map: BoundedVec<String, ConstU32<16>>,
 		}
 		let _foo = Foo { bar: 42, slice: BoundedSlice::truncate_from(&[0, 1][..]), map: BoundedVec::default() };
+	}
+
+	#[test]
+	fn is_full_works() {
+		let mut bounded: BoundedVec<u32, ConstU32<4>> = bounded_vec![1, 2, 3];
+		assert!(!bounded.is_full());
+		bounded.try_insert(1, 0).unwrap();
+		assert_eq!(*bounded, vec![1, 0, 2, 3]);
+
+		assert!(bounded.is_full());
+		assert!(bounded.try_insert(0, 9).is_err());
+		assert_eq!(*bounded, vec![1, 0, 2, 3]);
 	}
 }

--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -225,6 +225,11 @@ impl<T, S: Get<u32>> WeakBoundedVec<T, S> {
 			Err(())
 		}
 	}
+
+	/// Returns true of this collection is full.
+	pub fn is_full(&self) -> bool {
+		self.len() >= Self::bound()
+	}
 }
 
 impl<T, S> Default for WeakBoundedVec<T, S> {
@@ -516,5 +521,17 @@ mod test {
 		let v: Vec<u32> = vec![1, 2, 3, 4, 5];
 		let w = WeakBoundedVec::<u32, ConstU32<4>>::decode(&mut &v.encode()[..]).unwrap();
 		assert_eq!(v, *w);
+	}
+
+	#[test]
+	fn is_full_works() {
+		let mut bounded: WeakBoundedVec<u32, ConstU32<4>> = vec![1, 2, 3].try_into().unwrap();
+		assert!(!bounded.is_full());
+		bounded.try_insert(1, 0).unwrap();
+		assert_eq!(*bounded, vec![1, 0, 2, 3]);
+
+		assert!(bounded.is_full());
+		assert!(bounded.try_insert(0, 9).is_err());
+		assert_eq!(*bounded, vec![1, 0, 2, 3]);
 	}
 }

--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -226,7 +226,7 @@ impl<T, S: Get<u32>> WeakBoundedVec<T, S> {
 		}
 	}
 
-	/// Returns true of this collection is full.
+	/// Returns true if this collection is full.
 	pub fn is_full(&self) -> bool {
 		self.len() >= Self::bound()
 	}


### PR DESCRIPTION
This PR adds an `is_full` API to all the bounded collections.

This was only on `BoundedVec`, but is plenty useful for all the other types too.