### PR TITLE
Add `new()` function for `WeakBoundedVec`

### DIFF
--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -119,6 +119,11 @@ impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
 }
 
 impl<T, S> WeakBoundedVec<T, S> {
+	/// Create `Self` with no items.
+	pub fn new() -> Self {
+		Self(Vec::new(), Default::default())
+	}
+
 	/// Create `Self` from `t` without any checks.
 	fn unchecked_from(t: Vec<T>) -> Self {
 		Self(t, Default::default())


### PR DESCRIPTION
Currently, to create an empty `WeakBoundedVec`, you need to do something like `WeakBoundedVec::force_from(vec![], None)`. Having a `new()` function would make it easier.