### PR TITLE
Implement DecodeWithMemTracking for some structs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.75.0
+          toolchain: 1.79.0
           override: true
 
       - name: Rust Cache

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.2.3] - 2025-01-30
+- Implement DecodeWithMemTracking for some structs [#897](https://github.com/paritytech/parity-common/pull/897)
+
 ## [0.2.2] - 2024-11-08
 - Added `ConstInt` and `ConstUint` types. [#878](https://github.com/paritytech/parity-common/pull/878)
 

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.79.0"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }
-codec = { version = "3.7.2", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
+codec = { version = "3.7.3", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false }
 log = { version = "0.4.17", default-features = false }
 schemars = { version = ">=0.8.12", default-features = true, optional = true }

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.79.0"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }
-codec = { version = "3.7.3", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
+codec = { version = "3.7.4", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false }
 log = { version = "0.4.17", default-features = false }
 schemars = { version = ">=0.8.12", default-features = true, optional = true }

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.75.0"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }
-codec = { version = "3.3.0", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
+codec = { version = "3.7.2", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
 scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false }
 log = { version = "0.4.17", default-features = false }
 schemars = { version = ">=0.8.12", default-features = true, optional = true }

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"
 description = "Bounded types and their supporting traits"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.79.0"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }

--- a/bounded-collections/src/bounded_vec.rs
+++ b/bounded-collections/src/bounded_vec.rs
@@ -21,7 +21,7 @@
 use super::WeakBoundedVec;
 use crate::{Get, TryCollect};
 use alloc::vec::Vec;
-use codec::{decode_vec_with_len, Compact, Decode, Encode, EncodeLike, MaxEncodedLen};
+use codec::{decode_vec_with_len, Compact, Decode, DecodeWithMemTracking, Encode, EncodeLike, MaxEncodedLen};
 use core::{
 	marker::PhantomData,
 	ops::{Deref, Index, IndexMut, RangeBounds},
@@ -284,6 +284,8 @@ impl<T: Decode, S: Get<u32>> Decode for BoundedVec<T, S> {
 		Vec::<T>::skip(input)
 	}
 }
+
+impl<T: DecodeWithMemTracking, S: Get<u32>> DecodeWithMemTracking for BoundedVec<T, S> {}
 
 // `BoundedVec`s encode to something which will always decode as a `Vec`.
 impl<T: Encode + Decode, S: Get<u32>> EncodeLike<Vec<T>> for BoundedVec<T, S> {}

--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -21,7 +21,7 @@
 use super::{BoundedSlice, BoundedVec};
 use crate::Get;
 use alloc::vec::Vec;
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use core::{
 	marker::PhantomData,
 	ops::{Deref, Index, IndexMut},
@@ -117,6 +117,8 @@ impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
 		Vec::<T>::skip(input)
 	}
 }
+
+impl<T: DecodeWithMemTracking, S: Get<u32>> DecodeWithMemTracking for WeakBoundedVec<T, S> {}
 
 impl<T, S> WeakBoundedVec<T, S> {
 	/// Create `Self` from `t` without any checks.

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.13.2] - 2025-01-30
+- Implement DecodeWithMemTracking for some structs [#897](https://github.com/paritytech/parity-common/pull/897)
+
 ## [0.13.1] - 2024-09-12
 - Updated `uint` to 0.10. [#859](https://github.com/paritytech/parity-common/pull/859)
 

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/parity-common"
 repository = "https://github.com/paritytech/parity-common"
 description = "Primitive types shared by Ethereum and Substrate"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.79.0"
 
 [dependencies]
 fixed-hash = { version = "0.8", path = "../fixed-hash", default-features = false }

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-parity-scale-codec = { version = "3.3.0", default-features = false, features = ["max-encoded-len"] }
+parity-scale-codec = { version = "3.7.2", default-features = false, features = ["max-encoded-len"] }
 
 [features]
 default = ["std"]

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-parity-scale-codec = { version = "3.7.2", default-features = false, features = ["max-encoded-len"] }
+parity-scale-codec = { version = "3.7.3", default-features = false, features = ["max-encoded-len"] }
 
 [features]
 default = ["std"]

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-parity-scale-codec = { version = "3.7.3", default-features = false, features = ["max-encoded-len"] }
+parity-scale-codec = { version = "3.7.4", default-features = false, features = ["max-encoded-len"] }
 
 [features]
 default = ["std"]

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -32,6 +32,8 @@ macro_rules! impl_uint_codec {
 			}
 		}
 
+		impl $crate::codec::DecodeWithMemTracking for $name {}
+
 		impl $crate::codec::MaxEncodedLen for $name {
 			fn max_encoded_len() -> usize {
 				::core::mem::size_of::<$name>()
@@ -57,6 +59,8 @@ macro_rules! impl_fixed_hash_codec {
 				<[u8; $len] as $crate::codec::Decode>::decode(input).map($name)
 			}
 		}
+
+		impl $crate::codec::DecodeWithMemTracking for $name {}
 
 		impl $crate::codec::MaxEncodedLen for $name {
 			fn max_encoded_len() -> usize {


### PR DESCRIPTION
Implement `DecodeWithMemTracking` for:
- `uint` and fixed hashes
- `BoundedVec` and `WeakBoundedVec`