### PR TITLE
Implement traits from num-traits for uint types

### DIFF
--- a/primitive-types/impls/num-traits/CHANGELOG.md
+++ b/primitive-types/impls/num-traits/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Added missing trait impls. [#898](https://github.com/paritytech/parity-common/pull/898)
 
 ## [0.2.0] - 2024-09-11
 - Updated `uint` to 0.10. [#859](https://github.com/paritytech/parity-common/pull/859)

--- a/primitive-types/impls/num-traits/CHANGELOG.md
+++ b/primitive-types/impls/num-traits/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-- Added missing trait impls. [#898](https://github.com/paritytech/parity-common/pull/898)
+- Added missing num-traits impls for uint types. [#898](https://github.com/paritytech/parity-common/pull/898)
 
 ## [0.2.0] - 2024-09-11
 - Updated `uint` to 0.10. [#859](https://github.com/paritytech/parity-common/pull/859)

--- a/primitive-types/impls/num-traits/src/lib.rs
+++ b/primitive-types/impls/num-traits/src/lib.rs
@@ -23,7 +23,27 @@ pub use uint;
 #[macro_export]
 macro_rules! impl_uint_num_traits {
 	($name: ident, $len: expr) => {
+		impl $crate::num_traits::bounds::Bounded for $name {
+			#[inline]
+			fn min_value() -> Self {
+				Self::zero()
+			}
+
+			#[inline]
+			fn max_value() -> Self {
+				Self::max_value()
+			}
+		}
+
 		impl $crate::num_traits::sign::Unsigned for $name {}
+
+		impl $crate::num_traits::identities::ConstZero for $name {
+			const ZERO: Self = Self::zero();
+		}
+
+		impl $crate::num_traits::identities::ConstOne for $name {
+			const ONE: Self = Self::one();
+		}
 
 		impl $crate::num_traits::identities::Zero for $name {
 			#[inline]
@@ -58,6 +78,30 @@ macro_rules! impl_uint_num_traits {
 			}
 		}
 
+		impl $crate::num_traits::ops::bytes::FromBytes for $name {
+			type Bytes = [u8; $len * 8];
+
+			fn from_be_bytes(bytes: &Self::Bytes) -> Self {
+				Self::from_big_endian(&bytes[..])
+			}
+
+			fn from_le_bytes(bytes: &Self::Bytes) -> Self {
+				Self::from_little_endian(&bytes[..])
+			}
+		}
+
+		impl $crate::num_traits::ops::bytes::ToBytes for $name {
+			type Bytes = [u8; $len * 8];
+
+			fn to_be_bytes(&self) -> Self::Bytes {
+				self.to_big_endian()
+			}
+
+			fn to_le_bytes(&self) -> Self::Bytes {
+				self.to_little_endian()
+			}
+		}
+
 		impl $crate::num_traits::ops::checked::CheckedAdd for $name {
 			#[inline]
 			fn checked_add(&self, v: &Self) -> Option<Self> {
@@ -83,6 +127,61 @@ macro_rules! impl_uint_num_traits {
 			#[inline]
 			fn checked_mul(&self, v: &Self) -> Option<Self> {
 				$name::checked_mul(*self, *v)
+			}
+		}
+
+		impl $crate::num_traits::ops::checked::CheckedNeg for $name {
+			#[inline]
+			fn checked_neg(&self) -> Option<Self> {
+				Self::checked_neg(*self)
+			}
+		}
+
+		impl $crate::num_traits::ops::checked::CheckedRem for $name {
+			#[inline]
+			fn checked_rem(&self, v: &Self) -> Option<Self> {
+				Self::checked_rem(*self, *v)
+			}
+		}
+
+		impl $crate::num_traits::ops::saturating::Saturating for $name {
+			#[inline]
+			fn saturating_add(self, v: Self) -> Self {
+				Self::saturating_add(self, v)
+			}
+
+			#[inline]
+			fn saturating_sub(self, v: Self) -> Self {
+				Self::saturating_sub(self, v)
+			}
+		}
+
+		impl $crate::num_traits::ops::saturating::SaturatingAdd for $name {
+			#[inline]
+			fn saturating_add(&self, v: &Self) -> Self {
+				Self::saturating_add(*self, *v)
+			}
+		}
+
+		impl $crate::num_traits::ops::saturating::SaturatingMul for $name {
+			#[inline]
+			fn saturating_mul(&self, v: &Self) -> Self {
+				Self::saturating_mul(*self, *v)
+			}
+		}
+
+		impl $crate::num_traits::ops::saturating::SaturatingSub for $name {
+			#[inline]
+			fn saturating_sub(&self, v: &Self) -> Self {
+				Self::saturating_sub(*self, *v)
+			}
+		}
+
+		impl $crate::num_traits::pow::Pow<Self> for $name {
+			type Output = Self;
+
+			fn pow(self, rhs: Self) -> Self {
+				Self::pow(self, rhs)
 			}
 		}
 	};


### PR DESCRIPTION
This PR implements the traits from `num-traits` that can be forwarded to existing functions.