### PR TITLE
Prepare patch releases

### DIFF
--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.2.3] - 2025-01-30
+## [0.2.3] - 2025-02-11
 - Implement DecodeWithMemTracking for some structs [#897](https://github.com/paritytech/parity-common/pull/897)
 
 ## [0.2.2] - 2024-11-08

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.13.2] - 2025-01-30
-- Implement DecodeWithMemTracking for some structs [#897](https://github.com/paritytech/parity-common/pull/897)
-
 ## [0.13.1] - 2024-09-12
 - Updated `uint` to 0.10. [#859](https://github.com/paritytech/parity-common/pull/859)
 

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.13.2"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"

--- a/primitive-types/impls/codec/CHANGELOG.md
+++ b/primitive-types/impls/codec/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-02-11
+- Implement `DecodeWithMemTracking` for some structs [#897](https://github.com/paritytech/parity-common/pull/897)
+
 ## [0.7.0] - 2024-09-12
 ### Breaking
 - Updated to `uint` 0.10. [#860](https://github.com/paritytech/parity-common/pull/860)

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-codec"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/paritytech/parity-common"


### PR DESCRIPTION
Related to:
- https://github.com/paritytech/parity-common/pull/897
- https://github.com/paritytech/polkadot-sdk/issues/7360

prepare:
- `bounded-collections 0.2.3`
- `impl-codec 0.7.1`

revert `primitive-types` version to `0.13.1` since https://github.com/paritytech/parity-common/pull/897 didn't introduce any change to it