### PR TITLE
Use workspace metadata and deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
+[workspace.package]
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/paritytech/parity-common"
+repository = "https://github.com/paritytech/parity-common"
+
 [workspace]
 resolver = "2"
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ uint-crate = { path = "./uint", package = "uint", default-features = false }
 primitive-types = { path = "./primitive-types", default-features = false }
 impl-codec = { path = "./primitive-types/impls/codec", default-features = false }
 impl-num-traits = { path = "./primitive-types/impls/num-traits", default-features = false }
-impl-rlp = { path = "./primitive-types/impls/rlp", version = "0.4", default-features = false }
+impl-rlp = { path = "./primitive-types/impls/rlp", default-features = false }
 impl-serde = { path = "./primitive-types/impls/serde", default-features = false }
 kvdb = { path = "./kvdb" }
 kvdb-shared-tests = { path = "./kvdb-shared-tests" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,59 @@ members = [
 	"ethereum-types",
 	"ethbloom",
 ]
+
+[workspace.dependencies]
+serde_json = "1.0.41"
+criterion = "0.5.1"
+rand = { version = "0.8.0", default-features = false }
+hex-literal = "0.4.1"
+scale-info = { version = ">=1.0, <3", default-features = false }
+quickcheck = "1"
+rustc-hex = { version = "2.0.1", default-features = false }
+static_assertions = "1.0.0"
+arbitrary = "1.0"
+tiny-keccak = "2.0"
+crunchy = { version = "0.2.2", default-features = false }
+serde = { version = "1.0.101", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false }
+log = { version = "0.4.17", default-features = false }
+schemars = ">=0.8.12"
+rand_xorshift = "0.3.0"
+tempfile = "3.1.0"
+smallvec = "1.0.0"
+parking_lot = "0.12.0"
+num_cpus = "1.10.1"
+regex = "1.3.1"
+rocksdb = { version = "0.22.0", default-features = false }
+alloc_counter = "0.0.4"
+sysinfo = "0.30.13"
+ctrlc = "3.1.4"
+chrono = "0.4"
+num-traits = { version = "0.2", default-features = false }
+integer-sqrt = "0.1"
+bytes = { version = "1", default-features = false }
+syn = "2.0.72"
+quote = "1.0.2"
+proc-macro2 = "1.0.8"
+byteorder = { version = "1.4.2", default-features = false }
+hex = { version = "0.4", default-features = false }
+num-bigint = "0.4.0"
+rug = { version = "1.6.0", default-features = false }
+jsonschema = { version = "0.23", default-features = false }
+serde_derive = "1.0.101"
+
+ethbloom = { path = "./ethbloom", default-features = false }
+ethereum-types = { path = "./ethereum-types" }
+fixed-hash = { path = "./fixed-hash", default-features = false }
+uint = { path = "./uint", default-features = false }
+uint-crate = { path = "./uint", package = "uint", default-features = false }
+primitive-types = { path = "./primitive-types", default-features = false }
+impl-codec = { path = "./primitive-types/impls/codec", default-features = false }
+impl-num-traits = { path = "./primitive-types/impls/num-traits", default-features = false }
+impl-rlp = { path = "./primitive-types/impls/rlp", version = "0.4", default-features = false }
+impl-serde = { path = "./primitive-types/impls/serde", default-features = false }
+kvdb = { path = "./kvdb" }
+kvdb-shared-tests = { path = "./kvdb-shared-tests" }
+keccak-hash = { path = "./keccak-hash" }
+rlp = { path = "./rlp" }
+rlp-derive = { path = "./rlp-derive" }

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -10,14 +10,14 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }
-codec = { version = "3.7.4", default-features = false, features = ["max-encoded-len"], package = "parity-scale-codec" }
-scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false }
-log = { version = "0.4.17", default-features = false }
-schemars = { version = ">=0.8.12", default-features = true, optional = true }
+serde = { workspace = true, features = ["alloc", "derive"], optional = true }
+codec = { workspace = true, features = ["max-encoded-len"] }
+scale-info = { workspace = true, features = ["derive"] }
+log = { workspace = true }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.41"
+serde_json = { workspace = true }
 
 [features]
 default = ["std"]

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -3,6 +3,7 @@ name = "bounded-collections"
 version = "0.2.3"
 description = "Bounded types and their supporting traits"
 readme = "README.md"
+rust-version = "1.79.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "bounded-collections"
 version = "0.2.3"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
 description = "Bounded types and their supporting traits"
-edition = "2021"
-rust-version = "1.79.0"
+readme = "README.md"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, optional = true, features=["alloc", "derive"] }

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "ethbloom"
 version = "0.14.1"
-authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
-license = "MIT OR Apache-2.0"
-documentation = "https://docs.rs/ethbloom"
-homepage = "https://github.com/paritytech/parity-common"
-repository = "https://github.com/paritytech/parity-common"
-edition = "2021"
-rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 tiny-keccak = { version = "2.0", features = ["keccak"] }

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -9,18 +9,18 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-tiny-keccak = { version = "2.0", features = ["keccak"] }
-crunchy = { version = "0.2.2", default-features = false, features = ["limit_256"] }
-fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false }
-impl-serde = { path = "../primitive-types/impls/serde", version = "0.5", default-features = false, optional = true }
-impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.4", default-features = false, optional = true }
-impl-codec = { version = "0.7.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
-scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false, optional = true }
+tiny-keccak = { workspace = true, features = ["keccak"] }
+crunchy = { workspace = true, features = ["limit_256"] }
+fixed-hash = { workspace = true }
+impl-serde = { workspace = true, optional = true }
+impl-rlp = { workspace = true, optional = true }
+impl-codec = { workspace = true, optional = true }
+scale-info = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
-criterion = "0.5.1"
-rand = "0.8.0"
-hex-literal = "0.4.1"
+criterion = { workspace = true }
+rand = { workspace = true, default-features = true }
+hex-literal = { workspace = true }
 
 [features]
 default = ["std", "rlp", "serialize", "rustc-hex"]

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ethbloom"
 version = "0.14.1"
 description = "Ethereum bloom filter"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ethereum-types"
 version = "0.15.1"
 description = "Ethereum types"
+rust-version = "1.60.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ethereum-types"
 version = "0.15.1"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
 description = "Ethereum types"
-edition = "2021"
-rust-version = "1.60.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 ethbloom = { path = "../ethbloom", version = "0.14", optional = true, default-features = false }

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -9,17 +9,17 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-ethbloom = { path = "../ethbloom", version = "0.14", optional = true, default-features = false }
-fixed-hash = { path = "../fixed-hash", version = "0.8", default-features = false, features = ["rustc-hex"] }
-uint-crate = { path = "../uint", package = "uint", version = "0.10", default-features = false }
-primitive-types = { path = "../primitive-types", version = "0.13", features = ["rustc-hex"], default-features = false }
-impl-serde = { path = "../primitive-types/impls/serde", version = "0.5.0", default-features = false, optional = true }
-impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.4", default-features = false, optional = true }
-impl-codec = { version = "0.7.0", path = "../primitive-types/impls/codec", default-features = false, optional = true }
-scale-info = { version = ">=1.0, <3", features = ["derive"], default-features = false, optional = true }
+ethbloom = { workspace = true, optional = true }
+fixed-hash = { workspace = true, features = ["rustc-hex"] }
+uint-crate = { workspace = true }
+primitive-types = { workspace = true, features = ["rustc-hex"] }
+impl-serde = { workspace = true, optional = true }
+impl-rlp = { workspace = true, optional = true }
+impl-codec = { workspace = true, optional = true }
+scale-info = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.41"
+serde_json = { workspace = true }
 
 [features]
 default = ["std", "ethbloom", "rlp", "serialize"]

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -3,6 +3,7 @@ name = "fixed-hash"
 version = "0.8.0"
 description = "Macros to define custom fixed-size hash types"
 readme = "README.md"
+rust-version = "1.60"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "fixed-hash"
 version = "0.8.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
-repository = "https://github.com/paritytech/parity-common"
 description = "Macros to define custom fixed-size hash types"
-documentation = "https://docs.rs/fixed-hash/"
 readme = "README.md"
-edition = "2021"
-rust-version = "1.60"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [package.metadata.docs.rs]
 features = ["quickcheck", "api-dummy"]

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -13,16 +13,16 @@ repository.workspace = true
 features = ["quickcheck", "api-dummy"]
 
 [dependencies]
-quickcheck = { version = "1", optional = true }
-rand = { version = "0.8.0", optional = true, default-features = false }
-rustc-hex = { version = "2.0.1", optional = true, default-features = false }
-static_assertions = "1.0.0"
-arbitrary = { version = "1.0", optional = true }
+quickcheck = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
+rustc-hex = { workspace = true, optional = true }
+static_assertions = { workspace = true }
+arbitrary = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand_xorshift = "0.3.0"
-criterion = "0.5.1"
-rand = { version = "0.8.0", default-features = false, features = ["std_rng"] }
+rand_xorshift = { workspace = true }
+criterion = { workspace = true }
+rand = { workspace = true, default-features = false, features = ["std_rng"] }
 
 [features]
 default = ["std", "rand", "rustc-hex"]

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -2,12 +2,12 @@
 name = "keccak-hash"
 version = "0.11.0"
 description = "`keccak-hash` is a set of utility functions to facilitate working with Keccak hashes (256/512 bits long)."
-authors = ["Parity Technologies <admin@parity.io>"]
-repository = "https://github.com/paritytech/parity-common"
 readme = "README.md"
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 tiny-keccak = { version = "2.0", features = ["keccak"] }

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -3,6 +3,7 @@ name = "keccak-hash"
 version = "0.11.0"
 description = "`keccak-hash` is a set of utility functions to facilitate working with Keccak hashes (256/512 bits long)."
 readme = "README.md"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/keccak-hash/Cargo.toml
+++ b/keccak-hash/Cargo.toml
@@ -10,12 +10,12 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-tiny-keccak = { version = "2.0", features = ["keccak"] }
-primitive-types = { path = "../primitive-types", version = "0.13", default-features = false }
+tiny-keccak = { workspace = true, features = ["keccak"] }
+primitive-types = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.1.0"
-criterion = "0.5.1"
+tempfile = { workspace = true }
+criterion = { workspace = true }
 
 [features]
 default = ["std"]

--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "kvdb-memorydb"
 version = "0.13.0"
-description = "A key-value in-memory database that implements the  `KeyValueDB` trait"
+description = "A key-value in-memory database that implements the `KeyValueDB` trait"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -9,11 +9,11 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-parking_lot = "0.12.0"
-kvdb = { version = "0.13", path = "../kvdb" }
+parking_lot = { workspace = true }
+kvdb = { workspace = true }
 
 [dev-dependencies]
-kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.11" }
+kvdb-shared-tests = { workspace = true }
 
 [features]
 default = []

--- a/kvdb-memorydb/Cargo.toml
+++ b/kvdb-memorydb/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "kvdb-memorydb"
 version = "0.13.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-repository = "https://github.com/paritytech/parity-common"
 description = "A key-value in-memory database that implements the  `KeyValueDB` trait"
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 parking_lot = "0.12.0"

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kvdb-rocksdb"
 version = "0.19.0"
 description = "kvdb implementation backed by RocksDB"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -13,32 +13,28 @@ name = "bench_read_perf"
 harness = false
 
 [dependencies]
-smallvec = "1.0.0"
-kvdb = { path = "../kvdb", version = "0.13" }
-num_cpus = "1.10.1"
-parking_lot = "0.12.0"
-regex = "1.3.1"
+smallvec = { workspace = true }
+kvdb = { workspace = true }
+num_cpus = { workspace = true }
+parking_lot = { workspace = true }
+regex = { workspace = true }
 
 # OpenBSD and MSVC are unteested and shouldn't enable jemalloc:
 # https://github.com/tikv/jemallocator/blob/52de4257fab3e770f73d5174c12a095b49572fba/jemalloc-sys/build.rs#L26-L27
-[target.'cfg(any(target_os = "openbsd", target_env = "msvc"))'.dependencies.rocksdb]
-default-features = false
-features = ["snappy"]
-version = "0.22.0"
+[target.'cfg(any(target_os = "openbsd", target_env = "msvc"))'.dependencies]
+rocksdb = { workspace = true, features = ["snappy"] }
 
-[target.'cfg(not(any(target_os = "openbsd", target_env = "msvc")))'.dependencies.rocksdb]
-default-features = false
-features = ["snappy", "jemalloc"]
-version = "0.22.0"
+[target.'cfg(not(any(target_os = "openbsd", target_env = "msvc")))'.dependencies]
+rocksdb = { workspace = true, features = ["snappy", "jemalloc"] }
 
 [dev-dependencies]
-alloc_counter = "0.0.4"
-criterion = "0.5"
-ethereum-types = { path = "../ethereum-types", features = ["rand"] }
-kvdb-shared-tests = { path = "../kvdb-shared-tests", version = "0.11" }
-rand = "0.8.0"
-tempfile = "3.1.0"
-keccak-hash = { path = "../keccak-hash" }
-sysinfo = "0.30.13"
-ctrlc = "3.1.4"
-chrono = "0.4"
+alloc_counter = { workspace = true }
+criterion = { workspace = true }
+ethereum-types = { workspace = true, features = ["rand"] }
+kvdb-shared-tests = { workspace = true }
+rand = { workspace = true, default-features = true }
+tempfile = { workspace = true }
+keccak-hash = { workspace = true }
+sysinfo = { workspace = true }
+ctrlc = { workspace = true }
+chrono = { workspace = true }

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "kvdb-rocksdb"
 version = "0.19.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by RocksDB"
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [[bench]]
 name = "bench_read_perf"

--- a/kvdb-shared-tests/Cargo.toml
+++ b/kvdb-shared-tests/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "kvdb-shared-tests"
 version = "0.11.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
-rust-version = "1.56.1"
 description = "Shared tests for kvdb functionality, to be executed against actual implementations"
-license = "MIT OR Apache-2.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 kvdb = { path = "../kvdb", version = "0.13" }

--- a/kvdb-shared-tests/Cargo.toml
+++ b/kvdb-shared-tests/Cargo.toml
@@ -9,4 +9,4 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-kvdb = { path = "../kvdb", version = "0.13" }
+kvdb = { workspace = true }

--- a/kvdb-shared-tests/Cargo.toml
+++ b/kvdb-shared-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kvdb-shared-tests"
 version = "0.11.0"
 description = "Shared tests for kvdb functionality, to be executed against actual implementations"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -9,4 +9,4 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-smallvec = "1.0.0"
+smallvec = { workspace = true }

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "kvdb"
 version = "0.13.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-repository = "https://github.com/paritytech/parity-common"
 description = "Generic key-value trait"
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 smallvec = "1.0.0"

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kvdb"
 version = "0.13.0"
 description = "Generic key-value trait"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/parity-bytes/Cargo.toml
+++ b/parity-bytes/Cargo.toml
@@ -3,6 +3,7 @@ name = "parity-bytes"
 version = "0.1.2"
 description = "byte utilities for Parity"
 readme = "README.md"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/parity-bytes/Cargo.toml
+++ b/parity-bytes/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "parity-bytes"
 version = "0.1.2"
-authors = ["Parity Technologies <admin@parity.io>"]
-repository = "https://github.com/paritytech/parity-common"
 description = "byte utilities for Parity"
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.56.1"
-
-[dependencies]
+readme = "README.md"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [features]
 default = ["std"]

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "primitive-types"
 version = "0.13.1"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
-repository = "https://github.com/paritytech/parity-common"
 description = "Primitive types shared by Ethereum and Substrate"
-edition = "2021"
-rust-version = "1.79.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 fixed-hash = { version = "0.8", path = "../fixed-hash", default-features = false }

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -2,6 +2,7 @@
 name = "primitive-types"
 version = "0.13.1"
 description = "Primitive types shared by Ethereum and Substrate"
+rust-version = "1.79.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -9,19 +9,19 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-fixed-hash = { version = "0.8", path = "../fixed-hash", default-features = false }
-uint = { version = "0.10.0", path = "../uint", default-features = false }
-impl-serde = { version = "0.5.0", path = "impls/serde", default-features = false, optional = true }
-impl-codec = { version = "0.7.0", path = "impls/codec", default-features = false, optional = true }
-impl-num-traits = { version = "0.2.0", path = "impls/num-traits", default-features = false, optional = true }
-impl-rlp = { version = "0.4", path = "impls/rlp", default-features = false, optional = true }
-scale-info-crate = { package = "scale-info", version = ">=0.9, <3", features = ["derive"], default-features = false, optional = true }
-schemars = { version = ">=0.8.12", default-features = true, optional = true }
+fixed-hash = { workspace = true }
+uint = { workspace = true }
+impl-serde = { workspace = true, optional = true }
+impl-codec = { workspace = true, optional = true }
+impl-num-traits = { workspace = true, optional = true }
+impl-rlp = { workspace = true, optional = true }
+scale-info = { workspace = true, features = ["derive"], optional = true }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
-num-traits = "0.2"
-serde_json = { version = "1.0", default-features = false }
-jsonschema = { version = "0.23", default-features = false }
+num-traits = { workspace = true }
+serde_json = { workspace = true }
+jsonschema = { workspace = true }
 
 [features]
 default = ["std", "rand"]
@@ -32,7 +32,7 @@ serde = ["std", "impl-serde", "impl-serde/std"]
 json-schema = ["dep:schemars"]
 serde_no_std = ["impl-serde"]
 codec = ["impl-codec"]
-scale-info = ["codec", "scale-info-crate"]
+scale-info = ["codec", "dep:scale-info"]
 rlp = ["impl-rlp"]
 arbitrary = ["fixed-hash/arbitrary", "uint/arbitrary"]
 fp-conversion = ["std"]

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "impl-codec"
 version = "0.7.1"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
 description = "Parity Codec serialization support for uint and fixed hash."
-edition = "2021"
 rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 codec = { workspace = true, features = ["max-encoded-len"] }

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-parity-scale-codec = { version = "3.7.4", default-features = false, features = ["max-encoded-len"] }
+codec = { workspace = true, features = ["max-encoded-len"] }
 
 [features]
 default = ["std"]
-std = ["parity-scale-codec/std"]
+std = ["codec/std"]

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -11,7 +11,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
-pub use parity_scale_codec as codec;
+pub use codec;
 
 /// Add Parity Codec serialization support to an integer created by `construct_uint!`.
 #[macro_export]

--- a/primitive-types/impls/num-traits/Cargo.toml
+++ b/primitive-types/impls/num-traits/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-num-traits = { version = "0.2", default-features = false }
-integer-sqrt = "0.1"
-uint = { version = "0.10.0", path = "../../../uint", default-features = false }
+num-traits = { workspace = true }
+integer-sqrt = { workspace = true }
+uint = { workspace = true }

--- a/primitive-types/impls/num-traits/Cargo.toml
+++ b/primitive-types/impls/num-traits/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "impl-num-traits"
 version = "0.2.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
 description = "num-traits implementation for uint."
-edition = "2021"
 rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 num-traits = { workspace = true }

--- a/primitive-types/impls/rlp/Cargo.toml
+++ b/primitive-types/impls/rlp/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "impl-rlp"
 version = "0.4.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
 description = "RLP serialization support for uint and fixed hash."
-edition = "2021"
 rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 rlp = { workspace = true }

--- a/primitive-types/impls/rlp/Cargo.toml
+++ b/primitive-types/impls/rlp/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
-rlp = { version = "0.6", path = "../../../rlp", default-features = false }
+rlp = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -13,13 +13,13 @@ default = ["std"]
 std = ["serde/std"]
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, features = ["alloc"] }
+serde = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
-criterion = "0.5.1"
-serde_derive = "1.0.101"
-serde_json = "1.0.41"
-uint = { version = "0.10.0", path = "../../../uint" }
+criterion = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+uint = { workspace = true, default-features = true }
 
 [[bench]]
 name = "impl_serde"

--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "impl-serde"
 version = "0.5.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
-homepage = "https://github.com/paritytech/parity-common"
 description = "Serde serialization support for uint and fixed hash."
-edition = "2021"
 rust-version = "1.56.1"
-
-[features]
-default = ["std"]
-std = ["serde/std"]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["alloc"] }
@@ -20,6 +17,10 @@ criterion = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 uint = { workspace = true, default-features = true }
+
+[features]
+default = ["std"]
+std = ["serde/std"]
 
 [[bench]]
 name = "impl_serde"

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -26,7 +26,7 @@ mod json_schema;
 use core::convert::TryFrom;
 use fixed_hash::{construct_fixed_hash, impl_fixed_hash_conversions};
 #[cfg(feature = "scale-info")]
-use scale_info_crate::TypeInfo;
+use scale_info::TypeInfo;
 use uint::{construct_uint, uint_full_mul_reg};
 
 /// Error type for conversion.

--- a/primitive-types/tests/scale_info.rs
+++ b/primitive-types/tests/scale_info.rs
@@ -9,7 +9,7 @@
 //! Tests for scale-info feature of primitive-types.
 
 use primitive_types::{H256, U256};
-use scale_info_crate::{build::Fields, Path, Type, TypeInfo};
+use scale_info::{build::Fields, Path, Type, TypeInfo};
 
 #[test]
 fn u256_scale_info() {

--- a/rlp-derive/Cargo.toml
+++ b/rlp-derive/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rlp-derive"
 version = "0.2.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "MIT OR Apache-2.0"
 description = "Derive macro for #[derive(RlpEncodable, RlpDecodable)]"
-homepage = "http://parity.io"
-edition = "2021"
-rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [lib]
 proc-macro = true

--- a/rlp-derive/Cargo.toml
+++ b/rlp-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rlp-derive"
 version = "0.2.0"
 description = "Derive macro for #[derive(RlpEncodable, RlpDecodable)]"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/rlp-derive/Cargo.toml
+++ b/rlp-derive/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = "2.0.72"
-quote = "1.0.2"
-proc-macro2 = "1.0.8"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [dev-dependencies]
-rlp = { version = "0.6.0", path = "../rlp" }
+rlp = { workspace = true }

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -2,11 +2,12 @@
 name = "rlp"
 version = "0.6.1"
 description = "Recursive-length prefix encoding, decoding, and compression"
-repository = "https://github.com/paritytech/parity-common"
-license = "MIT OR Apache-2.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
-rust-version = "1.56.1"
+readme = "README.md"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -3,6 +3,7 @@ name = "rlp"
 version = "0.6.1"
 description = "Recursive-length prefix encoding, decoding, and compression"
 readme = "README.md"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -10,14 +10,14 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-bytes = { version = "1", default-features = false }
-rustc-hex = { version = "2.0.1", default-features = false }
-rlp-derive = { version = "0.2", path = "../rlp-derive", optional = true }
+bytes = { workspace = true }
+rustc-hex = { workspace = true }
+rlp-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = "0.5.1"
-hex-literal = "0.4.1"
-primitive-types = { path = "../primitive-types", version = "0.13", features = ["impl-rlp"] }
+criterion = { workspace = true }
+hex-literal = { workspace = true }
+primitive-types = { workspace = true, default-features = true, features = ["impl-rlp"] }
 
 [features]
 default = ["std"]

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -3,6 +3,7 @@ name = "uint"
 version = "0.10.0"
 description = "Large fixed-size integer arithmetic"
 readme = "README.md"
+rust-version = "1.56.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
-description = "Large fixed-size integer arithmetic"
-homepage = "http://parity.io"
-repository = "https://github.com/paritytech/parity-common"
-license = "MIT OR Apache-2.0"
 name = "uint"
 version = "0.10.0"
-authors = ["Parity Technologies <admin@parity.io>"]
+description = "Large fixed-size integer arithmetic"
 readme = "README.md"
-edition = "2021"
-rust-version = "1.56.1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 byteorder = { version = "1.4.2", default-features = false }

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -10,12 +10,19 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-byteorder = { version = "1.4.2", default-features = false }
-crunchy = { version = "0.2.2", default-features = false }
-quickcheck = { version = "1", optional = true }
-hex = { version = "0.4", default-features = false }
-static_assertions = "1.0.0"
-arbitrary = { version = "1.0", optional = true }
+byteorder = { workspace = true }
+crunchy = { workspace = true }
+quickcheck = { workspace = true, optional = true }
+hex = { workspace = true }
+static_assertions = { workspace = true }
+arbitrary = { workspace = true, optional = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+num-bigint = { workspace = true }
+
+[target.'cfg(all(unix, target_arch = "x86_64"))'.dev-dependencies]
+rug = { workspace = true, features = ["integer", "std"] }
 
 [features]
 default = ["std"]
@@ -27,16 +34,6 @@ name = "modular"
 [[test]]
 name = "uint_tests"
 required-features = ["std"]
-
-[dev-dependencies]
-criterion = "0.5.1"
-num-bigint = "0.4.0"
-
-[target.'cfg(all(unix, target_arch = "x86_64"))'.dev-dependencies]
-rug = { version = "1.6.0", default-features = false, features = [
-    "integer",
-    "std",
-] }
 
 [[bench]]
 name = "bigint"


### PR DESCRIPTION
In this PR:
- Extract common metadata fields to workspace Cargo.toml
- Extract deps to workspace Cargo.toml

This PR shouldn't change any dependencies. Just move them to the workspace Cargo.toml