### PR TITLE
Upgrade rocksdb to 0.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           toolchain: stable
           override: true
 
+      - run: sudo apt-get install libclang-dev
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
 
@@ -41,6 +43,13 @@ jobs:
           profile: minimal
           toolchain: 1.79.0
           override: true
+
+      - name: Install Clang (Ubuntu)
+        if: ${{ runner.os == 'Linux' }}
+        run: sudo apt-get install libclang-dev
+      - name: Workaround macOS Clang
+        if: ${{ runner.os == 'macOS' }}
+        run: brew link llvm@15
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ smallvec = "1.0.0"
 parking_lot = "0.12.0"
 num_cpus = "1.10.1"
 regex = "1.3.1"
-rocksdb = { version = "0.22.0", default-features = false }
+rocksdb = { version = "0.23.0", default-features = false }
 alloc_counter = "0.0.4"
 sysinfo = "0.30.13"
 ctrlc = "3.1.4"

--- a/kvdb-rocksdb/Cargo.toml
+++ b/kvdb-rocksdb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kvdb-rocksdb"
 version = "0.19.0"
 description = "kvdb implementation backed by RocksDB"
-rust-version = "1.56.1"
+rust-version = "1.71.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
RocksDB 0.23.0 was released on Dec 24, 2024.

Polkadot is still using 0.21.0, released on May 9, 2023. since it is still the default DB, I propose updating it to the new version. However, I don't know if we can gain performance improvement here.

I don't see it has a breaking change: https://github.com/rust-rocksdb/rust-rocksdb/releases/tag/v0.23.0


