### PR TITLE
Implement `DecodeWithMemTracking` for `BoundedBTreeMap`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           override: true
 
       - name: Install Clang (Ubuntu)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ arbitrary = "1.0"
 tiny-keccak = "2.0"
 crunchy = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.101", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false }
 log = { version = "0.4.17", default-features = false }
 schemars = ">=0.8.12"
 tempfile = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ arbitrary = "1.0"
 tiny-keccak = "2.0"
 crunchy = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.101", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false }
 log = { version = "0.4.17", default-features = false }
 schemars = ">=0.8.12"
 tempfile = "3.1.0"

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [0.2.4] - 2025-03-14
+## [0.2.4] - 2025-03-20
 - Implement DecodeWithMemTracking for BoundedBTreeMap [#906](https://github.com/paritytech/parity-common/pull/906)
 
 ## [0.2.3] - 2025-02-11

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.2.4] - 2025-03-14
+- Implement DecodeWithMemTracking for BoundedBTreeMap [#906](https://github.com/paritytech/parity-common/pull/906)
+
 ## [0.2.3] - 2025-02-11
 - Implement DecodeWithMemTracking for some structs [#897](https://github.com/paritytech/parity-common/pull/897)
 

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.2.3"
+version = "0.2.4"
 description = "Bounded types and their supporting traits"
 readme = "README.md"
 rust-version = "1.79.0"

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -19,7 +19,7 @@
 
 use crate::{Get, TryCollect};
 use alloc::collections::BTreeMap;
-use codec::{Compact, Decode, Encode, MaxEncodedLen};
+use codec::{Compact, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use core::{borrow::Borrow, marker::PhantomData, ops::Deref};
 #[cfg(feature = "serde")]
 use serde::{
@@ -121,6 +121,14 @@ where
 	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
 		BTreeMap::<K, V>::skip(input)
 	}
+}
+
+impl<K, V, S> DecodeWithMemTracking for BoundedBTreeMap<K, V, S>
+where
+	K: DecodeWithMemTracking + Ord,
+	V: DecodeWithMemTracking,
+	S: Get<u32>,
+{
 }
 
 impl<K, V, S> BoundedBTreeMap<K, V, S>

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -113,6 +113,7 @@ where
 			return Err("BoundedBTreeMap exceeds its limit".into());
 		}
 		input.descend_ref()?;
+		input.on_before_alloc_mem(codec::mem_size_of_btree::<(K, V)>(len))?;
 		let inner = Result::from_iter((0..len).map(|_| Decode::decode(input)))?;
 		input.ascend_ref();
 		Ok(Self(inner, PhantomData))
@@ -128,6 +129,7 @@ where
 	K: DecodeWithMemTracking + Ord,
 	V: DecodeWithMemTracking,
 	S: Get<u32>,
+	BoundedBTreeMap<K, V, S>: Decode,
 {
 }
 


### PR DESCRIPTION
Implement `DecodeWithMemTracking` for `BoundedBTreeMap` and release bounded collections as `0.2.4`.