### PR TITLE
Add generic `GetInto` type converter for `Get` trait

### DIFF
--- a/bounded-collections/src/lib.rs
+++ b/bounded-collections/src/lib.rs
@@ -45,15 +45,14 @@ pub trait Get<T> {
 	fn get() -> T;
 }
 
-pub struct GetInto<Inner>(core::marker::PhantomData<Inner>);
+pub struct GetInto<Inner, I, R>(core::marker::PhantomData<(Inner, I, R)>);
 
-impl<Inner, I, R> Get<R> for GetInto<Inner>
+impl<Inner, I, R> Get<R> for GetInto<Inner, I, R>
 where
     Inner: Get<I>,
     I: Into<R>,
 {
     fn get() -> R {
-        // Get I from Inner, then convert to R
         Inner::get().into()
     }
 }

--- a/bounded-collections/src/lib.rs
+++ b/bounded-collections/src/lib.rs
@@ -45,6 +45,19 @@ pub trait Get<T> {
 	fn get() -> T;
 }
 
+pub struct GetInto<Inner>(core::marker::PhantomData<Inner>);
+
+impl<Inner, I, R> Get<R> for GetInto<Inner>
+where
+    Inner: Get<I>,
+    I: Into<R>,
+{
+    fn get() -> R {
+        // Get I from Inner, then convert to R
+        Inner::get().into()
+    }
+}
+
 impl<T: Default> Get<T> for () {
 	fn get() -> T {
 		T::default()


### PR DESCRIPTION
### Description

Introduces GetInto<Inner, I, R>, a generic converter for the Get trait that leverages Into for type-safe conversions.

#### Issue
Currently, type conversions using the Get trait require manual implementation for each specific type pair (e.g., [`ConvertU16ToU32`](https://github.com/paritytech/polkadot-sdk/pull/7720#discussion_r1986942682)).