### PR TITLE
Support JAM codec for bounded collections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: stable
           override: true
 
       - name: Install Clang (Ubuntu)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ arbitrary = "1.0"
 tiny-keccak = "2.0"
 crunchy = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.101", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false }
+scale-codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false }
 log = { version = "0.4.17", default-features = false }
 schemars = ">=0.8.12"
 tempfile = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tiny-keccak = "2.0"
 crunchy = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.101", default-features = false }
 scale-codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false }
+jam-codec = { version = "0.1.0", default-features = false }
 log = { version = "0.4.17", default-features = false }
 schemars = ">=0.8.12"
 tempfile = "3.1.0"

--- a/bounded-collections/CHANGELOG.md
+++ b/bounded-collections/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.3.0] - 2025-05-21
+- Jam codec support [#914](https://github.com/paritytech/parity-common/pull/914)
+
 ## [0.2.4] - 2025-03-20
 - Implement DecodeWithMemTracking for BoundedBTreeMap [#906](https://github.com/paritytech/parity-common/pull/906)
 

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bounded-collections"
-version = "0.2.4"
+version = "0.3.0"
 description = "Bounded types and their supporting traits"
 readme = "README.md"
 rust-version = "1.79.0"

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -14,9 +14,9 @@ repository.workspace = true
 serde = { workspace = true, features = ["alloc", "derive"], optional = true }
 scale-codec = { workspace = true, default-features = false, features = ["max-encoded-len"], optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
+jam-codec = { workspace = true, features = ["derive","max-encoded-len"], optional = true }
 log = { workspace = true }
 schemars = { workspace = true, optional = true }
-jam-codec = { version = "0.1.0", default-features = false, features = ["derive","max-encoded-len"], optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -12,10 +12,11 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["alloc", "derive"], optional = true }
-codec = { workspace = true, features = ["max-encoded-len"] }
-scale-info = { workspace = true, features = ["derive"] }
+scale-codec = { workspace = true, default-features = false, features = ["max-encoded-len"], optional = true }
+scale-info = { workspace = true, features = ["derive"], optional = true }
 log = { workspace = true }
 schemars = { workspace = true, optional = true }
+jam-codec = { version = "0.1.0", default-features = false, features = ["derive","max-encoded-len"], optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -25,7 +26,9 @@ default = ["std"]
 json-schema = ["dep:schemars"]
 std = [
     "log/std",
-    "codec/std",
+    "jam-codec/std",
+    "scale-codec/std",
     "scale-info/std",
     "serde/std",
 ]
+scale-codec = [ "scale-info" ]

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -426,6 +426,7 @@ where
 	}
 }
 
+#[cfg(any(feature = "scale-codec", feature = "jam-codec"))]
 macro_rules! codec_impl {
 	($codec:ident) => {
 		use super::*;

--- a/bounded-collections/src/bounded_btree_map.rs
+++ b/bounded-collections/src/bounded_btree_map.rs
@@ -19,7 +19,6 @@
 
 use crate::{Get, TryCollect};
 use alloc::collections::BTreeMap;
-use codec::{Compact, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use core::{borrow::Borrow, marker::PhantomData, ops::Deref};
 #[cfg(feature = "serde")]
 use serde::{
@@ -35,8 +34,9 @@ use serde::{
 /// Unlike a standard `BTreeMap`, there is an enforced upper limit to the number of items in the
 /// map. All internal operations ensure this bound is respected.
 #[cfg_attr(feature = "serde", derive(Serialize), serde(transparent))]
-#[derive(Encode, scale_info::TypeInfo)]
-#[scale_info(skip_type_params(S))]
+#[cfg_attr(feature = "scale-codec", derive(scale_codec::Encode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "scale-codec", scale_info(skip_type_params(S)))]
+#[cfg_attr(feature = "jam-codec", derive(jam_codec::Encode))]
 pub struct BoundedBTreeMap<K, V, S>(
 	BTreeMap<K, V>,
 	#[cfg_attr(feature = "serde", serde(skip_serializing))] PhantomData<S>,
@@ -97,79 +97,6 @@ where
 				.map_err(|_| Error::custom("failed to create a BoundedBTreeMap from the provided map"))
 		})?
 	}
-}
-
-// Struct which allows prepending the compact after reading from an input.
-pub(crate) struct PrependCompactInput<'a, I> {
-	encoded_len: &'a [u8],
-	read: usize,
-	inner: &'a mut I,
-}
-
-impl<'a, I: codec::Input> codec::Input for PrependCompactInput<'a, I> {
-	fn remaining_len(&mut self) -> Result<Option<usize>, codec::Error> {
-		let remaining_compact = self.encoded_len.len().saturating_sub(self.read);
-		Ok(self.inner.remaining_len()?.map(|len| len.saturating_add(remaining_compact)))
-	}
-
-	fn read(&mut self, into: &mut [u8]) -> Result<(), codec::Error> {
-		if into.is_empty() {
-			return Ok(());
-		}
-
-		let remaining_compact = self.encoded_len.len().saturating_sub(self.read);
-		if remaining_compact > 0 {
-			let to_read = into.len().min(remaining_compact);
-			into[..to_read].copy_from_slice(&self.encoded_len[self.read..][..to_read]);
-			self.read += to_read;
-
-			if to_read < into.len() {
-				// Buffer not full, keep reading the inner.
-				self.inner.read(&mut into[to_read..])
-			} else {
-				// Buffer was filled by the compact.
-				Ok(())
-			}
-		} else {
-			// Prepended compact has been read, just read from inner.
-			self.inner.read(into)
-		}
-	}
-}
-
-impl<K, V, S> Decode for BoundedBTreeMap<K, V, S>
-where
-	K: Decode + Ord,
-	V: Decode,
-	S: Get<u32>,
-{
-	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
-		// Fail early if the len is too big. This is a compact u32 which we will later put back.
-		let compact = <Compact<u32>>::decode(input)?;
-		if compact.0 > S::get() {
-			return Err("BoundedBTreeMap exceeds its limit".into());
-		}
-		// Reconstruct the original input by prepending the length we just read, then delegate the decoding to BTreeMap.
-		let inner = BTreeMap::decode(&mut PrependCompactInput {
-			encoded_len: compact.encode().as_ref(),
-			read: 0,
-			inner: input,
-		})?;
-		Ok(Self(inner, PhantomData))
-	}
-
-	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
-		BTreeMap::<K, V>::skip(input)
-	}
-}
-
-impl<K, V, S> DecodeWithMemTracking for BoundedBTreeMap<K, V, S>
-where
-	K: DecodeWithMemTracking + Ord,
-	V: DecodeWithMemTracking,
-	S: Get<u32>,
-	BoundedBTreeMap<K, V, S>: Decode,
-{
 }
 
 impl<K, V, S> BoundedBTreeMap<K, V, S>
@@ -439,19 +366,6 @@ impl<'a, K, V, S> IntoIterator for &'a mut BoundedBTreeMap<K, V, S> {
 	}
 }
 
-impl<K, V, S> MaxEncodedLen for BoundedBTreeMap<K, V, S>
-where
-	K: MaxEncodedLen,
-	V: MaxEncodedLen,
-	S: Get<u32>,
-{
-	fn max_encoded_len() -> usize {
-		Self::bound()
-			.saturating_mul(K::max_encoded_len().saturating_add(V::max_encoded_len()))
-			.saturating_add(codec::Compact(S::get()).encoded_size())
-	}
-}
-
 impl<K, V, S> Deref for BoundedBTreeMap<K, V, S>
 where
 	K: Ord,
@@ -495,17 +409,6 @@ where
 	}
 }
 
-impl<K, V, S> codec::DecodeLength for BoundedBTreeMap<K, V, S> {
-	fn len(self_encoded: &[u8]) -> Result<usize, codec::Error> {
-		// `BoundedBTreeMap<K, V, S>` is stored just a `BTreeMap<K, V>`, which is stored as a
-		// `Compact<u32>` with its length followed by an iteration of its items. We can just use
-		// the underlying implementation.
-		<BTreeMap<K, V> as codec::DecodeLength>::len(self_encoded)
-	}
-}
-
-impl<K, V, S> codec::EncodeLike<BTreeMap<K, V>> for BoundedBTreeMap<K, V, S> where BTreeMap<K, V>: Encode {}
-
 impl<I, K, V, Bound> TryCollect<BoundedBTreeMap<K, V, Bound>> for I
 where
 	K: Ord,
@@ -523,12 +426,131 @@ where
 	}
 }
 
+macro_rules! codec_impl {
+	($codec:ident) => {
+		use super::*;
+		use $codec::{
+			Compact, Decode, DecodeLength, DecodeWithMemTracking, Encode, EncodeLike, Error, Input, MaxEncodedLen,
+		};
+
+		// Struct which allows prepending the compact after reading from an input.
+		pub(crate) struct PrependCompactInput<'a, I> {
+			pub encoded_len: &'a [u8],
+			pub read: usize,
+			pub inner: &'a mut I,
+		}
+
+		impl<'a, I: Input> Input for PrependCompactInput<'a, I> {
+			fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
+				let remaining_compact = self.encoded_len.len().saturating_sub(self.read);
+				Ok(self.inner.remaining_len()?.map(|len| len.saturating_add(remaining_compact)))
+			}
+
+			fn read(&mut self, into: &mut [u8]) -> Result<(), Error> {
+				if into.is_empty() {
+					return Ok(());
+				}
+
+				let remaining_compact = self.encoded_len.len().saturating_sub(self.read);
+				if remaining_compact > 0 {
+					let to_read = into.len().min(remaining_compact);
+					into[..to_read].copy_from_slice(&self.encoded_len[self.read..][..to_read]);
+					self.read += to_read;
+
+					if to_read < into.len() {
+						// Buffer not full, keep reading the inner.
+						self.inner.read(&mut into[to_read..])
+					} else {
+						// Buffer was filled by the compact.
+						Ok(())
+					}
+				} else {
+					// Prepended compact has been read, just read from inner.
+					self.inner.read(into)
+				}
+			}
+		}
+
+		impl<K, V, S> Decode for BoundedBTreeMap<K, V, S>
+		where
+			K: Decode + Ord,
+			V: Decode,
+			S: Get<u32>,
+		{
+			fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+				// Fail early if the len is too big. This is a compact u32 which we will later put back.
+				let compact = <Compact<u32>>::decode(input)?;
+				if compact.0 > S::get() {
+					return Err("BoundedBTreeMap exceeds its limit".into());
+				}
+				// Reconstruct the original input by prepending the length we just read, then delegate the decoding to BTreeMap.
+				let inner = BTreeMap::decode(&mut PrependCompactInput {
+					encoded_len: compact.encode().as_ref(),
+					read: 0,
+					inner: input,
+				})?;
+				Ok(Self(inner, PhantomData))
+			}
+
+			fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+				BTreeMap::<K, V>::skip(input)
+			}
+		}
+
+		impl<K, V, S> DecodeWithMemTracking for BoundedBTreeMap<K, V, S>
+		where
+			K: DecodeWithMemTracking + Ord,
+			V: DecodeWithMemTracking,
+			S: Get<u32>,
+			BoundedBTreeMap<K, V, S>: Decode,
+		{
+		}
+
+		impl<K, V, S> MaxEncodedLen for BoundedBTreeMap<K, V, S>
+		where
+			K: MaxEncodedLen,
+			V: MaxEncodedLen,
+			S: Get<u32>,
+		{
+			fn max_encoded_len() -> usize {
+				Self::bound()
+					.saturating_mul(K::max_encoded_len().saturating_add(V::max_encoded_len()))
+					.saturating_add(Compact(S::get()).encoded_size())
+			}
+		}
+
+		impl<K, V, S> EncodeLike<BTreeMap<K, V>> for BoundedBTreeMap<K, V, S> where BTreeMap<K, V>: Encode {}
+
+		impl<K, V, S> DecodeLength for BoundedBTreeMap<K, V, S> {
+			fn len(self_encoded: &[u8]) -> Result<usize, Error> {
+				// `BoundedBTreeMap<K, V, S>` is stored just a `BTreeMap<K, V>`, which is stored as a
+				// `Compact<u32>` with its length followed by an iteration of its items. We can just use
+				// the underlying implementation.
+				<BTreeMap<K, V> as DecodeLength>::len(self_encoded)
+			}
+		}
+	};
+}
+
+#[cfg(feature = "scale-codec")]
+mod scale_codec_impl {
+	codec_impl!(scale_codec);
+}
+
+#[cfg(feature = "jam-codec")]
+mod jam_codec_impl {
+	codec_impl!(jam_codec);
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;
 	use crate::ConstU32;
 	use alloc::{vec, vec::Vec};
-	use codec::{CompactLen, Input};
+	#[cfg(feature = "scale-codec")]
+	use scale_codec::{Compact, CompactLen, Decode, Encode, Input};
+	#[cfg(feature = "scale-codec")]
+	use scale_codec_impl::PrependCompactInput;
 
 	fn map_from_keys<K>(keys: &[K]) -> BTreeMap<K, ()>
 	where
@@ -546,6 +568,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn encoding_same_as_unbounded_map() {
 		let b = boundedmap_from_keys::<u32, ConstU32<7>>(&[1, 2, 3, 4, 5, 6]);
 		let m = map_from_keys(&[1, 2, 3, 4, 5, 6]);
@@ -554,6 +577,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn encode_then_decode_gives_original_map() {
 		let b = boundedmap_from_keys::<u32, ConstU32<7>>(&[1, 2, 3, 4, 5, 6]);
 		let b_encode_decode = BoundedBTreeMap::<u32, (), ConstU32<7>>::decode(&mut &b.encode()[..]).unwrap();
@@ -603,6 +627,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn too_big_fail_to_decode() {
 		let v: Vec<(u32, u32)> = vec![(1, 1), (2, 2), (3, 3), (4, 4), (5, 5)];
 		assert_eq!(
@@ -612,6 +637,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn dont_consume_more_data_than_bounded_len() {
 		let m = map_from_keys(&[1, 2, 3, 4, 5, 6]);
 		let data = m.encode();
@@ -779,6 +805,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn prepend_compact_input_works() {
 		let encoded_len = Compact(3u32).encode();
 		let inner = [2, 3, 4];
@@ -805,6 +832,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn prepend_compact_input_incremental_read_works() {
 		let encoded_len = Compact(3u32).encode();
 		let inner = [2, 3, 4];

--- a/bounded-collections/src/bounded_btree_set.rs
+++ b/bounded-collections/src/bounded_btree_set.rs
@@ -34,7 +34,8 @@ use serde::{
 /// Unlike a standard `BTreeSet`, there is an enforced upper limit to the number of items in the
 /// set. All internal operations ensure this bound is respected.
 #[cfg_attr(feature = "serde", derive(Serialize), serde(transparent))]
-#[cfg_attr(feature = "scale-codec", derive(scale_codec::Encode, scale_info::TypeInfo), scale_info(skip_type_params(S)))]
+#[cfg_attr(feature = "scale-codec", derive(scale_codec::Encode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "scale-codec", scale_info(skip_type_params(S)))]
 #[cfg_attr(feature = "jam-codec", derive(jam_codec::Encode))]
 pub struct BoundedBTreeSet<T, S>(BTreeSet<T>, #[cfg_attr(feature = "serde", serde(skip_serializing))] PhantomData<S>);
 
@@ -441,6 +442,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn encoding_same_as_unbounded_set() {
 		let b = boundedset_from_keys::<u32, ConstU32<7>>(&[1, 2, 3, 4, 5, 6]);
 		let m = set_from_keys(&[1, 2, 3, 4, 5, 6]);
@@ -490,6 +492,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn too_big_fail_to_decode() {
 		let v: Vec<u32> = vec![1, 2, 3, 4, 5];
 		assert_eq!(
@@ -499,6 +502,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn dont_consume_more_data_than_bounded_len() {
 		let s = set_from_keys(&[1, 2, 3, 4, 5, 6]);
 		let data = s.encode();

--- a/bounded-collections/src/bounded_btree_set.rs
+++ b/bounded-collections/src/bounded_btree_set.rs
@@ -354,6 +354,7 @@ where
 	}
 }
 
+#[cfg(any(feature = "scale-codec", feature = "jam-codec"))]
 macro_rules! codec_impl {
 	($codec:ident) => {
 		use super::*;

--- a/bounded-collections/src/bounded_btree_set.rs
+++ b/bounded-collections/src/bounded_btree_set.rs
@@ -19,7 +19,6 @@
 
 use crate::{Get, TryCollect};
 use alloc::collections::BTreeSet;
-use codec::{Compact, Decode, Encode, MaxEncodedLen};
 use core::{borrow::Borrow, marker::PhantomData, ops::Deref};
 #[cfg(feature = "serde")]
 use serde::{
@@ -35,8 +34,8 @@ use serde::{
 /// Unlike a standard `BTreeSet`, there is an enforced upper limit to the number of items in the
 /// set. All internal operations ensure this bound is respected.
 #[cfg_attr(feature = "serde", derive(Serialize), serde(transparent))]
-#[derive(Encode, scale_info::TypeInfo)]
-#[scale_info(skip_type_params(S))]
+#[cfg_attr(feature = "scale-codec", derive(scale_codec::Encode, scale_info::TypeInfo), scale_info(skip_type_params(S)))]
+#[cfg_attr(feature = "jam-codec", derive(jam_codec::Encode))]
 pub struct BoundedBTreeSet<T, S>(BTreeSet<T>, #[cfg_attr(feature = "serde", serde(skip_serializing))] PhantomData<S>);
 
 #[cfg(feature = "serde")]
@@ -79,7 +78,7 @@ where
 
 					while let Some(value) = seq.next_element()? {
 						if values.len() >= max {
-							return Err(A::Error::custom("out of bounds"))
+							return Err(A::Error::custom("out of bounds"));
 						}
 						values.insert(value);
 					}
@@ -93,29 +92,6 @@ where
 		deserializer
 			.deserialize_seq(visitor)
 			.map(|v| BoundedBTreeSet::<T, S>::try_from(v).map_err(|_| Error::custom("out of bounds")))?
-	}
-}
-
-impl<T, S> Decode for BoundedBTreeSet<T, S>
-where
-	T: Decode + Ord,
-	S: Get<u32>,
-{
-	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
-		// Same as the underlying implementation for `Decode` on `BTreeSet`, except we fail early if
-		// the len is too big.
-		let len: u32 = <Compact<u32>>::decode(input)?.into();
-		if len > S::get() {
-			return Err("BoundedBTreeSet exceeds its limit".into())
-		}
-		input.descend_ref()?;
-		let inner = Result::from_iter((0..len).map(|_| Decode::decode(input)))?;
-		input.ascend_ref();
-		Ok(Self(inner, PhantomData))
-	}
-
-	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
-		BTreeSet::<T>::skip(input)
 	}
 }
 
@@ -318,18 +294,6 @@ impl<'a, T, S> IntoIterator for &'a BoundedBTreeSet<T, S> {
 	}
 }
 
-impl<T, S> MaxEncodedLen for BoundedBTreeSet<T, S>
-where
-	T: MaxEncodedLen,
-	S: Get<u32>,
-{
-	fn max_encoded_len() -> usize {
-		Self::bound()
-			.saturating_mul(T::max_encoded_len())
-			.saturating_add(codec::Compact(S::get()).encoded_size())
-	}
-}
-
 impl<T, S> Deref for BoundedBTreeSet<T, S>
 where
 	T: Ord,
@@ -373,17 +337,6 @@ where
 	}
 }
 
-impl<T, S> codec::DecodeLength for BoundedBTreeSet<T, S> {
-	fn len(self_encoded: &[u8]) -> Result<usize, codec::Error> {
-		// `BoundedBTreeSet<T, S>` is stored just a `BTreeSet<T>`, which is stored as a
-		// `Compact<u32>` with its length followed by an iteration of its items. We can just use
-		// the underlying implementation.
-		<BTreeSet<T> as codec::DecodeLength>::len(self_encoded)
-	}
-}
-
-impl<T, S> codec::EncodeLike<BTreeSet<T>> for BoundedBTreeSet<T, S> where BTreeSet<T>: Encode {}
-
 impl<I, T, Bound> TryCollect<BoundedBTreeSet<T, Bound>> for I
 where
 	T: Ord,
@@ -401,12 +354,75 @@ where
 	}
 }
 
+macro_rules! codec_impl {
+	($codec:ident) => {
+		use super::*;
+		use $codec::{Compact, Decode, DecodeLength, Encode, EncodeLike, Error, Input, MaxEncodedLen};
+		impl<T, S> Decode for BoundedBTreeSet<T, S>
+		where
+			T: Decode + Ord,
+			S: Get<u32>,
+		{
+			fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+				// Same as the underlying implementation for `Decode` on `BTreeSet`, except we fail early if
+				// the len is too big.
+				let len: u32 = <Compact<u32>>::decode(input)?.into();
+				if len > S::get() {
+					return Err("BoundedBTreeSet exceeds its limit".into());
+				}
+				input.descend_ref()?;
+				let inner = Result::from_iter((0..len).map(|_| Decode::decode(input)))?;
+				input.ascend_ref();
+				Ok(Self(inner, PhantomData))
+			}
+
+			fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+				BTreeSet::<T>::skip(input)
+			}
+		}
+
+		impl<T, S> MaxEncodedLen for BoundedBTreeSet<T, S>
+		where
+			T: MaxEncodedLen,
+			S: Get<u32>,
+		{
+			fn max_encoded_len() -> usize {
+				Self::bound()
+					.saturating_mul(T::max_encoded_len())
+					.saturating_add(Compact(S::get()).encoded_size())
+			}
+		}
+
+		impl<T, S> DecodeLength for BoundedBTreeSet<T, S> {
+			fn len(self_encoded: &[u8]) -> Result<usize, Error> {
+				// `BoundedBTreeSet<T, S>` is stored just a `BTreeSet<T>`, which is stored as a
+				// `Compact<u32>` with its length followed by an iteration of its items. We can just use
+				// the underlying implementation.
+				<BTreeSet<T> as DecodeLength>::len(self_encoded)
+			}
+		}
+
+		impl<T, S> EncodeLike<BTreeSet<T>> for BoundedBTreeSet<T, S> where BTreeSet<T>: Encode {}
+	};
+}
+
+#[cfg(feature = "scale-codec")]
+mod scale_codec_impl {
+	codec_impl!(scale_codec);
+}
+
+#[cfg(feature = "jam-codec")]
+mod jam_codec_impl {
+	codec_impl!(jam_codec);
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;
 	use crate::ConstU32;
 	use alloc::{vec, vec::Vec};
-	use codec::CompactLen;
+	#[cfg(feature = "scale-codec")]
+	use scale_codec::{Compact, CompactLen, Decode, Encode};
 
 	fn set_from_keys<T>(keys: &[T]) -> BTreeSet<T>
 	where

--- a/bounded-collections/src/bounded_vec.rs
+++ b/bounded-collections/src/bounded_vec.rs
@@ -877,6 +877,7 @@ where
 	}
 }
 
+#[cfg(any(feature = "scale-codec", feature = "jam-codec"))]
 macro_rules! codec_impl {
 	($codec:ident) => {
 		use super::*;

--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -21,7 +21,6 @@
 use super::{BoundedSlice, BoundedVec};
 use crate::Get;
 use alloc::vec::Vec;
-use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use core::{
 	marker::PhantomData,
 	ops::{Deref, Index, IndexMut},
@@ -41,8 +40,9 @@ use serde::{
 /// The length of the vec is not strictly bounded. Decoding a vec with more element that the bound
 /// is accepted, and some method allow to bypass the restriction with warnings.
 #[cfg_attr(feature = "serde", derive(Serialize), serde(transparent))]
-#[derive(Encode, scale_info::TypeInfo)]
-#[scale_info(skip_type_params(S))]
+#[cfg_attr(feature = "scale-codec", derive(scale_codec::Encode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "scale-codec", scale_info(skip_type_params(S)))]
+#[cfg_attr(feature = "jam-codec", derive(jam_codec::Encode))]
 pub struct WeakBoundedVec<T, S>(
 	pub(super) Vec<T>,
 	#[cfg_attr(feature = "serde", serde(skip_serializing))] PhantomData<S>,
@@ -106,19 +106,6 @@ where
 			.map(|v| WeakBoundedVec::<T, S>::try_from(v).map_err(|_| Error::custom("out of bounds")))?
 	}
 }
-
-impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
-	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
-		let inner = Vec::<T>::decode(input)?;
-		Ok(Self::force_from(inner, Some("decode")))
-	}
-
-	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
-		Vec::<T>::skip(input)
-	}
-}
-
-impl<T: DecodeWithMemTracking, S: Get<u32>> DecodeWithMemTracking for WeakBoundedVec<T, S> {}
 
 impl<T, S> WeakBoundedVec<T, S> {
 	/// Create `Self` from `t` without any checks.
@@ -348,14 +335,6 @@ impl<'a, T, S> core::iter::IntoIterator for &'a mut WeakBoundedVec<T, S> {
 	}
 }
 
-impl<T, S> codec::DecodeLength for WeakBoundedVec<T, S> {
-	fn len(self_encoded: &[u8]) -> Result<usize, codec::Error> {
-		// `WeakBoundedVec<T, _>` stored just a `Vec<T>`, thus the length is at the beginning in
-		// `Compact` form, and same implementation as `Vec<T>` can be used.
-		<Vec<T> as codec::DecodeLength>::len(self_encoded)
-	}
-}
-
 impl<T, BoundSelf, BoundRhs> PartialEq<WeakBoundedVec<T, BoundRhs>> for WeakBoundedVec<T, BoundSelf>
 where
 	T: PartialEq,
@@ -436,20 +415,58 @@ impl<T: Ord, S: Get<u32>> Ord for WeakBoundedVec<T, S> {
 	}
 }
 
-impl<T, S> MaxEncodedLen for WeakBoundedVec<T, S>
-where
-	T: MaxEncodedLen,
-	S: Get<u32>,
-	WeakBoundedVec<T, S>: Encode,
-{
-	fn max_encoded_len() -> usize {
-		// WeakBoundedVec<T, S> encodes like Vec<T> which encodes like [T], which is a compact u32
-		// plus each item in the slice:
-		// See: https://docs.polkadot.com/polkadot-protocol/basics/data-encoding/#scale-codec-libraries
-		codec::Compact(S::get())
-			.encoded_size()
-			.saturating_add(Self::bound().saturating_mul(T::max_encoded_len()))
-	}
+macro_rules! codec_impl {
+	($codec:ident) => {
+		use super::*;
+		use $codec::{Compact, Decode, DecodeLength, DecodeWithMemTracking, Encode, Error, Input, MaxEncodedLen};
+
+		impl<T, S> MaxEncodedLen for WeakBoundedVec<T, S>
+		where
+			T: MaxEncodedLen,
+			S: Get<u32>,
+			WeakBoundedVec<T, S>: Encode,
+		{
+			fn max_encoded_len() -> usize {
+				// WeakBoundedVec<T, S> encodes like Vec<T> which encodes like [T], which is a compact u32
+				// plus each item in the slice:
+				// See: https://docs.polkadot.com/polkadot-protocol/basics/data-encoding/#scale-codec-libraries
+				Compact(S::get())
+					.encoded_size()
+					.saturating_add(Self::bound().saturating_mul(T::max_encoded_len()))
+			}
+		}
+
+		impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
+			fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+				let inner = Vec::<T>::decode(input)?;
+				Ok(Self::force_from(inner, Some("decode")))
+			}
+
+			fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+				Vec::<T>::skip(input)
+			}
+		}
+
+		impl<T: DecodeWithMemTracking, S: Get<u32>> DecodeWithMemTracking for WeakBoundedVec<T, S> {}
+
+		impl<T, S> DecodeLength for WeakBoundedVec<T, S> {
+			fn len(self_encoded: &[u8]) -> Result<usize, Error> {
+				// `WeakBoundedVec<T, _>` stored just a `Vec<T>`, thus the length is at the beginning in
+				// `Compact` form, and same implementation as `Vec<T>` can be used.
+				<Vec<T> as DecodeLength>::len(self_encoded)
+			}
+		}
+	};
+}
+
+#[cfg(feature = "scale-codec")]
+mod scale_impl {
+	codec_impl!(scale_codec);
+}
+
+#[cfg(feature = "jam-codec")]
+mod jam_impl {
+	codec_impl!(jam_codec);
 }
 
 #[cfg(test)]
@@ -457,6 +474,8 @@ mod test {
 	use super::*;
 	use crate::ConstU32;
 	use alloc::vec;
+	#[cfg(feature = "scale-codec")]
+	use scale_codec::{Decode, Encode};
 
 	#[test]
 	fn bound_returns_correct_value() {
@@ -519,6 +538,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "scale-codec")]
 	fn too_big_succeed_to_decode() {
 		let v: Vec<u32> = vec![1, 2, 3, 4, 5];
 		let w = WeakBoundedVec::<u32, ConstU32<4>>::decode(&mut &v.encode()[..]).unwrap();

--- a/bounded-collections/src/weak_bounded_vec.rs
+++ b/bounded-collections/src/weak_bounded_vec.rs
@@ -415,6 +415,7 @@ impl<T: Ord, S: Get<u32>> Ord for WeakBoundedVec<T, S> {
 	}
 }
 
+#[cfg(any(feature = "scale-codec", feature = "jam-codec"))]
 macro_rules! codec_impl {
 	($codec:ident) => {
 		use super::*;

--- a/primitive-types/impls/codec/Cargo.toml
+++ b/primitive-types/impls/codec/Cargo.toml
@@ -10,8 +10,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, features = ["max-encoded-len"] }
+scale-codec = { workspace = true, features = ["max-encoded-len"] }
 
 [features]
 default = ["std"]
-std = ["codec/std"]
+std = ["scale-codec/std"]

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -11,7 +11,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
-pub use codec;
+pub use scale_codec as codec;
 
 /// Add Parity Codec serialization support to an integer created by `construct_uint!`.
 #[macro_export]


### PR DESCRIPTION
Previously, `bounded-collections` was tightly coupled to `scale-codec`, which posed limitations as our usage evolved.

For now, in **PolkaJam**, we're relying on a temporary fork: [`bounded-collections-next`](https://crates.io/crates/bounded-collections-next) with these changes applied. However, our long-term goal is to have `jam-codec` supported upstream.

---

This PR introduces the following changes:

- Makes the choice of codec optional (though we might retain `scale-codec` as the default for backward compatibility).
- Uses feature flags and macros to conditionally enable codec-specific code, as `jam-codec` and `scale-codec` share an identical API (different in their implementations of integers compact encoding).
