### PR TITLE
fix(bounded-collections): Fix scale-codec feature config

### DIFF
--- a/bounded-collections/Cargo.toml
+++ b/bounded-collections/Cargo.toml
@@ -31,4 +31,4 @@ std = [
     "scale-info/std",
     "serde/std",
 ]
-scale-codec = [ "scale-info" ]
+scale-codec = [ "dep:scale-codec", "scale-info" ]


### PR DESCRIPTION
# Description

I'm working on updating polkadot-sdk to use the latest version of bounded-collections ([0.3.1](https://crates.io/crates/bounded-collections/0.3.1)) to fix an issue related to `BoundedBTreeSet` (also related to my previous [PR](https://github.com/paritytech/parity-common/pull/915)).

While doing so, I ran into the following error:

```
 error[E0432]: unresolved import `scale_codec`
    --> /Users/diego/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bounded-collections-0.3.1/src/codec_utils.rs:75:30
     |
  75 |     impl_prepend_compact_input!(scale_codec);
     |                                 ^^^^^^^^^^^ use of unresolved module or unlinked crate `scale_codec`
```

I'm not an expert in Rust, but after some experimentation, I found that this change solves the issue when testing with my fork.

That said, I'm open to suggestions if there's a better or more idiomatic way to fix it.