### PR TITLE
Update `impl_const_get` macro to allow getting larger types

### DIFF
--- a/bounded-collections/src/lib.rs
+++ b/bounded-collections/src/lib.rs
@@ -93,7 +93,7 @@ impl<T: Default> Get<T> for GetDefault {
 }
 
 macro_rules! impl_const_get {
-	($name:ident, $t:ty) => {
+	($name:ident, $t:ty, get_into: [$($larger:ty),*]) => {
 		/// Const getter for a basic type.
 		#[derive(Default, Clone)]
 		pub struct $name<const T: $t>;
@@ -126,20 +126,34 @@ macro_rules! impl_const_get {
 				T
 			}
 		}
+
+		// Allow smaller types to provide `Get` for larger types.
+		$(
+			impl<const T: $t> Get<$larger> for $name<T> {
+				fn get() -> $larger {
+					<$larger>::from(T)
+				}
+			}
+			impl<const T: $t> Get<Option<$larger>> for $name<T> {
+				fn get() -> Option<$larger> {
+					Some(<$larger>::from(T))
+				}
+			}
+		)*
 	};
 }
 
-impl_const_get!(ConstBool, bool);
-impl_const_get!(ConstU8, u8);
-impl_const_get!(ConstU16, u16);
-impl_const_get!(ConstU32, u32);
-impl_const_get!(ConstU64, u64);
-impl_const_get!(ConstU128, u128);
-impl_const_get!(ConstI8, i8);
-impl_const_get!(ConstI16, i16);
-impl_const_get!(ConstI32, i32);
-impl_const_get!(ConstI64, i64);
-impl_const_get!(ConstI128, i128);
+impl_const_get!(ConstBool, bool, get_into: []);
+impl_const_get!(ConstU8, u8, get_into: [u16, u32, u64, u128, i16, i32, i64, i128]);
+impl_const_get!(ConstU16, u16, get_into: [u32, u64, u128, i32, i64, i128]);
+impl_const_get!(ConstU32, u32, get_into: [u64, u128, i64, i128]);
+impl_const_get!(ConstU64, u64, get_into: [u128, i128]);
+impl_const_get!(ConstU128, u128, get_into: []);
+impl_const_get!(ConstI8, i8, get_into: [i16, i32, i64, i128]);
+impl_const_get!(ConstI16, i16, get_into: [i32, i64, i128]);
+impl_const_get!(ConstI32, i32, get_into: [i64, i128]);
+impl_const_get!(ConstI64, i64, get_into: [i128]);
+impl_const_get!(ConstI128, i128, get_into: []);
 
 /// Try and collect into a collection `C`.
 pub trait TryCollect<C> {


### PR DESCRIPTION
This update implements smaller types to implement `Get` for larger types.

For example, a `ConstU8` will be able to provide `Get<u32>`.

This can help if you are making a `BoundedVec`, where now you can use smaller types like `ConstU8` as the bound.