### PR TITLE
primitive-types: Use correct scale info type for `U256` and `U128`

### DIFF
--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+## [0.14.0] - 2025-09-18
+- Fixed `scale-info` representation of `U256` and `U128` [#939](https://github.com/paritytech/parity-common/pull/939)
+
 ### Breaking
 - removed `byteorder` feature [#872](https://github.com/paritytech/parity-common/pull/872)
 

--- a/primitive-types/CHANGELOG.md
+++ b/primitive-types/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.14.0] - 2025-09-18
+## [0.14.0] - 2025-09-19
 - Fixed `scale-info` representation of `U256` and `U128` [#939](https://github.com/paritytech/parity-common/pull/939)
 
 ### Breaking

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitive-types"
-version = "0.13.1"
+version = "0.14.0"
 description = "Primitive types shared by Ethereum and Substrate"
 rust-version = "1.79.0"
 authors.workspace = true

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -38,12 +38,10 @@ pub enum Error {
 
 construct_uint! {
 	/// 128-bit unsigned integer.
-	#[cfg_attr(feature = "scale-info", derive(TypeInfo))]
 	pub struct U128(2);
 }
 construct_uint! {
 	/// 256-bit unsigned integer.
-	#[cfg_attr(feature = "scale-info", derive(TypeInfo))]
 	pub struct U256(4);
 }
 construct_uint! {
@@ -82,6 +80,27 @@ construct_fixed_hash! {
 	/// Fixed-size uninterpreted hash type with 96 bytes (768 bits) size.
 	#[cfg_attr(feature = "scale-info", derive(TypeInfo))]
 	pub struct H768(96);
+}
+
+#[cfg(feature = "scale-info")]
+mod scale_info_impl {
+	use super::*;
+
+	impl scale_info::TypeInfo for U256 {
+		type Identity = Self;
+
+		fn type_info() -> scale_info::Type {
+			scale_info::TypeDefPrimitive::U256.into()
+		}
+	}
+
+	impl scale_info::TypeInfo for U128 {
+		type Identity = Self;
+
+		fn type_info() -> scale_info::Type {
+			scale_info::TypeDefPrimitive::U128.into()
+		}
+	}
 }
 
 #[cfg(feature = "num-traits")]

--- a/primitive-types/tests/scale_info.rs
+++ b/primitive-types/tests/scale_info.rs
@@ -13,11 +13,7 @@ use scale_info::{build::Fields, Path, Type, TypeInfo};
 
 #[test]
 fn u256_scale_info() {
-	let r#type = Type::builder()
-		.path(Path::new("U256", "primitive_types"))
-		.composite(Fields::unnamed().field(|f| f.ty::<[u64; 4]>().type_name("[u64; 4]")));
-
-	assert_eq!(U256::type_info(), r#type.into());
+	assert_eq!(U256::type_info(), scale_info::TypeDefPrimitive::U256.into());
 }
 
 #[test]


### PR DESCRIPTION
Fixes: https://github.com/paritytech/polkadot-sdk/issues/9773