### PR TITLE
Fix trailing semicolon in expression macro bodies

### DIFF
--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -251,10 +251,10 @@ macro_rules! uint_overflowing_binop {
 #[doc(hidden)]
 macro_rules! uint_full_mul_reg {
 	($name:ident, 8, $self_expr:expr, $other:expr) => {
-		$crate::uint_full_mul_reg!($name, 8, $self_expr, $other, |a, b| a != 0 || b != 0);
+		$crate::uint_full_mul_reg!($name, 8, $self_expr, $other, |a, b| a != 0 || b != 0)
 	};
 	($name:ident, $n_words:tt, $self_expr:expr, $other:expr) => {
-		$crate::uint_full_mul_reg!($name, $n_words, $self_expr, $other, |_, _| true);
+		$crate::uint_full_mul_reg!($name, $n_words, $self_expr, $other, |_, _| true)
 	};
 	($name:ident, $n_words:tt, $self_expr:expr, $other:expr, $check:expr) => {{
 		{


### PR DESCRIPTION
This is a trivial change, which addresses https://github.com/rust-lang/rust/issues/79813.

It is going to become a hard error soon: https://github.com/rust-lang/rust/pull/159218.

The only reason is wasn't caught earlier is due to https://github.com/rust-lang/rust/pull/159222, which is how I noticed it after Nightly upgrade.

I would also appreciate a patch version released shortly after merging this.